### PR TITLE
chore: reorder workspace deps and normalize formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ redundant_lifetimes = "warn"
 all = "warn"
 
 [workspace.dependencies]
-## alloy
+# alloy
 alloy-consensus = { version = "2.0.0", default-features = false }
 alloy-dyn-abi = "1.5.2"
 alloy-json-abi = { version = "1.3", features = ["serde_json"] }
@@ -125,14 +125,7 @@ alloy-signer-trezor = { version = "2.0.0", default-features = false }
 alloy-signer-turnkey = { version = "2.0.0", default-features = false }
 alloy-sol-types = "1.5.2"
 
-## compilers
-foundry-compilers.path = "crates/compilers/crates/compilers"
-foundry-compilers-artifacts.path = "crates/compilers/crates/artifacts/artifacts"
-foundry-compilers-artifacts-solc.path = "crates/compilers/crates/artifacts/solc"
-foundry-compilers-artifacts-vyper.path = "crates/compilers/crates/artifacts/vyper"
-foundry-compilers-core.path = "crates/compilers/crates/core"
-
-# Tempo
+# tempo
 tempo-primitives = { version = "1.6", default-features = false, features = [
     "std",
     "serde",
@@ -169,3 +162,10 @@ tracing = "0.1"
 uuid = { version = "1.19.0", features = ["v4", "serde"] }
 walkdir = "2.5"
 yansi = "1.0"
+
+# crates
+foundry-compilers = { path = "crates/compilers/crates/compilers" }
+foundry-compilers-artifacts = { path = "crates/compilers/crates/artifacts/artifacts" }
+foundry-compilers-artifacts-solc = { path = "crates/compilers/crates/artifacts/solc" }
+foundry-compilers-artifacts-vyper = { path = "crates/compilers/crates/artifacts/vyper" }
+foundry-compilers-core = { path = "crates/compilers/crates/core" }


### PR DESCRIPTION
Moves internal crate path deps to the bottom under `# crates` and normalizes to `{ path = "..." }` format. Section order is now: alloy → tempo → misc → crates.

Prompted by: zerosnacks