### PR TITLE
fix: bump revm to 38.0.0

### DIFF
--- a/crates/fork-db/Cargo.toml
+++ b/crates/fork-db/Cargo.toml
@@ -28,7 +28,7 @@ futures = "0.3"
 
 parking_lot = "0.12"
 
-revm = { version = "37.0.0", features = ["std", "serde"] }
+revm = { version = "38.0.0", features = ["std", "serde"] }
 
 serde = { workspace = true }
 serde_json.workspace = true


### PR DESCRIPTION
Same fix as [foundry-fork-db#138](https://github.com/foundry-rs/foundry-fork-db/pull/138).

revm 37.0.0 resolves to incompatible transitive deps (`revm-handler` 18.1.0 + `revm-inspector` 18.0.0), causing `error[E0308]: mismatched types` on all CI jobs that compile.

Bumping to revm 38.0.0 pulls compatible versions and fixes CI.

Prompted by: zerosnacks