### PR TITLE
fix: nextest filter excluding all unit tests, remove stale advisory ignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build: ## Build the project.
 
 .PHONY: test-unit
 test-unit: ## Run unit tests.
-	cargo nextest run -E 'kind(test)'
+	cargo nextest run
 
 .PHONY: test-doc
 test-doc: ## Run doc tests.

--- a/deny.toml
+++ b/deny.toml
@@ -7,8 +7,6 @@ yanked = "warn"
 ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained
     "RUSTSEC-2024-0436",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand is unsound with a custom logger
-    "RUSTSEC-2026-0097",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
## Changes

- **Makefile**: Remove `-E 'kind(test)'` filter from `make test-unit`. This filter only matches integration test binaries (`tests/` directory), causing all 25 unit tests in library crates to be skipped.
- **deny.toml**: Remove stale `RUSTSEC-2026-0097` advisory ignore that no longer matches any crate.