### PR TITLE
docs: link to previous repositories

### DIFF
--- a/crates/compilers/README.md
+++ b/crates/compilers/README.md
@@ -4,6 +4,8 @@ Compiler abstraction and Foundry project implementation.
 
 Originally part of [`ethers-rs`](https://github.com/gakonst/ethers-rs) as `ethers-solc`, this is the compilation backend for [Foundry](https://github.com/foundry-rs/foundry).
 
+> **Note:** This crate was previously maintained at [foundry-rs/compilers](https://github.com/foundry-rs/compilers).
+
 ## Features
 
 - `full`: Enables `async` + `svm-solc`.

--- a/crates/fork-db/README.md
+++ b/crates/fork-db/README.md
@@ -2,4 +2,6 @@
 
 Fork database used by [Foundry](https://github.com/foundry-rs/foundry).
 
+> **Note:** This crate was previously maintained at [foundry-rs/foundry-fork-db](https://github.com/foundry-rs/foundry-fork-db).
+
 Provides a shared, caching database layer backed by a remote RPC provider, allowing EVM execution against forked chain state. Built on top of [revm](https://github.com/bluealloy/revm).


### PR DESCRIPTION
Adds notes linking to the old standalone repos for discoverability:

- `foundry-compilers` → [foundry-rs/compilers](https://github.com/foundry-rs/compilers)
- `foundry-fork-db` → [foundry-rs/foundry-fork-db](https://github.com/foundry-rs/foundry-fork-db)

Prompted by: zerosnacks