### PR TITLE
feat(wallets): feature-gate browser and tempo signers

### DIFF
--- a/crates/wallets/Cargo.toml
+++ b/crates/wallets/Cargo.toml
@@ -24,11 +24,13 @@ alloy-sol-types.workspace = true
 alloy-dyn-abi.workspace = true
 
 # browser wallet
-axum.workspace = true
-serde_json.workspace = true
-tokio = { workspace = true, features = ["macros"] }
-uuid.workspace = true
-webbrowser = "1.0.6"
+axum = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["macros"], optional = true }
+uuid = { workspace = true, optional = true }
+webbrowser = { version = "1.0.6", optional = true }
+tower = { workspace = true, optional = true }
+tower-http = { workspace = true, features = ["cors", "set-header"], optional = true }
 
 # aws-kms
 alloy-signer-aws = { workspace = true, features = ["eip712"], optional = true }
@@ -40,9 +42,10 @@ alloy-signer-gcp = { workspace = true, features = ["eip712"], optional = true }
 # turnkey
 alloy-signer-turnkey = { workspace = true, features = ["eip712"], optional = true }
 
-tempo-primitives.workspace = true
-rusqlite.workspace = true
-alloy-rlp.workspace = true
+# tempo
+tempo-primitives = { workspace = true, optional = true }
+rusqlite = { workspace = true, optional = true }
+alloy-rlp = { workspace = true, optional = true }
 
 async-trait.workspace = true
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
@@ -52,16 +55,18 @@ eyre.workspace = true
 rpassword = "7"
 serde.workspace = true
 thiserror.workspace = true
-toml.workspace = true
-tower.workspace = true
-tower-http = { workspace = true, features = ["cors", "set-header"] }
+toml = { workspace = true, optional = true }
 tracing.workspace = true
 eth-keystore = "0.5.0"
 
 [dev-dependencies]
 reqwest = { workspace = true, features = ["json"] }
+tokio = { workspace = true, features = ["macros"] }
 
 [features]
+default = ["browser", "tempo"]
+browser = ["dep:axum", "dep:serde_json", "dep:tokio", "dep:uuid", "dep:webbrowser", "dep:tower", "dep:tower-http"]
+tempo = ["dep:tempo-primitives", "dep:rusqlite", "dep:alloy-rlp", "dep:toml"]
 aws-kms = ["dep:alloy-signer-aws", "dep:aws-config"]
 gcp-kms = ["dep:alloy-signer-gcp"]
 turnkey = ["dep:alloy-signer-turnkey"]

--- a/crates/wallets/Cargo.toml
+++ b/crates/wallets/Cargo.toml
@@ -64,7 +64,6 @@ reqwest = { workspace = true, features = ["json"] }
 tokio = { workspace = true, features = ["macros"] }
 
 [features]
-default = ["browser", "tempo"]
 browser = ["dep:axum", "dep:serde_json", "dep:tokio", "dep:uuid", "dep:webbrowser", "dep:tower", "dep:tower-http"]
 tempo = ["dep:tempo-primitives", "dep:rusqlite", "dep:alloy-rlp", "dep:toml"]
 aws-kms = ["dep:alloy-signer-aws", "dep:aws-config"]

--- a/crates/wallets/src/error.rs
+++ b/crates/wallets/src/error.rs
@@ -13,6 +13,7 @@ use alloy_signer_gcp::GcpSignerError;
 #[cfg(feature = "turnkey")]
 use alloy_signer_turnkey::TurnkeySignerError;
 
+#[cfg(feature = "browser")]
 use crate::wallet_browser::error::BrowserWalletError;
 
 #[derive(Debug, thiserror::Error)]
