### PR TITLE
chore(compilers): remove unused `path-slash` dep in artifacts vyper crate

### DIFF
--- a/crates/compilers/crates/artifacts/vyper/Cargo.toml
+++ b/crates/compilers/crates/artifacts/vyper/Cargo.toml
@@ -22,9 +22,6 @@ alloy-primitives.workspace = true
 alloy-json-abi.workspace = true
 semver.workspace = true
 
-[target.'cfg(windows)'.dependencies]
-path-slash.workspace = true
-
 [dev-dependencies]
 serde_path_to_error = "0.1"
 similar-asserts.workspace = true


### PR DESCRIPTION
Remove unused `path-slash` dep in `foundry-compilers-artifacts-vyper` crate, to prevent warning on windows:
```
warning: extern crate `path_slash` is unused in crate `foundry_compilers_artifacts_vyper`
  |
  = help: remove the dependency or add `use path_slash as _;` to the crate root
note: the lint level is defined here
 --> crates\compilers\crates\artifacts\vyper\src\lib.rs:3:29
  |
3 | #![cfg_attr(not(test), warn(unused_crate_dependencies))]
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^

warning: `foundry-compilers-artifacts-vyper` (lib) generated 1 warning

```