@@ -51,6 +52,7 @@ pub enum WalletSignerError {
     #[cfg(feature = "turnkey")]
     Turnkey(#[from] TurnkeySignerError),
     #[error(transparent)]
+    #[cfg(feature = "browser")]
     Browser(#[from] BrowserWalletError),
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/crates/wallets/src/lib.rs
+++ b/crates/wallets/src/lib.rs
@@ -8,21 +8,27 @@
 #[macro_use]
 extern crate tracing;
 
+#[cfg(feature = "tempo")]
 pub mod channel_db;
 pub mod error;
 pub mod opts;
 pub mod signer;
+#[cfg(feature = "tempo")]
 pub mod tempo;
 pub mod utils;
+#[cfg(feature = "browser")]
 pub mod wallet_browser;
 pub mod wallet_multi;
 pub mod wallet_raw;
 
+#[cfg(feature = "tempo")]
 pub use channel_db::{Channel, ChannelDb};
 pub use error::StoreError;
-pub use opts::WalletOpts;
+pub use opts::{MaybeTempoConfig, WalletOpts};
 pub use signer::{PendingSigner, WalletSigner};
+#[cfg(feature = "tempo")]
 pub use tempo::TempoAccessKeyConfig;
+#[cfg(feature = "browser")]
 pub use wallet_browser::opts::BrowserWalletOpts;
 pub use wallet_multi::MultiWalletOpts;
 pub use wallet_raw::RawWalletOpts;

--- a/crates/wallets/src/opts.rs
+++ b/crates/wallets/src/opts.rs
@@ -278,6 +278,8 @@ impl From<RawWalletOpts> for WalletOpts {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[allow(redundant_imports)]
+    use alloy_signer::Signer;
     use std::{path::Path, str::FromStr};
 
     #[tokio::test]

--- a/crates/wallets/src/opts.rs
+++ b/crates/wallets/src/opts.rs
@@ -1,9 +1,19 @@
-use crate::{signer::WalletSigner, tempo::TempoAccessKeyConfig, utils, wallet_raw::RawWalletOpts};
+#[cfg(feature = "tempo")]
+use crate::tempo::TempoAccessKeyConfig;
+use crate::{signer::WalletSigner, utils, wallet_raw::RawWalletOpts};
 use alloy_primitives::Address;
+#[cfg(feature = "tempo")]
 use alloy_signer::Signer;
 use clap::Parser;
 use eyre::Result;
 use serde::Serialize;
+
+/// When the `tempo` feature is enabled this is [`TempoAccessKeyConfig`];
+/// otherwise it is `()` so the API shape stays the same.
+#[cfg(feature = "tempo")]
+pub type MaybeTempoConfig = TempoAccessKeyConfig;
+#[cfg(not(feature = "tempo"))]
+pub type MaybeTempoConfig = ();
 
 /// The wallet options can either be:
 /// 1. Raw (via private key / mnemonic file, see `RawWallet`)
@@ -112,7 +122,8 @@ pub struct WalletOpts {
         long = "tempo.access-key",
         help_heading = "Wallet options - Tempo",
         value_name = "PRIVATE_KEY",
-        env = "TEMPO_ACCESS_KEY"
+        env = "TEMPO_ACCESS_KEY",
+        hide = !cfg!(feature = "tempo")
     )]
     pub tempo_access_key: Option<String>,
 
@@ -124,7 +135,8 @@ pub struct WalletOpts {
         help_heading = "Wallet options - Tempo",
         value_name = "ADDRESS",
         requires = "tempo_access_key",
-        env = "TEMPO_ROOT_ACCOUNT"
+        env = "TEMPO_ROOT_ACCOUNT",
+        hide = !cfg!(feature = "tempo")
     )]
     pub tempo_root_account: Option<Address>,
 }
@@ -132,17 +144,16 @@ pub struct WalletOpts {
 impl WalletOpts {
     /// Attempts to resolve a signer from the configured wallet options.
     ///
-    /// Returns the signer and, for Tempo keychain mode, an [`TempoAccessKeyConfig`] describing the
-    /// root wallet and provisioning data.
+    /// Returns the signer and, when the `tempo` feature is enabled and Tempo keychain mode is
+    /// used, a [`TempoAccessKeyConfig`] describing the root wallet and provisioning data.
     ///
     /// Returns `Ok((None, None))` if no wallet option was configured and no Tempo fallback
     /// matched.
-    pub async fn maybe_signer(
-        &self,
-    ) -> Result<(Option<WalletSigner>, Option<TempoAccessKeyConfig>)> {
+    pub async fn maybe_signer(&self) -> Result<(Option<WalletSigner>, Option<MaybeTempoConfig>)> {
         trace!("start finding signer");
 
         // If a Tempo access key is provided on the CLI, use it directly.
+        #[cfg(feature = "tempo")]
         if let Some(ref access_key) = self.tempo_access_key {
             let root_account = self.tempo_root_account.ok_or_else(|| {
                 eyre::eyre!("--tempo.root-account is required when --tempo.access-key is set")
@@ -209,6 +220,7 @@ impl WalletOpts {
         } else {
             // No explicit wallet option was provided. Try Tempo wallet as a fallback
             // if `--from` is set.
+            #[cfg(feature = "tempo")]
             if let Some(from) = self.from {
                 match crate::tempo::lookup_signer(from)? {
                     crate::tempo::TempoLookup::Direct(signer) => {

--- a/crates/wallets/src/wallet_multi/mod.rs
+++ b/crates/wallets/src/wallet_multi/mod.rs
@@ -1,9 +1,10 @@
+#[cfg(feature = "browser")]
+use crate::{BrowserWalletOpts, wallet_browser::signer::BrowserSigner};
 use crate::{
-    BrowserWalletOpts,
     signer::{PendingSigner, WalletSigner},
     utils,
-    wallet_browser::signer::BrowserSigner,
 };
+#[cfg(feature = "browser")]
 use alloy_network::Network;
 use alloy_primitives::map::AddressHashMap;
 use alloy_signer::Signer;
@@ -233,6 +234,7 @@ pub struct MultiWalletOpts {
     pub turnkey: bool,
 
     /// Browser wallet options
+    #[cfg(feature = "browser")]
     #[command(flatten)]
     pub browser: BrowserWalletOpts,
 }
@@ -498,6 +500,7 @@ impl MultiWalletOpts {
     }
 
     /// Launches and returns the Browser signer if `--browser` flag is set
+    #[cfg(feature = "browser")]
     pub async fn browser_signer<N: Network>(&self) -> Result<Option<BrowserSigner<N>>> {
         self.browser.run().await
     }


### PR DESCRIPTION
Feature-gate browser and tempo signers, suggested by https://github.com/foundry-rs/foundry/issues/13800#issuecomment-4293469726

- `browser`: gates axum, serde_json, tokio, uuid, webbrowser, tower, tower-http and the wallet_browser module
- `tempo`: gates tempo-primitives, rusqlite, alloy-rlp, toml and the tempo/channel_db modules