### PR TITLE
feat: add OP crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/explorers/*",
     "crates/fork-db",
     "crates/wallets",
+    "crates/op/*",
 ]
 resolver = "2"
 
@@ -167,6 +168,29 @@ tracing = "0.1"
 uuid = { version = "1.19.0", features = ["v4", "serde"] }
 walkdir = "2.5"
 yansi = "1.0"
+
+# revm
+revm = { version = "38.0.0", default-features = false }
+
+# alloy-evm
+alloy-evm = { version = "0.33.2", default-features = false }
+
+# alloy (additions for OP crates)
+alloy-hardforks = { version = "0.4.7", default-features = false }
+alloy-provider = { version = "2.0.0", default-features = false }
+alloy-network-primitives = { version = "2.0.0", default-features = false }
+
+# misc (additions for OP crates)
+auto_impl = "1"
+derive_more = { version = "2.1", features = ["full"] }
+
+# op crates
+alloy-op-hardforks = { path = "crates/op/alloy-op-hardforks" }
+op-revm = { path = "crates/op/op-revm" }
+op-alloy-consensus = { path = "crates/op/op-alloy-consensus" }
+op-alloy-rpc-types = { path = "crates/op/op-alloy-rpc-types" }
+op-alloy-network = { path = "crates/op/op-alloy-network" }
+alloy-op-evm = { path = "crates/op/alloy-op-evm" }
 
 # crates
 foundry-compilers = { path = "crates/compilers/crates/compilers" }

--- a/crates/op/alloy-op-evm/Cargo.toml
+++ b/crates/op/alloy-op-evm/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "alloy-op-evm"
+description = "OP EVM implementation"
+
+version = "0.30.0"
+edition.workspace = true
+rust-version.workspace = true
+authors = ["Alloy Contributors", "OpLabsPBC"]
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/ethereum-optimism/optimism"
+repository = "https://github.com/ethereum-optimism/optimism"
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-evm = { workspace = true }
+
+alloy-eips = { workspace = true }
+alloy-consensus = { workspace = true }
+alloy-primitives = { workspace = true }
+
+op-alloy-consensus = { workspace = true }
+
+revm = { workspace = true }
+op-revm = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"alloy-primitives/std",
+	"revm/std",
+	"alloy-evm/std",
+	"op-revm/std",
+	"alloy-consensus/std",
+	"alloy-eips/std",
+	"op-alloy-consensus/std",
+]
+rpc = ["alloy-evm/rpc"]
+asm-keccak = ["alloy-evm/asm-keccak", "alloy-primitives/asm-keccak", "revm/asm-keccak"]
+arbitrary = [
+	"alloy-consensus/arbitrary",
+	"alloy-eips/arbitrary",
+	"alloy-primitives/arbitrary",
+	"op-alloy-consensus/arbitrary",
+	"revm/arbitrary",
+]

--- a/crates/op/alloy-op-evm/src/error.rs
+++ b/crates/op/alloy-op-evm/src/error.rs
@@ -1,0 +1,42 @@
+//! Error types for OP EVM execution.
+
+use alloy_evm::InvalidTxError;
+use core::fmt;
+use op_revm::OpTransactionError;
+use revm::context_interface::result::{EVMError, InvalidTransaction};
+
+/// Newtype wrapper around [`OpTransactionError`] that allows implementing foreign traits.
+#[derive(Debug)]
+pub struct OpTxError(pub OpTransactionError);
+
+impl fmt::Display for OpTxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl core::error::Error for OpTxError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        self.0.source()
+    }
+}
+
+impl InvalidTxError for OpTxError {
+    fn as_invalid_tx_err(&self) -> Option<&InvalidTransaction> {
+        match &self.0 {
+            OpTransactionError::Base(tx) => Some(tx),
+            _ => None,
+        }
+    }
+}
+
+/// Maps an [`EVMError<DB, OpTransactionError>`] to [`EVMError<DB, OpTxError>`].
+pub fn map_op_err<DB>(err: EVMError<DB, OpTransactionError>) -> EVMError<DB, OpTxError> {
+    match err {
+        EVMError::Transaction(e) => EVMError::Transaction(OpTxError(e)),
+        EVMError::Database(e) => EVMError::Database(e),
+        EVMError::Header(e) => EVMError::Header(e),
+        EVMError::Custom(e) => EVMError::Custom(e),
+        EVMError::CustomAny(e) => EVMError::CustomAny(e),
+    }
+}

--- a/crates/op/alloy-op-evm/src/lib.rs
+++ b/crates/op/alloy-op-evm/src/lib.rs
@@ -1,0 +1,251 @@
+//! OP Stack EVM implementation.
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod error;
+pub use error::{OpTxError, map_op_err};
+
+use alloy_evm::{Database, Evm, EvmEnv, EvmFactory, IntoTxEnv, precompiles::PrecompilesMap};
+use alloy_primitives::{Address, Bytes};
+use core::{
+    fmt::Debug,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
+use op_revm::{
+    DefaultOp, L1BlockInfo, OpBuilder, OpContext, OpHaltReason, OpSpecId, OpTransaction,
+    precompiles::OpPrecompiles,
+};
+use revm::{
+    Context, ExecuteEvm, InspectEvm, Inspector, Journal, SystemCallEvm,
+    context::{BlockEnv, CfgEnv, TxEnv},
+    context_interface::result::{EVMError, ResultAndState},
+    handler::{PrecompileProvider, instructions::EthInstructions},
+    inspector::NoOpInspector,
+    interpreter::{InterpreterResult, interpreter::EthInterpreter},
+};
+
+pub mod tx;
+pub use tx::OpTx;
+
+/// The OP EVM context type.
+pub type OpEvmContext<DB> = Context<BlockEnv, OpTx, CfgEnv<OpSpecId>, DB, Journal<DB>, L1BlockInfo>;
+
+/// OP EVM implementation.
+///
+/// This is a wrapper type around the `revm` evm with optional [`Inspector`] (tracing)
+/// support. [`Inspector`] support is configurable at runtime because it's part of the underlying
+/// [`OpEvm`](op_revm::OpEvm) type.
+///
+/// The `Tx` type parameter controls the transaction environment type. By default it uses
+/// [`OpTx`] which wraps [`OpTransaction<TxEnv>`] and implements the necessary foreign traits.
+#[allow(missing_debug_implementations)] // missing revm::OpContext Debug impl
+pub struct OpEvm<DB: Database, I, P = OpPrecompiles, Tx = OpTx> {
+    inner: op_revm::OpEvm<OpContext<DB>, I, EthInstructions<EthInterpreter, OpContext<DB>>, P>,
+    inspect: bool,
+    _tx: PhantomData<Tx>,
+}
+
+impl<DB: Database, I, P, Tx> OpEvm<DB, I, P, Tx> {
+    /// Consumes self and return the inner EVM instance.
+    pub fn into_inner(
+        self,
+    ) -> op_revm::OpEvm<OpContext<DB>, I, EthInstructions<EthInterpreter, OpContext<DB>>, P> {
+        self.inner
+    }
+
+    /// Provides a reference to the EVM context.
+    pub const fn ctx(&self) -> &OpContext<DB> {
+        &self.inner.0.ctx
+    }
+
+    /// Provides a mutable reference to the EVM context.
+    pub const fn ctx_mut(&mut self) -> &mut OpContext<DB> {
+        &mut self.inner.0.ctx
+    }
+}
+
+impl<DB: Database, I, P, Tx> OpEvm<DB, I, P, Tx> {
+    /// Creates a new OP EVM instance.
+    ///
+    /// The `inspect` argument determines whether the configured [`Inspector`] of the given
+    /// [`OpEvm`](op_revm::OpEvm) should be invoked on [`Evm::transact`].
+    pub const fn new(
+        evm: op_revm::OpEvm<OpContext<DB>, I, EthInstructions<EthInterpreter, OpContext<DB>>, P>,
+        inspect: bool,
+    ) -> Self {
+        Self { inner: evm, inspect, _tx: PhantomData }
+    }
+}
+
+impl<DB: Database, I, P, Tx> Deref for OpEvm<DB, I, P, Tx> {
+    type Target = OpContext<DB>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.ctx()
+    }
+}
+
+impl<DB: Database, I, P, Tx> DerefMut for OpEvm<DB, I, P, Tx> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.ctx_mut()
+    }
+}
+
+impl<DB, I, P, Tx> Evm for OpEvm<DB, I, P, Tx>
+where
+    DB: Database,
+    I: Inspector<OpContext<DB>>,
+    P: PrecompileProvider<OpContext<DB>, Output = InterpreterResult>,
+    Tx: IntoTxEnv<Tx> + Into<OpTransaction<TxEnv>>,
+{
+    type DB = DB;
+    type Tx = Tx;
+    type Error = EVMError<DB::Error, OpTxError>;
+    type HaltReason = OpHaltReason;
+    type Spec = OpSpecId;
+    type BlockEnv = BlockEnv;
+    type Precompiles = P;
+    type Inspector = I;
+
+    fn block(&self) -> &BlockEnv {
+        &self.block
+    }
+
+    fn chain_id(&self) -> u64 {
+        self.cfg.chain_id
+    }
+
+    fn cfg_env(&self) -> &CfgEnv<Self::Spec> {
+        &self.cfg
+    }
+
+    fn transact_raw(
+        &mut self,
+        tx: Self::Tx,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+        let inner_tx: OpTransaction<TxEnv> = tx.into();
+        let result = if self.inspect {
+            self.inner.inspect_tx(inner_tx)
+        } else {
+            self.inner.transact(inner_tx)
+        };
+        result.map_err(map_op_err)
+    }
+
+    fn transact_system_call(
+        &mut self,
+        caller: Address,
+        contract: Address,
+        data: Bytes,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+        self.inner.system_call_with_caller(caller, contract, data).map_err(map_op_err)
+    }
+
+    fn finish(self) -> (Self::DB, EvmEnv<Self::Spec>) {
+        let Context { block: block_env, cfg: cfg_env, journaled_state, .. } = self.inner.0.ctx;
+
+        (journaled_state.database, EvmEnv { block_env, cfg_env })
+    }
+
+    fn set_inspector_enabled(&mut self, enabled: bool) {
+        self.inspect = enabled;
+    }
+
+    fn components(&self) -> (&Self::DB, &Self::Inspector, &Self::Precompiles) {
+        (
+            &self.inner.0.ctx.journaled_state.database,
+            &self.inner.0.inspector,
+            &self.inner.0.precompiles,
+        )
+    }
+
+    fn components_mut(&mut self) -> (&mut Self::DB, &mut Self::Inspector, &mut Self::Precompiles) {
+        (
+            &mut self.inner.0.ctx.journaled_state.database,
+            &mut self.inner.0.inspector,
+            &mut self.inner.0.precompiles,
+        )
+    }
+}
+
+/// Factory producing [`OpEvm`]s.
+///
+/// The `Tx` type parameter controls the transaction type used by the created EVMs.
+/// By default it uses [`OpTx`] which wraps [`OpTransaction<TxEnv>`] and implements
+/// the necessary foreign traits.
+#[derive(Debug)]
+pub struct OpEvmFactory<Tx = OpTx>(PhantomData<Tx>);
+
+impl<Tx> Clone for OpEvmFactory<Tx> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<Tx> Copy for OpEvmFactory<Tx> {}
+
+impl<Tx> Default for OpEvmFactory<Tx> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<Tx> EvmFactory for OpEvmFactory<Tx>
+where
+    Tx: IntoTxEnv<Tx> + Into<OpTransaction<TxEnv>> + Default + Clone + Debug,
+{
+    type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I, Self::Precompiles, Tx>;
+    type Context<DB: Database> = OpContext<DB>;
+    type Tx = Tx;
+    type Error<DBError: core::error::Error + Send + Sync + 'static> = EVMError<DBError, OpTxError>;
+    type HaltReason = OpHaltReason;
+    type Spec = OpSpecId;
+    type BlockEnv = BlockEnv;
+    type Precompiles = PrecompilesMap;
+
+    fn create_evm<DB: Database>(
+        &self,
+        db: DB,
+        input: EvmEnv<OpSpecId>,
+    ) -> Self::Evm<DB, NoOpInspector> {
+        let spec_id = input.cfg_env.spec;
+        OpEvm {
+            inner: Context::op()
+                .with_db(db)
+                .with_block(input.block_env)
+                .with_cfg(input.cfg_env)
+                .build_op_with_inspector(NoOpInspector {})
+                .with_precompiles(PrecompilesMap::from_static(
+                    OpPrecompiles::new_with_spec(spec_id).precompiles(),
+                )),
+            inspect: false,
+            _tx: PhantomData,
+        }
+    }
+
+    fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
+        &self,
+        db: DB,
+        input: EvmEnv<OpSpecId>,
+        inspector: I,
+    ) -> Self::Evm<DB, I> {
+        let spec_id = input.cfg_env.spec;
+        OpEvm {
+            inner: Context::op()
+                .with_db(db)
+                .with_block(input.block_env)
+                .with_cfg(input.cfg_env)
+                .build_op_with_inspector(inspector)
+                .with_precompiles(PrecompilesMap::from_static(
+                    OpPrecompiles::new_with_spec(spec_id).precompiles(),
+                )),
+            inspect: true,
+            _tx: PhantomData,
+        }
+    }
+}

--- a/crates/op/alloy-op-evm/src/tx.rs
+++ b/crates/op/alloy-op-evm/src/tx.rs
@@ -1,0 +1,276 @@
+//! [`OpTx`] newtype wrapper around [`OpTransaction<TxEnv>`].
+
+use alloy_consensus::{
+    Signed, Transaction, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip7702, TxLegacy,
+};
+use alloy_eips::{Encodable2718, Typed2718, eip7594::Encodable7594};
+use alloy_evm::{FromRecoveredTx, FromTxWithEncoded, IntoTxEnv, TransactionEnvMut};
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
+use core::ops::{Deref, DerefMut};
+use op_alloy_consensus::{OpTxEnvelope, TxDeposit, TxPostExec};
+use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
+use revm::context::TxEnv;
+
+/// Helper to convert a deposit transaction into a [`TxEnv`].
+fn deposit_tx_env(tx: &TxDeposit, caller: Address) -> TxEnv {
+    TxEnv {
+        tx_type: tx.ty(),
+        caller,
+        gas_limit: tx.gas_limit,
+        kind: tx.to,
+        value: tx.value,
+        data: tx.input.clone(),
+        ..Default::default()
+    }
+}
+
+/// Newtype wrapper around [`OpTransaction<TxEnv>`] that allows implementing foreign traits.
+#[derive(Clone, Debug, Default)]
+pub struct OpTx(pub OpTransaction<TxEnv>);
+
+impl From<OpTx> for OpTransaction<TxEnv> {
+    fn from(tx: OpTx) -> Self {
+        tx.0
+    }
+}
+
+impl Deref for OpTx {
+    type Target = OpTransaction<TxEnv>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for OpTx {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl IntoTxEnv<Self> for OpTx {
+    fn into_tx_env(self) -> Self {
+        self
+    }
+}
+
+impl OpTxEnv for OpTx {
+    fn encoded_bytes(&self) -> Option<&Bytes> {
+        self.0.enveloped_tx.as_ref()
+    }
+}
+
+impl revm::context::Transaction for OpTx {
+    type AccessListItem<'a>
+        = <OpTransaction<TxEnv> as revm::context::Transaction>::AccessListItem<'a>
+    where
+        Self: 'a;
+    type Authorization<'a>
+        = <OpTransaction<TxEnv> as revm::context::Transaction>::Authorization<'a>
+    where
+        Self: 'a;
+
+    fn tx_type(&self) -> u8 {
+        self.0.tx_type()
+    }
+    fn caller(&self) -> Address {
+        self.0.caller()
+    }
+    fn gas_limit(&self) -> u64 {
+        self.0.gas_limit()
+    }
+    fn value(&self) -> U256 {
+        self.0.value()
+    }
+    fn input(&self) -> &Bytes {
+        self.0.input()
+    }
+    fn nonce(&self) -> u64 {
+        revm::context::Transaction::nonce(&self.0)
+    }
+    fn kind(&self) -> TxKind {
+        self.0.kind()
+    }
+    fn chain_id(&self) -> Option<u64> {
+        self.0.chain_id()
+    }
+    fn gas_price(&self) -> u128 {
+        self.0.gas_price()
+    }
+    fn access_list(&self) -> Option<impl Iterator<Item = Self::AccessListItem<'_>>> {
+        self.0.access_list()
+    }
+    fn blob_versioned_hashes(&self) -> &[B256] {
+        self.0.blob_versioned_hashes()
+    }
+    fn max_fee_per_blob_gas(&self) -> u128 {
+        self.0.max_fee_per_blob_gas()
+    }
+    fn authorization_list_len(&self) -> usize {
+        self.0.authorization_list_len()
+    }
+    fn authorization_list(&self) -> impl Iterator<Item = Self::Authorization<'_>> {
+        self.0.authorization_list()
+    }
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        self.0.max_priority_fee_per_gas()
+    }
+}
+
+impl op_revm::transaction::OpTxTr for OpTx {
+    fn enveloped_tx(&self) -> Option<&Bytes> {
+        self.0.enveloped_tx()
+    }
+
+    fn source_hash(&self) -> Option<B256> {
+        self.0.source_hash()
+    }
+
+    fn mint(&self) -> Option<u128> {
+        self.0.mint()
+    }
+
+    fn is_system_transaction(&self) -> bool {
+        self.0.is_system_transaction()
+    }
+}
+
+impl FromRecoveredTx<OpTxEnvelope> for OpTx {
+    fn from_recovered_tx(tx: &OpTxEnvelope, sender: Address) -> Self {
+        let encoded = tx.encoded_2718();
+        Self::from_encoded_tx(tx, sender, encoded.into())
+    }
+}
+
+impl FromTxWithEncoded<OpTxEnvelope> for OpTx {
+    fn from_encoded_tx(tx: &OpTxEnvelope, caller: Address, encoded: Bytes) -> Self {
+        match tx {
+            OpTxEnvelope::Legacy(tx) => Self::from_encoded_tx(tx, caller, encoded),
+            OpTxEnvelope::Eip1559(tx) => Self::from_encoded_tx(tx, caller, encoded),
+            OpTxEnvelope::Eip2930(tx) => Self::from_encoded_tx(tx, caller, encoded),
+            OpTxEnvelope::Eip7702(tx) => Self::from_encoded_tx(tx, caller, encoded),
+            OpTxEnvelope::Deposit(tx) => Self::from_encoded_tx(tx.inner(), caller, encoded),
+            OpTxEnvelope::PostExec(tx) => Self::from_encoded_tx(tx.inner(), caller, encoded),
+        }
+    }
+}
+
+/// Generates [`FromRecoveredTx`] and [`FromTxWithEncoded`] impls for [`OpTx`] from a
+/// `Signed<$tx>` and bare `$tx` type. The bare type conversion creates the [`TxEnv`] via
+/// [`FromRecoveredTx`] and wraps it in an [`OpTransaction`].
+macro_rules! impl_from_tx {
+    ($($tx:ty),+ $(,)?) => {
+        $(
+            impl FromRecoveredTx<Signed<$tx>> for OpTx {
+                fn from_recovered_tx(tx: &Signed<$tx>, sender: Address) -> Self {
+                    let encoded = tx.encoded_2718();
+                    Self::from_encoded_tx(tx, sender, encoded.into())
+                }
+            }
+
+            impl FromTxWithEncoded<Signed<$tx>> for OpTx {
+                fn from_encoded_tx(tx: &Signed<$tx>, caller: Address, encoded: Bytes) -> Self {
+                    Self::from_encoded_tx(tx.tx(), caller, encoded)
+                }
+            }
+
+            impl FromTxWithEncoded<$tx> for OpTx {
+                fn from_encoded_tx(tx: &$tx, caller: Address, encoded: Bytes) -> Self {
+                    let base = TxEnv::from_recovered_tx(tx, caller);
+                    Self(OpTransaction {
+                        base,
+                        enveloped_tx: Some(encoded),
+                        deposit: Default::default(),
+                    })
+                }
+            }
+        )+
+    };
+}
+
+impl_from_tx!(TxLegacy, TxEip2930, TxEip1559, TxEip4844, TxEip7702);
+
+/// `TxEip4844Variant<T>` conversion is not necessary for `OpTx`, but it's useful
+/// sugar for Foundry.
+impl<T> FromRecoveredTx<Signed<TxEip4844Variant<T>>> for OpTx
+where
+    T: Encodable7594 + Send + Sync,
+{
+    fn from_recovered_tx(tx: &Signed<TxEip4844Variant<T>>, sender: Address) -> Self {
+        let encoded = tx.encoded_2718();
+        Self::from_encoded_tx(tx, sender, encoded.into())
+    }
+}
+
+impl<T> FromTxWithEncoded<Signed<TxEip4844Variant<T>>> for OpTx {
+    fn from_encoded_tx(tx: &Signed<TxEip4844Variant<T>>, caller: Address, encoded: Bytes) -> Self {
+        Self::from_encoded_tx(tx.tx(), caller, encoded)
+    }
+}
+
+impl<T> FromTxWithEncoded<TxEip4844Variant<T>> for OpTx {
+    fn from_encoded_tx(tx: &TxEip4844Variant<T>, caller: Address, encoded: Bytes) -> Self {
+        let base = TxEnv::from_recovered_tx(tx, caller);
+        Self(OpTransaction { base, enveloped_tx: Some(encoded), deposit: Default::default() })
+    }
+}
+
+impl FromRecoveredTx<TxDeposit> for OpTx {
+    fn from_recovered_tx(tx: &TxDeposit, sender: Address) -> Self {
+        let encoded = tx.encoded_2718();
+        Self::from_encoded_tx(tx, sender, encoded.into())
+    }
+}
+
+impl FromTxWithEncoded<TxDeposit> for OpTx {
+    fn from_encoded_tx(tx: &TxDeposit, caller: Address, encoded: Bytes) -> Self {
+        let base = deposit_tx_env(tx, caller);
+        let deposit = DepositTransactionParts {
+            source_hash: tx.source_hash,
+            mint: Some(tx.mint),
+            is_system_transaction: tx.is_system_transaction,
+        };
+        Self(OpTransaction { base, enveloped_tx: Some(encoded), deposit })
+    }
+}
+
+impl FromRecoveredTx<TxPostExec> for OpTx {
+    fn from_recovered_tx(tx: &TxPostExec, _sender: Address) -> Self {
+        let encoded = tx.encoded_2718();
+        Self::from_encoded_tx(tx, Address::ZERO, encoded.into())
+    }
+}
+
+impl FromTxWithEncoded<TxPostExec> for OpTx {
+    fn from_encoded_tx(tx: &TxPostExec, caller: Address, encoded: Bytes) -> Self {
+        let base = TxEnv { tx_type: tx.ty(), caller, kind: tx.kind(), ..Default::default() };
+        Self(OpTransaction { base, enveloped_tx: Some(encoded), deposit: Default::default() })
+    }
+}
+
+impl TransactionEnvMut for OpTx {
+    fn set_gas_limit(&mut self, gas_limit: u64) {
+        self.0.base.gas_limit = gas_limit;
+    }
+
+    fn set_nonce(&mut self, nonce: u64) {
+        self.0.base.nonce = nonce;
+    }
+
+    fn set_access_list(&mut self, access_list: alloy_eips::eip2930::AccessList) {
+        self.0.base.access_list = access_list;
+    }
+}
+
+/// Trait for OP transaction environments. Allows to recover the transaction encoded bytes if
+/// they're available.
+pub trait OpTxEnv {
+    /// Returns the encoded bytes of the transaction.
+    fn encoded_bytes(&self) -> Option<&Bytes>;
+}
+
+impl<T: revm::context::Transaction> OpTxEnv for OpTransaction<T> {
+    fn encoded_bytes(&self) -> Option<&Bytes> {
+        self.enveloped_tx.as_ref()
+    }
+}

--- a/crates/op/alloy-op-hardforks/Cargo.toml
+++ b/crates/op/alloy-op-hardforks/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "alloy-op-hardforks"
+description = "Bindings for named OP hardforks"
+
+version = "0.4.7"
+edition = "2024"
+rust-version.workspace = true
+authors = ["Alloy Contributors", "OpLabsPBC"]
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/foundry-rs/foundry-core"
+repository = "https://github.com/foundry-rs/foundry-core"
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-hardforks = { workspace = true }
+
+# ethereum
+alloy-chains = { workspace = true }
+alloy-primitives = { workspace = true }
+
+# misc
+auto_impl = { workspace = true }
+serde = { workspace = true, optional = true }
+
+[features]
+serde = [
+	"dep:serde",
+	"alloy-hardforks/serde",
+	"alloy-chains/serde",
+	"alloy-primitives/serde"
+]

--- a/crates/op/alloy-op-hardforks/src/base/mainnet.rs
+++ b/crates/op/alloy-op-hardforks/src/base/mainnet.rs
@@ -1,0 +1,22 @@
+//! Base Mainnet hardfork starting points
+
+use crate::optimism::mainnet::*;
+
+/// Bedrock base hardfork activation block is 0.
+pub const BASE_MAINNET_BEDROCK_BLOCK: u64 = 0;
+/// Regolith base hardfork activation timestamp is 0.
+pub const BASE_MAINNET_REGOLITH_TIMESTAMP: u64 = OP_MAINNET_REGOLITH_TIMESTAMP;
+/// Canyon base hardfork activation timestamp is 1704992401.
+pub const BASE_MAINNET_CANYON_TIMESTAMP: u64 = OP_MAINNET_CANYON_TIMESTAMP;
+/// Ecotone base hardfork activation timestamp is 1710374401.
+pub const BASE_MAINNET_ECOTONE_TIMESTAMP: u64 = OP_MAINNET_ECOTONE_TIMESTAMP;
+/// Fjord base hardfork activation timestamp is 1720627201.
+pub const BASE_MAINNET_FJORD_TIMESTAMP: u64 = OP_MAINNET_FJORD_TIMESTAMP;
+/// Granite base hardfork activation timestamp is 1726070401.
+pub const BASE_MAINNET_GRANITE_TIMESTAMP: u64 = OP_MAINNET_GRANITE_TIMESTAMP;
+/// Holocene base hardfork activation timestamp is 1736445601.
+pub const BASE_MAINNET_HOLOCENE_TIMESTAMP: u64 = OP_MAINNET_HOLOCENE_TIMESTAMP;
+/// Isthmus base hardfork activation timestamp is 1746806401.
+pub const BASE_MAINNET_ISTHMUS_TIMESTAMP: u64 = OP_MAINNET_ISTHMUS_TIMESTAMP;
+/// Jovian base hardfork activation timestamp is `1_763_481_601`.
+pub const BASE_MAINNET_JOVIAN_TIMESTAMP: u64 = OP_MAINNET_JOVIAN_TIMESTAMP;

--- a/crates/op/alloy-op-hardforks/src/base/mod.rs
+++ b/crates/op/alloy-op-hardforks/src/base/mod.rs
@@ -1,0 +1,6 @@
+//! Base hardfork starting points
+
+pub mod mainnet;
+pub use mainnet::*;
+pub mod sepolia;
+pub use sepolia::*;

--- a/crates/op/alloy-op-hardforks/src/base/sepolia.rs
+++ b/crates/op/alloy-op-hardforks/src/base/sepolia.rs
@@ -1,0 +1,22 @@
+//! Base Sepolia hardfork starting points
+
+use crate::optimism::sepolia::*;
+
+/// Bedrock base sepolia hardfork activation block is 0.
+pub const BASE_SEPOLIA_BEDROCK_BLOCK: u64 = OP_SEPOLIA_BEDROCK_BLOCK;
+/// Regolith base sepolia hardfork activation timestamp is 0.
+pub const BASE_SEPOLIA_REGOLITH_TIMESTAMP: u64 = OP_SEPOLIA_REGOLITH_TIMESTAMP;
+/// Canyon base sepolia hardfork activation timestamp is 1699981200.
+pub const BASE_SEPOLIA_CANYON_TIMESTAMP: u64 = OP_SEPOLIA_CANYON_TIMESTAMP;
+/// Ecotone base sepolia hardfork activation timestamp is 1708534800.
+pub const BASE_SEPOLIA_ECOTONE_TIMESTAMP: u64 = OP_SEPOLIA_ECOTONE_TIMESTAMP;
+/// Fjord base sepolia hardfork activation timestamp is 1716998400.
+pub const BASE_SEPOLIA_FJORD_TIMESTAMP: u64 = OP_SEPOLIA_FJORD_TIMESTAMP;
+/// Granite base sepolia hardfork activation timestamp is 1723478400.
+pub const BASE_SEPOLIA_GRANITE_TIMESTAMP: u64 = OP_SEPOLIA_GRANITE_TIMESTAMP;
+/// Holocene base sepolia hardfork activation timestamp is 1732633200.
+pub const BASE_SEPOLIA_HOLOCENE_TIMESTAMP: u64 = OP_SEPOLIA_HOLOCENE_TIMESTAMP;
+/// Isthmus base sepolia hardfork activation timestamp is 1744905600.
+pub const BASE_SEPOLIA_ISTHMUS_TIMESTAMP: u64 = OP_SEPOLIA_ISTHMUS_TIMESTAMP;
+/// Jovian base sepolia hardfork activation timestamp is `1_762_963_201`.
+pub const BASE_SEPOLIA_JOVIAN_TIMESTAMP: u64 = OP_SEPOLIA_JOVIAN_TIMESTAMP;

--- a/crates/op/alloy-op-hardforks/src/lib.rs
+++ b/crates/op/alloy-op-hardforks/src/lib.rs
@@ -1,0 +1,385 @@
+//! OP Stack hardfork definitions.
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![no_std]
+
+extern crate alloc;
+use alloc::vec::Vec;
+use alloy_chains::{Chain, NamedChain};
+use alloy_hardforks::{EthereumHardfork, hardfork};
+pub use alloy_hardforks::{EthereumHardforks, ForkCondition};
+use alloy_primitives::U256;
+use core::ops::Index;
+
+pub mod optimism;
+pub use optimism::{mainnet as op_mainnet, mainnet::*, sepolia as op_sepolia, sepolia::*};
+
+pub mod base;
+pub use base::{mainnet as base_mainnet, mainnet::*, sepolia as base_sepolia, sepolia::*};
+
+hardfork!(
+    /// The name of an optimism hardfork.
+    ///
+    /// When building a list of hardforks for a chain, it's still expected to zip with
+    /// [`EthereumHardfork`].
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Default)]
+    OpHardfork {
+        /// Bedrock: <https://blog.oplabs.co/introducing-optimism-bedrock>.
+        Bedrock,
+        /// Regolith: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#regolith>.
+        Regolith,
+        /// <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#canyon>.
+        Canyon,
+        /// Ecotone: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#ecotone>.
+        Ecotone,
+        /// Fjord: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#fjord>
+        Fjord,
+        /// Granite: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#granite>
+        Granite,
+        /// Holocene: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/superchain-upgrades.md#holocene>
+        Holocene,
+        /// Isthmus: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/isthmus/overview.md>
+        Isthmus,
+        /// Jovian: <https://github.com/ethereum-optimism/specs/tree/main/specs/protocol/jovian>
+        #[default]
+        Jovian,
+        /// Karst: <https://github.com/ethereum-optimism/specs/tree/main/specs/protocol/karst>
+        Karst,
+        /// TODO: add interop hardfork overview when available
+        Interop,
+    }
+);
+
+impl OpHardfork {
+    /// Reverse lookup to find the hardfork given a chain ID and block timestamp.
+    /// Returns the active hardfork at the given timestamp for the specified OP chain.
+    pub fn from_chain_and_timestamp(chain: Chain, timestamp: u64) -> Option<Self> {
+        let named = chain.named()?;
+
+        match named {
+            NamedChain::Optimism => Some(match timestamp {
+                _i if timestamp < OP_MAINNET_CANYON_TIMESTAMP => Self::Regolith,
+                _i if timestamp < OP_MAINNET_ECOTONE_TIMESTAMP => Self::Canyon,
+                _i if timestamp < OP_MAINNET_FJORD_TIMESTAMP => Self::Ecotone,
+                _i if timestamp < OP_MAINNET_GRANITE_TIMESTAMP => Self::Fjord,
+                _i if timestamp < OP_MAINNET_HOLOCENE_TIMESTAMP => Self::Granite,
+                _i if timestamp < OP_MAINNET_ISTHMUS_TIMESTAMP => Self::Holocene,
+                _i if timestamp < OP_MAINNET_JOVIAN_TIMESTAMP => Self::Isthmus,
+                _ => Self::Jovian,
+            }),
+            NamedChain::OptimismSepolia => Some(match timestamp {
+                _i if timestamp < OP_SEPOLIA_CANYON_TIMESTAMP => Self::Regolith,
+                _i if timestamp < OP_SEPOLIA_ECOTONE_TIMESTAMP => Self::Canyon,
+                _i if timestamp < OP_SEPOLIA_FJORD_TIMESTAMP => Self::Ecotone,
+                _i if timestamp < OP_SEPOLIA_GRANITE_TIMESTAMP => Self::Fjord,
+                _i if timestamp < OP_SEPOLIA_HOLOCENE_TIMESTAMP => Self::Granite,
+                _i if timestamp < OP_SEPOLIA_ISTHMUS_TIMESTAMP => Self::Holocene,
+                _i if timestamp < OP_SEPOLIA_JOVIAN_TIMESTAMP => Self::Isthmus,
+                _ => Self::Jovian,
+            }),
+            NamedChain::Base => Some(match timestamp {
+                _i if timestamp < BASE_MAINNET_CANYON_TIMESTAMP => Self::Regolith,
+                _i if timestamp < BASE_MAINNET_ECOTONE_TIMESTAMP => Self::Canyon,
+                _i if timestamp < BASE_MAINNET_FJORD_TIMESTAMP => Self::Ecotone,
+                _i if timestamp < BASE_MAINNET_GRANITE_TIMESTAMP => Self::Fjord,
+                _i if timestamp < BASE_MAINNET_HOLOCENE_TIMESTAMP => Self::Granite,
+                _i if timestamp < BASE_MAINNET_ISTHMUS_TIMESTAMP => Self::Holocene,
+                _i if timestamp < BASE_MAINNET_JOVIAN_TIMESTAMP => Self::Isthmus,
+                _ => Self::Jovian,
+            }),
+            NamedChain::BaseSepolia => Some(match timestamp {
+                _i if timestamp < BASE_SEPOLIA_CANYON_TIMESTAMP => Self::Regolith,
+                _i if timestamp < BASE_SEPOLIA_ECOTONE_TIMESTAMP => Self::Canyon,
+                _i if timestamp < BASE_SEPOLIA_FJORD_TIMESTAMP => Self::Ecotone,
+                _i if timestamp < BASE_SEPOLIA_GRANITE_TIMESTAMP => Self::Fjord,
+                _i if timestamp < BASE_SEPOLIA_HOLOCENE_TIMESTAMP => Self::Granite,
+                _i if timestamp < BASE_SEPOLIA_ISTHMUS_TIMESTAMP => Self::Holocene,
+                _i if timestamp < BASE_SEPOLIA_JOVIAN_TIMESTAMP => Self::Isthmus,
+                _ => Self::Jovian,
+            }),
+            _ => None,
+        }
+    }
+
+    /// Optimism mainnet list of hardforks.
+    pub const fn op_mainnet() -> [(Self, ForkCondition); 9] {
+        [
+            (Self::Bedrock, ForkCondition::Block(OP_MAINNET_BEDROCK_BLOCK)),
+            (Self::Regolith, ForkCondition::Timestamp(OP_MAINNET_REGOLITH_TIMESTAMP)),
+            (Self::Canyon, ForkCondition::Timestamp(OP_MAINNET_CANYON_TIMESTAMP)),
+            (Self::Ecotone, ForkCondition::Timestamp(OP_MAINNET_ECOTONE_TIMESTAMP)),
+            (Self::Fjord, ForkCondition::Timestamp(OP_MAINNET_FJORD_TIMESTAMP)),
+            (Self::Granite, ForkCondition::Timestamp(OP_MAINNET_GRANITE_TIMESTAMP)),
+            (Self::Holocene, ForkCondition::Timestamp(OP_MAINNET_HOLOCENE_TIMESTAMP)),
+            (Self::Isthmus, ForkCondition::Timestamp(OP_MAINNET_ISTHMUS_TIMESTAMP)),
+            (Self::Jovian, ForkCondition::Timestamp(OP_MAINNET_JOVIAN_TIMESTAMP)),
+        ]
+    }
+
+    /// Optimism Sepolia list of hardforks.
+    pub const fn op_sepolia() -> [(Self, ForkCondition); 9] {
+        [
+            (Self::Bedrock, ForkCondition::Block(OP_SEPOLIA_BEDROCK_BLOCK)),
+            (Self::Regolith, ForkCondition::Timestamp(OP_SEPOLIA_REGOLITH_TIMESTAMP)),
+            (Self::Canyon, ForkCondition::Timestamp(OP_SEPOLIA_CANYON_TIMESTAMP)),
+            (Self::Ecotone, ForkCondition::Timestamp(OP_SEPOLIA_ECOTONE_TIMESTAMP)),
+            (Self::Fjord, ForkCondition::Timestamp(OP_SEPOLIA_FJORD_TIMESTAMP)),
+            (Self::Granite, ForkCondition::Timestamp(OP_SEPOLIA_GRANITE_TIMESTAMP)),
+            (Self::Holocene, ForkCondition::Timestamp(OP_SEPOLIA_HOLOCENE_TIMESTAMP)),
+            (Self::Isthmus, ForkCondition::Timestamp(OP_SEPOLIA_ISTHMUS_TIMESTAMP)),
+            (Self::Jovian, ForkCondition::Timestamp(OP_SEPOLIA_JOVIAN_TIMESTAMP)),
+        ]
+    }
+
+    /// Base mainnet list of hardforks.
+    pub const fn base_mainnet() -> [(Self, ForkCondition); 9] {
+        [
+            (Self::Bedrock, ForkCondition::Block(BASE_MAINNET_BEDROCK_BLOCK)),
+            (Self::Regolith, ForkCondition::Timestamp(BASE_MAINNET_REGOLITH_TIMESTAMP)),
+            (Self::Canyon, ForkCondition::Timestamp(BASE_MAINNET_CANYON_TIMESTAMP)),
+            (Self::Ecotone, ForkCondition::Timestamp(BASE_MAINNET_ECOTONE_TIMESTAMP)),
+            (Self::Fjord, ForkCondition::Timestamp(BASE_MAINNET_FJORD_TIMESTAMP)),
+            (Self::Granite, ForkCondition::Timestamp(BASE_MAINNET_GRANITE_TIMESTAMP)),
+            (Self::Holocene, ForkCondition::Timestamp(BASE_MAINNET_HOLOCENE_TIMESTAMP)),
+            (Self::Isthmus, ForkCondition::Timestamp(BASE_MAINNET_ISTHMUS_TIMESTAMP)),
+            (Self::Jovian, ForkCondition::Timestamp(BASE_MAINNET_JOVIAN_TIMESTAMP)),
+        ]
+    }
+
+    /// Base Sepolia list of hardforks.
+    pub const fn base_sepolia() -> [(Self, ForkCondition); 9] {
+        [
+            (Self::Bedrock, ForkCondition::Block(BASE_SEPOLIA_BEDROCK_BLOCK)),
+            (Self::Regolith, ForkCondition::Timestamp(BASE_SEPOLIA_REGOLITH_TIMESTAMP)),
+            (Self::Canyon, ForkCondition::Timestamp(BASE_SEPOLIA_CANYON_TIMESTAMP)),
+            (Self::Ecotone, ForkCondition::Timestamp(BASE_SEPOLIA_ECOTONE_TIMESTAMP)),
+            (Self::Fjord, ForkCondition::Timestamp(BASE_SEPOLIA_FJORD_TIMESTAMP)),
+            (Self::Granite, ForkCondition::Timestamp(BASE_SEPOLIA_GRANITE_TIMESTAMP)),
+            (Self::Holocene, ForkCondition::Timestamp(BASE_SEPOLIA_HOLOCENE_TIMESTAMP)),
+            (Self::Isthmus, ForkCondition::Timestamp(BASE_SEPOLIA_ISTHMUS_TIMESTAMP)),
+            (Self::Jovian, ForkCondition::Timestamp(BASE_SEPOLIA_JOVIAN_TIMESTAMP)),
+        ]
+    }
+
+    /// Returns index of `self` in sorted canonical array.
+    pub const fn idx(&self) -> usize {
+        *self as usize
+    }
+}
+
+/// Extends [`EthereumHardforks`] with optimism helper methods.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait OpHardforks: EthereumHardforks {
+    /// Retrieves [`ForkCondition`] by an [`OpHardfork`]. If `fork` is not present, returns
+    /// [`ForkCondition::Never`].
+    fn op_fork_activation(&self, fork: OpHardfork) -> ForkCondition;
+
+    /// Convenience method to check if [`OpHardfork::Bedrock`] is active at a given block
+    /// number.
+    fn is_bedrock_active_at_block(&self, block_number: u64) -> bool {
+        self.op_fork_activation(OpHardfork::Bedrock).active_at_block(block_number)
+    }
+
+    /// Returns `true` if [`Regolith`](OpHardfork::Regolith) is active at given block
+    /// timestamp.
+    fn is_regolith_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.op_fork_activation(OpHardfork::Regolith).active_at_timestamp(timestamp)
+    }
+
+    /// Returns `true` if [`Canyon`](OpHardfork::Canyon) is active at given block timestamp.
+    fn is_canyon_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.op_fork_activation(OpHardfork::Canyon).active_at_timestamp(timestamp)
+    }
+
+    /// Returns `true` if [`Ecotone`](OpHardfork::Ecotone) is active at given block timestamp.
+    fn is_ecotone_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.op_fork_activation(OpHardfork::Ecotone).active_at_timestamp(timestamp)
+    }
+
+    /// Returns `true` if [`Fjord`](OpHardfork::Fjord) is active at given block timestamp.
+    fn is_fjord_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.op_fork_activation(OpHardfork::Fjord).active_at_timestamp(timestamp)
+    }
+
+    /// Returns `true` if [`Granite`](OpHardfork::Granite) is active at given block timestamp.
+    fn is_granite_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.op_fork_activation(OpHardfork::Granite).active_at_timestamp(timestamp)
+    }
+
+    /// Returns `true` if [`Holocene`](OpHardfork::Holocene) is active at given block
+    /// timestamp.
+    fn is_holocene_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.op_fork_activation(OpHardfork::Holocene).active_at_timestamp(timestamp)
+    }
+
+    /// Returns `true` if [`Isthmus`](OpHardfork::Isthmus) is active at given block
+    /// timestamp.
+    fn is_isthmus_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.op_fork_activation(OpHardfork::Isthmus).active_at_timestamp(timestamp)
+    }
+
+    /// Returns `true` if [`Jovian`](OpHardfork::Jovian) is active at given block
+    /// timestamp.
+    fn is_jovian_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.op_fork_activation(OpHardfork::Jovian).active_at_timestamp(timestamp)
+    }
+
+    /// Returns `true` if [`Karst`](OpHardfork::Karst) is active at given block
+    /// timestamp.
+    fn is_karst_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.op_fork_activation(OpHardfork::Karst).active_at_timestamp(timestamp)
+    }
+
+    /// Returns `true` if [`Interop`](OpHardfork::Interop) is active at given block
+    /// timestamp.
+    fn is_interop_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.op_fork_activation(OpHardfork::Interop).active_at_timestamp(timestamp)
+    }
+}
+
+/// A type allowing to configure activation [`ForkCondition`]s for a given list of
+/// [`OpHardfork`]s.
+///
+/// Zips together [`EthereumHardfork`]s and [`OpHardfork`]s. Optimism hard forks, at least,
+/// whenever Ethereum hard forks. When Ethereum hard forks, a new [`OpHardfork`] piggybacks on top
+/// of the new [`EthereumHardfork`] to include (or to noop) the L1 changes on L2.
+///
+/// Optimism can also hard fork independently of Ethereum. The relation between Ethereum and
+/// Optimism hard forks is described by predicate [`EthereumHardfork`] `=>` [`OpHardfork`], since
+/// an OP chain can undergo an [`OpHardfork`] without an [`EthereumHardfork`], but not the other
+/// way around.
+#[derive(Debug, Clone)]
+pub struct OpChainHardforks {
+    /// Ordered list of OP hardfork activations.
+    forks: Vec<(OpHardfork, ForkCondition)>,
+}
+
+impl OpChainHardforks {
+    /// Creates a new [`OpChainHardforks`] with the given list of forks. The input list is sorted
+    /// w.r.t. the hardcoded canonicity of [`OpHardfork`]s.
+    pub fn new(forks: impl IntoIterator<Item = (OpHardfork, ForkCondition)>) -> Self {
+        let mut forks = forks.into_iter().collect::<Vec<_>>();
+        forks.sort();
+        Self { forks }
+    }
+
+    /// Creates a new [`OpChainHardforks`] with OP mainnet configuration.
+    pub fn op_mainnet() -> Self {
+        Self::new(OpHardfork::op_mainnet())
+    }
+
+    /// Creates a new [`OpChainHardforks`] with OP Sepolia configuration.
+    pub fn op_sepolia() -> Self {
+        Self::new(OpHardfork::op_sepolia())
+    }
+
+    /// Creates a new [`OpChainHardforks`] with Base mainnet configuration.
+    pub fn base_mainnet() -> Self {
+        Self::new(OpHardfork::base_mainnet())
+    }
+
+    /// Creates a new [`OpChainHardforks`] with Base Sepolia configuration.
+    pub fn base_sepolia() -> Self {
+        Self::new(OpHardfork::base_sepolia())
+    }
+
+    /// Returns `true` if this is an OP mainnet instance.
+    pub fn is_op_mainnet(&self) -> bool {
+        self[OpHardfork::Bedrock] == ForkCondition::Block(OP_MAINNET_BEDROCK_BLOCK)
+    }
+}
+
+impl EthereumHardforks for OpChainHardforks {
+    fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
+        use EthereumHardfork::{Cancun, Osaka, Prague, Shanghai};
+        use OpHardfork::{Canyon, Ecotone, Isthmus, Karst};
+
+        if self.forks.is_empty() {
+            return ForkCondition::Never;
+        }
+
+        let forks_len = self.forks.len();
+        // check index out of bounds
+        match fork {
+            Shanghai if forks_len <= Canyon.idx() => ForkCondition::Never,
+            Cancun if forks_len <= Ecotone.idx() => ForkCondition::Never,
+            Prague if forks_len <= Isthmus.idx() => ForkCondition::Never,
+            Osaka if forks_len <= Karst.idx() => ForkCondition::Never,
+            _ => self[fork],
+        }
+    }
+}
+
+impl OpHardforks for OpChainHardforks {
+    fn op_fork_activation(&self, fork: OpHardfork) -> ForkCondition {
+        // check index out of bounds
+        if self.forks.len() <= fork.idx() {
+            return ForkCondition::Never;
+        }
+        self[fork]
+    }
+}
+
+impl Index<OpHardfork> for OpChainHardforks {
+    type Output = ForkCondition;
+
+    fn index(&self, hf: OpHardfork) -> &Self::Output {
+        use OpHardfork::{
+            Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Interop, Isthmus, Jovian, Karst,
+            Regolith,
+        };
+
+        match hf {
+            Bedrock => &self.forks[Bedrock.idx()].1,
+            Regolith => &self.forks[Regolith.idx()].1,
+            Canyon => &self.forks[Canyon.idx()].1,
+            Ecotone => &self.forks[Ecotone.idx()].1,
+            Fjord => &self.forks[Fjord.idx()].1,
+            Granite => &self.forks[Granite.idx()].1,
+            Holocene => &self.forks[Holocene.idx()].1,
+            Isthmus => &self.forks[Isthmus.idx()].1,
+            Jovian => &self.forks[Jovian.idx()].1,
+            Karst => &self.forks[Karst.idx()].1,
+            Interop => &self.forks[Interop.idx()].1,
+        }
+    }
+}
+
+impl Index<EthereumHardfork> for OpChainHardforks {
+    type Output = ForkCondition;
+
+    fn index(&self, hf: EthereumHardfork) -> &Self::Output {
+        use EthereumHardfork::{
+            Amsterdam, ArrowGlacier, Berlin, Bpo1, Bpo2, Bpo3, Bpo4, Bpo5, Byzantium, Cancun,
+            Constantinople, Dao, Frontier, GrayGlacier, Homestead, Istanbul, London, MuirGlacier,
+            Osaka, Paris, Petersburg, Prague, Shanghai, SpuriousDragon, Tangerine,
+        };
+        use OpHardfork::{Bedrock, Canyon, Ecotone, Isthmus, Karst};
+
+        match hf {
+            // Dao Hardfork is not needed for OpChainHardforks
+            Dao | Bpo1 | Bpo2 | Bpo3 | Bpo4 | Bpo5 | Amsterdam => &ForkCondition::Never,
+            Berlin if self.is_op_mainnet() => &ForkCondition::Block(OP_MAINNET_BERLIN_BLOCK),
+            Frontier | Homestead | Tangerine | SpuriousDragon | Byzantium | Constantinople
+            | Petersburg | Istanbul | MuirGlacier | Berlin => &ForkCondition::ZERO_BLOCK,
+            London | ArrowGlacier | GrayGlacier => &self[Bedrock],
+            Paris if self.is_op_mainnet() => &ForkCondition::TTD {
+                activation_block_number: OP_MAINNET_BEDROCK_BLOCK,
+                fork_block: Some(OP_MAINNET_BEDROCK_BLOCK),
+                total_difficulty: U256::ZERO,
+            },
+            Paris => &ForkCondition::TTD {
+                activation_block_number: 0,
+                fork_block: Some(0),
+                total_difficulty: U256::ZERO,
+            },
+            Shanghai => &self[Canyon],
+            Cancun => &self[Ecotone],
+            Prague => &self[Isthmus],
+            Osaka => &self[Karst],
+            _ => unreachable!(),
+        }
+    }
+}

--- a/crates/op/alloy-op-hardforks/src/optimism/mainnet.rs
+++ b/crates/op/alloy-op-hardforks/src/optimism/mainnet.rs
@@ -1,0 +1,24 @@
+//! Optimism Mainnet hardfork starting points
+
+//------------------------ OVM chain ------------------------//
+/// Berlin hardfork activation block is 3950000.
+pub const OP_MAINNET_BERLIN_BLOCK: u64 = 3_950_000;
+//------------------------ EVM chain ------------------------//
+/// Bedrock hardfork activation block is 105235063.
+pub const OP_MAINNET_BEDROCK_BLOCK: u64 = 105_235_063;
+/// Regolith hardfork activation timestamp is 0.
+pub const OP_MAINNET_REGOLITH_TIMESTAMP: u64 = 0;
+/// Canyon hardfork activation timestamp is 1704992401.
+pub const OP_MAINNET_CANYON_TIMESTAMP: u64 = 1_704_992_401;
+/// Ecotone hardfork activation timestamp is 1710374401.
+pub const OP_MAINNET_ECOTONE_TIMESTAMP: u64 = 1_710_374_401;
+/// Fjord hardfork activation timestamp is 1720627201.
+pub const OP_MAINNET_FJORD_TIMESTAMP: u64 = 1_720_627_201;
+/// Granite hardfork activation timestamp is 1726070401.
+pub const OP_MAINNET_GRANITE_TIMESTAMP: u64 = 1_726_070_401;
+/// Holocene hardfork activation timestamp is 1736445601.
+pub const OP_MAINNET_HOLOCENE_TIMESTAMP: u64 = 1_736_445_601;
+/// Isthmus hardfork activation timestamp is 1746806401.
+pub const OP_MAINNET_ISTHMUS_TIMESTAMP: u64 = 1_746_806_401;
+/// Jovian hardfork activation timestamp is `1_764_691_201` # Tue 2 Dec 2025 16:00:01 UTC
+pub const OP_MAINNET_JOVIAN_TIMESTAMP: u64 = 1_764_691_201;

--- a/crates/op/alloy-op-hardforks/src/optimism/mod.rs
+++ b/crates/op/alloy-op-hardforks/src/optimism/mod.rs
@@ -1,0 +1,6 @@
+//! Optimism hardfork starting points
+
+pub mod mainnet;
+pub use mainnet::*;
+pub mod sepolia;
+pub use sepolia::*;

--- a/crates/op/alloy-op-hardforks/src/optimism/sepolia.rs
+++ b/crates/op/alloy-op-hardforks/src/optimism/sepolia.rs
@@ -1,0 +1,20 @@
+//! Optimism Sepolia hardfork starting points
+
+/// Bedrock sepolia hardfork activation block is 0.
+pub const OP_SEPOLIA_BEDROCK_BLOCK: u64 = 0;
+/// Regolith sepolia hardfork activation timestamp is 0.
+pub const OP_SEPOLIA_REGOLITH_TIMESTAMP: u64 = 0;
+/// Canyon sepolia hardfork activation timestamp is 1699981200.
+pub const OP_SEPOLIA_CANYON_TIMESTAMP: u64 = 1_699_981_200;
+/// Ecotone sepolia hardfork activation timestamp is 1708534800.
+pub const OP_SEPOLIA_ECOTONE_TIMESTAMP: u64 = 1_708_534_800;
+/// Fjord sepolia hardfork activation timestamp is 1716998400.
+pub const OP_SEPOLIA_FJORD_TIMESTAMP: u64 = 1_716_998_400;
+/// Granite sepolia hardfork activation timestamp is 1723478400.
+pub const OP_SEPOLIA_GRANITE_TIMESTAMP: u64 = 1_723_478_400;
+/// Holocene sepolia hardfork activation timestamp is 1732633200.
+pub const OP_SEPOLIA_HOLOCENE_TIMESTAMP: u64 = 1_732_633_200;
+/// Isthmus sepolia hardfork activation timestamp is 1744905600.
+pub const OP_SEPOLIA_ISTHMUS_TIMESTAMP: u64 = 1_744_905_600;
+/// Jovian sepolia hardfork activation timestamp is `1_763_568_001` # Wed 19 Nov 2025 16:00:01 UTC.
+pub const OP_SEPOLIA_JOVIAN_TIMESTAMP: u64 = 1_763_568_001;

--- a/crates/op/op-alloy-consensus/Cargo.toml
+++ b/crates/op/op-alloy-consensus/Cargo.toml
@@ -1,0 +1,66 @@
+[package]
+name = "op-alloy-consensus"
+description = "Optimism alloy consensus types"
+
+version = "0.24.0"
+edition.workspace = true
+rust-version.workspace = true
+authors = ["Alloy Contributors"]
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/ethereum-optimism/optimism"
+repository = "https://github.com/ethereum-optimism/optimism"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Alloy
+alloy-rlp.workspace = true
+alloy-eips.workspace = true
+alloy-consensus.workspace = true
+alloy-primitives = { workspace = true, features = ["rlp"] }
+
+# compat
+alloy-network = { workspace = true, optional = true }
+alloy-rpc-types-eth = { workspace = true, optional = true }
+
+# arbitrary
+arbitrary = { version = "1", features = ["derive"], optional = true }
+
+# serde
+alloy-serde = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
+
+[features]
+default = ["std"]
+std = [
+	"alloy-eips/std",
+	"alloy-consensus/std",
+	"alloy-primitives/std",
+	"alloy-rlp/std",
+	"alloy-rpc-types-eth?/std",
+	"alloy-serde?/std",
+	"serde?/std",
+]
+alloy-compat = ["serde", "dep:alloy-network", "dep:alloy-rpc-types-eth"]
+k256 = ["alloy-primitives/k256", "alloy-consensus/k256"]
+kzg = ["alloy-eips/kzg", "alloy-consensus/kzg", "std"]
+arbitrary = [
+	"std",
+	"dep:arbitrary",
+	"alloy-consensus/arbitrary",
+	"alloy-eips/arbitrary",
+	"alloy-primitives/rand",
+	"alloy-primitives/arbitrary",
+	"alloy-rpc-types-eth?/arbitrary",
+	"alloy-serde?/arbitrary",
+]
+serde = [
+	"dep:serde",
+	"dep:alloy-serde",
+	"alloy-primitives/serde",
+	"alloy-consensus/serde",
+	"alloy-eips/serde",
+	"alloy-rpc-types-eth?/serde",
+]
+

--- a/crates/op/op-alloy-consensus/src/alloy_compat.rs
+++ b/crates/op/op-alloy-consensus/src/alloy_compat.rs
@@ -1,0 +1,65 @@
+//! Additional compatibility implementations.
+
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
+use crate::{DEPOSIT_TX_TYPE_ID, OpTxEnvelope, TxDeposit};
+use alloy_consensus::Sealed;
+use alloy_eips::Typed2718;
+use alloy_network::{AnyRpcTransaction, AnyTxEnvelope, UnknownTxEnvelope, UnknownTypedTransaction};
+use alloy_rpc_types_eth::{ConversionError, Transaction as AlloyRpcTransaction};
+use alloy_serde::WithOtherFields;
+
+impl TryFrom<UnknownTxEnvelope> for TxDeposit {
+    type Error = ConversionError;
+
+    fn try_from(value: UnknownTxEnvelope) -> Result<Self, Self::Error> {
+        value.inner.try_into()
+    }
+}
+
+impl TryFrom<UnknownTypedTransaction> for TxDeposit {
+    type Error = ConversionError;
+
+    fn try_from(value: UnknownTypedTransaction) -> Result<Self, Self::Error> {
+        if !value.is_type(DEPOSIT_TX_TYPE_ID) {
+            return Err(ConversionError::Custom("invalid transaction type".to_string()));
+        }
+        value
+            .fields
+            .deserialize_into()
+            .map_err(|_| ConversionError::Custom("invalid transaction data".to_string()))
+    }
+}
+
+impl TryFrom<AnyTxEnvelope> for OpTxEnvelope {
+    type Error = AnyTxEnvelope;
+
+    fn try_from(value: AnyTxEnvelope) -> Result<Self, Self::Error> {
+        Self::try_from_any_envelope(value)
+    }
+}
+
+impl TryFrom<AnyRpcTransaction> for OpTxEnvelope {
+    type Error = ConversionError;
+
+    fn try_from(tx: AnyRpcTransaction) -> Result<Self, Self::Error> {
+        let WithOtherFields { inner: AlloyRpcTransaction { inner, .. }, other: _ } = tx.0;
+
+        let from = inner.signer();
+        match inner.into_inner() {
+            AnyTxEnvelope::Ethereum(tx) => Self::try_from_eth_envelope(tx).map_err(|_| {
+                ConversionError::Custom("unable to convert from ethereum type".to_string())
+            }),
+            AnyTxEnvelope::Unknown(mut tx) => {
+                // Re-insert `from` field which was consumed by outer `Transaction`.
+                // Ref hack in op-alloy <https://github.com/alloy-rs/op-alloy/blob/7d50b698631dd73f8d20f9f60ee78cd0597dc278/crates/rpc-types/src/transaction.rs#L236-L237>
+                tx.inner
+                    .fields
+                    .insert_value("from".to_string(), from)
+                    .map_err(|err| ConversionError::Custom(err.to_string()))?;
+                Ok(Self::Deposit(Sealed::new(tx.try_into()?)))
+            }
+        }
+    }
+}

--- a/crates/op/op-alloy-consensus/src/lib.rs
+++ b/crates/op/op-alloy-consensus/src/lib.rs
@@ -1,0 +1,28 @@
+//! Optimism consensus types.
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(feature = "alloy-compat")]
+mod alloy_compat;
+
+mod receipts;
+pub use receipts::{
+    OpDepositReceipt, OpDepositReceiptWithBloom, OpReceipt, OpReceiptEnvelope, OpTxReceipt,
+};
+
+pub mod transaction;
+pub use transaction::{
+    DEPOSIT_TX_TYPE_ID, DepositTransaction, OpTransaction, OpTxEnvelope, OpTxType,
+    OpTypedTransaction, TxDeposit,
+};
+
+pub mod post_exec;
+pub use post_exec::*;
+
+#[cfg(feature = "serde")]
+pub use transaction::serde_deposit_tx_rpc;

--- a/crates/op/op-alloy-consensus/src/post_exec.rs
+++ b/crates/op/op-alloy-consensus/src/post_exec.rs
@@ -1,0 +1,379 @@
+//! Post-execution transaction types.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+#[cfg(feature = "serde")]
+use alloy_consensus::Sealed;
+use alloy_consensus::{Sealable, Transaction, Typed2718, transaction::RlpEcdsaEncodableTx};
+use alloy_eips::{
+    eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718, IsTyped2718},
+    eip2930::AccessList,
+};
+use alloy_primitives::{Address, B256, Bytes, ChainId, TxHash, TxKind, U256, keccak256};
+use alloy_rlp::{BufMut, Decodable, Encodable, Header, RlpDecodable, RlpEncodable};
+
+/// Type byte for the post-execution transaction.
+pub const POST_EXEC_TX_TYPE_ID: u8 = 0x7D;
+
+/// Current format version for [`PostExecPayload`].
+pub const POST_EXEC_PAYLOAD_VERSION: u8 = 1;
+
+/// Per-transaction gas refund entry within a [`PostExecPayload`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct SDMGasEntry {
+    /// Transaction index within the block.
+    pub index: u64,
+    /// Gas refund from post-execution warming settlement.
+    pub gas_refund: u64,
+}
+
+/// Payload for the post-execution transaction.
+///
+/// Today this only carries the SDM gas refund data, but additional post-exec fields may
+/// be added in the future.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct PostExecPayload {
+    /// Format version.
+    pub version: u8,
+    /// L2 block number this synthetic payload is anchored to.
+    pub block_number: u64,
+    /// Initial SDM gas refund entries keyed by transaction index.
+    pub gas_refund_entries: Vec<SDMGasEntry>,
+}
+
+// `version` is pinned rather than left arbitrary because `decode_checked` rejects any
+// non-`POST_EXEC_PAYLOAD_VERSION` value, which would break encode/decode roundtrip
+// property tests (and any downstream fuzzer using arbitrary-generated payloads).
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for PostExecPayload {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            version: POST_EXEC_PAYLOAD_VERSION,
+            block_number: u64::arbitrary(u)?,
+            gas_refund_entries: <Vec<SDMGasEntry>>::arbitrary(u)?,
+        })
+    }
+}
+
+impl PostExecPayload {
+    /// Look up refund for a given tx index.
+    pub fn gas_refund_for_idx(&self, index: u64) -> Option<u64> {
+        self.gas_refund_entries.iter().find(|e| e.index == index).map(|e| e.gas_refund)
+    }
+
+    /// RLP-encode the payload into bytes.
+    pub fn to_rlp_bytes(&self) -> Bytes {
+        let mut buf = Vec::new();
+        self.encode(&mut buf);
+        buf.into()
+    }
+
+    /// Decode a payload from an RLP stream, validating the payload version.
+    ///
+    /// Advances `buf` past the consumed bytes. Unlike [`Self::from_rlp_bytes`], trailing bytes
+    /// are left in place for the caller to consume; this is the decoder to use on the EIP-2718
+    /// path where the envelope already framed the packet exactly.
+    pub fn decode_checked(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let payload = Self::decode(buf)?;
+        if payload.version != POST_EXEC_PAYLOAD_VERSION {
+            return Err(alloy_rlp::Error::Custom("unsupported post-exec payload version"));
+        }
+        Ok(payload)
+    }
+
+    /// Decode a payload from RLP bytes.
+    ///
+    /// Rejects payloads whose `version` is not [`POST_EXEC_PAYLOAD_VERSION`] and rejects any
+    /// trailing bytes after the RLP structure.
+    pub fn from_rlp_bytes(data: &[u8]) -> alloy_rlp::Result<Self> {
+        let mut buf = data;
+        let payload = Self::decode_checked(&mut buf)?;
+        if !buf.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(payload)
+    }
+}
+
+/// Post-execution transaction carrying a [`PostExecPayload`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(into = "PostExecPayload", from = "PostExecPayload"))]
+pub struct TxPostExec {
+    /// Decoded payload.
+    pub payload: PostExecPayload,
+    /// RLP-encoded payload bytes used as the transaction input.
+    pub input: Bytes,
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for TxPostExec {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // Keep `payload` and the cached `input` bytes in sync for fuzzed values.
+        Ok(Self::new(PostExecPayload::arbitrary(u)?))
+    }
+}
+
+impl From<PostExecPayload> for TxPostExec {
+    fn from(payload: PostExecPayload) -> Self {
+        Self::new(payload)
+    }
+}
+
+impl From<TxPostExec> for PostExecPayload {
+    fn from(tx: TxPostExec) -> Self {
+        tx.payload
+    }
+}
+
+impl TxPostExec {
+    /// Construct a post-exec transaction from its decoded payload.
+    pub fn new(payload: PostExecPayload) -> Self {
+        let input = payload.to_rlp_bytes();
+        Self { payload, input }
+    }
+
+    /// Returns the canonical signature for post-exec transactions, which don't include a
+    /// signature.
+    pub const fn signature() -> alloy_primitives::Signature {
+        alloy_primitives::Signature::new(U256::ZERO, U256::ZERO, false)
+    }
+
+    /// Returns the canonical signer address for post-exec transactions.
+    pub const fn signer_address(&self) -> Address {
+        Address::ZERO
+    }
+
+    /// Encoded length of the transaction body.
+    pub fn rlp_encoded_length(&self) -> usize {
+        self.input.len()
+    }
+
+    /// Encoded length including the type byte.
+    pub fn eip2718_encoded_length(&self) -> usize {
+        self.rlp_encoded_length() + 1
+    }
+
+    fn network_header(&self) -> Header {
+        Header { list: false, payload_length: self.eip2718_encoded_length() }
+    }
+
+    /// Encoded length including the outer network RLP header.
+    pub fn network_encoded_length(&self) -> usize {
+        self.network_header().length_with_payload()
+    }
+
+    /// Network encode the transaction.
+    pub fn network_encode(&self, out: &mut dyn BufMut) {
+        self.network_header().encode(out);
+        self.encode_2718(out);
+    }
+
+    /// Calculates a heuristic for the in-memory size of the transaction.
+    pub fn size(&self) -> usize {
+        core::mem::size_of::<PostExecPayload>()
+            + self.input.len()
+            + self.payload.gas_refund_entries.len() * core::mem::size_of::<SDMGasEntry>()
+    }
+
+    /// Calculate the transaction hash.
+    pub fn tx_hash(&self) -> TxHash {
+        let mut buf = Vec::with_capacity(self.eip2718_encoded_length());
+        self.encode_2718(&mut buf);
+        keccak256(&buf)
+    }
+}
+
+impl Typed2718 for TxPostExec {
+    fn ty(&self) -> u8 {
+        POST_EXEC_TX_TYPE_ID
+    }
+}
+
+impl IsTyped2718 for TxPostExec {
+    fn is_type(ty: u8) -> bool {
+        ty == POST_EXEC_TX_TYPE_ID
+    }
+}
+
+impl RlpEcdsaEncodableTx for TxPostExec {
+    fn rlp_encoded_fields_length(&self) -> usize {
+        self.input.len()
+    }
+
+    fn rlp_encode_fields(&self, out: &mut dyn alloy_rlp::BufMut) {
+        // `input` already stores the canonical RLP-encoded payload, so the transaction fields are
+        // written as-is instead of being wrapped in an additional RLP list.
+        out.put_slice(self.input.as_ref());
+    }
+}
+
+impl Transaction for TxPostExec {
+    fn chain_id(&self) -> Option<ChainId> {
+        None
+    }
+    fn nonce(&self) -> u64 {
+        0
+    }
+    fn gas_limit(&self) -> u64 {
+        0
+    }
+    fn gas_price(&self) -> Option<u128> {
+        None
+    }
+    fn max_fee_per_gas(&self) -> u128 {
+        0
+    }
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        None
+    }
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+    fn priority_fee_or_price(&self) -> u128 {
+        0
+    }
+    fn effective_gas_price(&self, _: Option<u64>) -> u128 {
+        0
+    }
+    fn is_dynamic_fee(&self) -> bool {
+        false
+    }
+    fn kind(&self) -> TxKind {
+        // Post-exec transactions do not carry a destination like deposits do, so expose them as a
+        // synthetic zero-address call placeholder.
+        TxKind::Call(Default::default())
+    }
+    fn is_create(&self) -> bool {
+        false
+    }
+    fn value(&self) -> U256 {
+        U256::ZERO
+    }
+    fn input(&self) -> &Bytes {
+        &self.input
+    }
+    fn access_list(&self) -> Option<&AccessList> {
+        None
+    }
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        None
+    }
+    fn authorization_list(&self) -> Option<&[alloy_eips::eip7702::SignedAuthorization]> {
+        None
+    }
+}
+
+impl Encodable2718 for TxPostExec {
+    fn type_flag(&self) -> Option<u8> {
+        Some(POST_EXEC_TX_TYPE_ID)
+    }
+    fn encode_2718_len(&self) -> usize {
+        self.eip2718_encoded_length()
+    }
+    fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
+        out.put_u8(POST_EXEC_TX_TYPE_ID);
+        out.put_slice(self.input.as_ref());
+    }
+}
+
+impl Decodable2718 for TxPostExec {
+    fn typed_decode(ty: u8, data: &mut &[u8]) -> Eip2718Result<Self> {
+        if ty != POST_EXEC_TX_TYPE_ID {
+            return Err(Eip2718Error::UnexpectedType(ty));
+        }
+        Ok(Self::new(PostExecPayload::decode_checked(data)?))
+    }
+
+    fn fallback_decode(data: &mut &[u8]) -> Eip2718Result<Self> {
+        Ok(Self::new(PostExecPayload::decode_checked(data)?))
+    }
+}
+
+impl Encodable for TxPostExec {
+    fn encode(&self, out: &mut dyn BufMut) {
+        out.put_slice(self.input.as_ref());
+    }
+
+    fn length(&self) -> usize {
+        self.rlp_encoded_length()
+    }
+}
+
+impl Decodable for TxPostExec {
+    fn decode(data: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(Self::new(PostExecPayload::decode_checked(data)?))
+    }
+}
+
+impl Sealable for TxPostExec {
+    fn hash_slow(&self) -> B256 {
+        self.tx_hash()
+    }
+}
+
+#[cfg(feature = "alloy-compat")]
+impl From<TxPostExec> for alloy_rpc_types_eth::TransactionRequest {
+    fn from(tx: TxPostExec) -> Self {
+        Self {
+            from: Some(tx.signer_address()),
+            transaction_type: Some(POST_EXEC_TX_TYPE_ID),
+            gas: Some(0),
+            nonce: Some(0),
+            value: Some(U256::ZERO),
+            input: tx.input.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Build a post-execution transaction from a block number and refund entries.
+pub fn build_post_exec_tx(block_number: u64, gas_refund_entries: Vec<SDMGasEntry>) -> TxPostExec {
+    TxPostExec::new(PostExecPayload {
+        version: POST_EXEC_PAYLOAD_VERSION,
+        block_number,
+        gas_refund_entries,
+    })
+}
+
+/// Post-exec transactions serialize as full RPC transaction objects when embedded in a
+/// [`crate::OpTxEnvelope`] response.
+///
+/// Unlike the standalone [`TxPostExec`] serde form, RPC consumers such as op-node expect the
+/// canonical `input` field to be present so the transaction can be decoded by go-ethereum types.
+#[cfg(feature = "serde")]
+pub fn serde_post_exec_tx_rpc<S>(
+    value: &Sealed<TxPostExec>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct SerdeHelper<'a> {
+        hash: B256,
+        #[serde(rename = "type", with = "alloy_serde::quantity")]
+        tx_type: u8,
+        #[serde(with = "alloy_serde::quantity")]
+        gas: u64,
+        value: U256,
+        input: &'a Bytes,
+    }
+
+    SerdeHelper {
+        hash: value.hash(),
+        tx_type: POST_EXEC_TX_TYPE_ID,
+        gas: 0,
+        value: U256::ZERO,
+        input: &value.inner().input,
+    }
+    .serialize(serializer)
+}

--- a/crates/op/op-alloy-consensus/src/receipts/deposit.rs
+++ b/crates/op/op-alloy-consensus/src/receipts/deposit.rs
@@ -1,0 +1,266 @@
+//! Transaction receipt types for Optimism.
+
+use super::OpTxReceipt;
+use crate::transaction::OpDepositInfo;
+use alloy_consensus::{
+    Eip658Value, Receipt, ReceiptWithBloom, RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt,
+};
+use alloy_primitives::{Bloom, Log};
+use alloy_rlp::{Buf, BufMut, Decodable, Encodable, Header};
+
+/// [`OpDepositReceipt`] with calculated bloom filter, modified for the OP Stack.
+///
+/// This convenience type allows us to lazily calculate the bloom filter for a
+/// receipt, similar to [`Sealed`].
+///
+/// [`Sealed`]: alloy_consensus::Sealed
+pub type OpDepositReceiptWithBloom<T = Log> = ReceiptWithBloom<OpDepositReceipt<T>>;
+
+/// Receipt containing result of transaction execution.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct OpDepositReceipt<T = Log> {
+    /// The inner receipt type.
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub inner: Receipt<T>,
+    /// Deposit nonce for Optimism deposit transactions
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
+    pub deposit_nonce: Option<u64>,
+    /// Deposit receipt version for Optimism deposit transactions
+    ///
+    /// The deposit receipt version was introduced in Canyon to indicate an update to how
+    /// receipt hashes should be computed when set. The state transition process
+    /// ensures this is only set for post-Canyon deposit transactions.
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
+    pub deposit_receipt_version: Option<u64>,
+}
+
+impl OpDepositReceipt {
+    /// Calculates [`Log`]'s bloom filter. this is slow operation and [`OpDepositReceiptWithBloom`]
+    /// can be used to cache this value.
+    pub fn bloom_slow(&self) -> Bloom {
+        self.inner.logs.iter().collect()
+    }
+
+    /// Calculates the bloom filter for the receipt and returns the [`OpDepositReceiptWithBloom`]
+    /// container type.
+    pub fn with_bloom(self) -> OpDepositReceiptWithBloom {
+        self.into()
+    }
+}
+
+impl<T> OpDepositReceipt<T> {
+    /// Maps the inner receipt value of this receipt.
+    ///
+    /// This is mainly useful for mapping the receipt log type to the rpc variant.
+    pub fn map_inner<U, F>(self, f: F) -> OpDepositReceipt<U>
+    where
+        F: FnOnce(Receipt<T>) -> Receipt<U>,
+    {
+        OpDepositReceipt {
+            inner: f(self.inner),
+            deposit_nonce: self.deposit_nonce,
+            deposit_receipt_version: self.deposit_receipt_version,
+        }
+    }
+
+    /// Attaches the given bloom to the receipt returning [`ReceiptWithBloom`].
+    pub const fn with_bloom_unchecked(self, bloom: Bloom) -> ReceiptWithBloom<Self> {
+        ReceiptWithBloom::new(self, bloom)
+    }
+
+    /// Consumes the type and returns the inner [`Receipt`].
+    pub fn into_inner(self) -> Receipt<T> {
+        self.inner
+    }
+
+    /// Returns the deposit info for this receipt.
+    pub const fn deposit_info(&self) -> OpDepositInfo {
+        OpDepositInfo {
+            deposit_nonce: self.deposit_nonce,
+            deposit_receipt_version: self.deposit_receipt_version,
+        }
+    }
+
+    /// Converts the receipt's log type by applying a function to each log.
+    ///
+    /// Returns the receipt with the new log type
+    pub fn map_logs<U>(self, f: impl FnMut(T) -> U) -> OpDepositReceipt<U> {
+        self.map_inner(|r| r.map_logs(f))
+    }
+}
+
+impl<T: Encodable> OpDepositReceipt<T> {
+    /// Returns length of RLP-encoded receipt fields with the given [`Bloom`] without an RLP header.
+    pub fn rlp_encoded_fields_length_with_bloom(&self, bloom: &Bloom) -> usize {
+        self.inner.rlp_encoded_fields_length_with_bloom(bloom)
+            + self.deposit_nonce.map_or(0, |nonce| nonce.length())
+            + self.deposit_receipt_version.map_or(0, |version| version.length())
+    }
+
+    /// RLP-encodes receipt fields with the given [`Bloom`] without an RLP header.
+    pub fn rlp_encode_fields_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut) {
+        self.inner.rlp_encode_fields_with_bloom(bloom, out);
+
+        if let Some(nonce) = self.deposit_nonce {
+            nonce.encode(out);
+        }
+        if let Some(version) = self.deposit_receipt_version {
+            version.encode(out);
+        }
+    }
+
+    /// Returns RLP header for this receipt encoding with the given [`Bloom`].
+    pub fn rlp_header_with_bloom(&self, bloom: &Bloom) -> Header {
+        Header { list: true, payload_length: self.rlp_encoded_fields_length_with_bloom(bloom) }
+    }
+}
+
+impl<T: Decodable> OpDepositReceipt<T> {
+    /// RLP-decodes receipt's field with a [`Bloom`].
+    ///
+    /// Does not expect an RLP header.
+    pub fn rlp_decode_fields_with_bloom(
+        buf: &mut &[u8],
+    ) -> alloy_rlp::Result<ReceiptWithBloom<Self>> {
+        let ReceiptWithBloom { receipt: inner, logs_bloom } =
+            Receipt::rlp_decode_fields_with_bloom(buf)?;
+
+        let deposit_nonce = (!buf.is_empty()).then(|| Decodable::decode(buf)).transpose()?;
+        let deposit_receipt_version =
+            (!buf.is_empty()).then(|| Decodable::decode(buf)).transpose()?;
+
+        Ok(ReceiptWithBloom {
+            logs_bloom,
+            receipt: Self { inner, deposit_nonce, deposit_receipt_version },
+        })
+    }
+}
+
+impl<T> AsRef<Receipt<T>> for OpDepositReceipt<T> {
+    fn as_ref(&self) -> &Receipt<T> {
+        &self.inner
+    }
+}
+
+impl<T> From<OpDepositReceipt<T>> for Receipt<T> {
+    fn from(value: OpDepositReceipt<T>) -> Self {
+        value.into_inner()
+    }
+}
+
+impl<T> TxReceipt for OpDepositReceipt<T>
+where
+    T: AsRef<Log> + Clone + core::fmt::Debug + PartialEq + Eq + Send + Sync,
+{
+    type Log = T;
+
+    fn status_or_post_state(&self) -> Eip658Value {
+        self.inner.status_or_post_state()
+    }
+
+    fn status(&self) -> bool {
+        self.inner.status()
+    }
+
+    fn bloom(&self) -> Bloom {
+        self.inner.bloom_slow()
+    }
+
+    fn cumulative_gas_used(&self) -> u64 {
+        self.inner.cumulative_gas_used()
+    }
+
+    fn logs(&self) -> &[Self::Log] {
+        self.inner.logs()
+    }
+}
+
+impl<T: Encodable> RlpEncodableReceipt for OpDepositReceipt<T> {
+    fn rlp_encoded_length_with_bloom(&self, bloom: &Bloom) -> usize {
+        self.rlp_header_with_bloom(bloom).length_with_payload()
+    }
+
+    fn rlp_encode_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut) {
+        self.rlp_header_with_bloom(bloom).encode(out);
+        self.rlp_encode_fields_with_bloom(bloom, out);
+    }
+}
+
+impl<T: Decodable> RlpDecodableReceipt for OpDepositReceipt<T> {
+    fn rlp_decode_with_bloom(buf: &mut &[u8]) -> alloy_rlp::Result<ReceiptWithBloom<Self>> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+
+        if buf.len() < header.payload_length {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+
+        // Note: we pass a separate buffer to `rlp_decode_fields_with_bloom` to allow it decode
+        // optional fields based on the remaining length.
+        let mut fields_buf = &buf[..header.payload_length];
+        let this = Self::rlp_decode_fields_with_bloom(&mut fields_buf)?;
+
+        if !fields_buf.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        buf.advance(header.payload_length);
+
+        Ok(this)
+    }
+}
+
+impl OpTxReceipt for OpDepositReceipt {
+    fn deposit_nonce(&self) -> Option<u64> {
+        self.deposit_nonce
+    }
+
+    fn deposit_receipt_version(&self) -> Option<u64> {
+        self.deposit_receipt_version
+    }
+}
+
+impl<T> From<ReceiptWithBloom<Self>> for OpDepositReceipt<T> {
+    fn from(value: ReceiptWithBloom<Self>) -> Self {
+        value.receipt
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a, T> arbitrary::Arbitrary<'a> for OpDepositReceipt<T>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let deposit_nonce = Option::<u64>::arbitrary(u)?;
+        let deposit_receipt_version =
+            deposit_nonce.is_some().then(|| u64::arbitrary(u)).transpose()?;
+        Ok(Self {
+            inner: Receipt {
+                status: Eip658Value::arbitrary(u)?,
+                cumulative_gas_used: u64::arbitrary(u)?,
+                logs: Vec::<T>::arbitrary(u)?,
+            },
+            deposit_nonce,
+            deposit_receipt_version,
+        })
+    }
+}

--- a/crates/op/op-alloy-consensus/src/receipts/envelope.rs
+++ b/crates/op/op-alloy-consensus/src/receipts/envelope.rs
@@ -1,0 +1,387 @@
+//! Receipt envelope types for Optimism.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use crate::{OpDepositReceipt, OpDepositReceiptWithBloom, OpTxType};
+use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom, TxReceipt};
+use alloy_eips::{
+    Typed2718,
+    eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718, IsTyped2718},
+};
+use alloy_primitives::{Bloom, Log, logs_bloom};
+use alloy_rlp::{BufMut, Decodable, Encodable, length_of_length};
+
+/// Receipt envelope, as defined in [EIP-2718], modified for OP Stack chains.
+///
+/// This enum distinguishes between tagged and untagged legacy receipts, as the
+/// in-protocol merkle tree may commit to EITHER 0-prefixed or raw. Therefore
+/// we must ensure that encoding returns the precise byte-array that was
+/// decoded, preserving the presence or absence of the `TransactionType` flag.
+///
+/// Transaction receipt payloads are specified in their respective EIPs.
+///
+/// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
+pub enum OpReceiptEnvelope<T = Log> {
+    /// Receipt envelope with no type flag.
+    #[cfg_attr(feature = "serde", serde(rename = "0x0", alias = "0x00"))]
+    Legacy(ReceiptWithBloom<Receipt<T>>),
+    /// Receipt envelope with type flag 1, containing a [EIP-2930] receipt.
+    ///
+    /// [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
+    #[cfg_attr(feature = "serde", serde(rename = "0x1", alias = "0x01"))]
+    Eip2930(ReceiptWithBloom<Receipt<T>>),
+    /// Receipt envelope with type flag 2, containing a [EIP-1559] receipt.
+    ///
+    /// [EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
+    #[cfg_attr(feature = "serde", serde(rename = "0x2", alias = "0x02"))]
+    Eip1559(ReceiptWithBloom<Receipt<T>>),
+    /// Receipt envelope with type flag 4, containing a [EIP-7702] receipt.
+    ///
+    /// [EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
+    #[cfg_attr(feature = "serde", serde(rename = "0x4", alias = "0x04"))]
+    Eip7702(ReceiptWithBloom<Receipt<T>>),
+    /// Receipt envelope with type flag 125, containing a synthetic post-exec receipt.
+    #[cfg_attr(feature = "serde", serde(rename = "0x7d", alias = "0x7D"))]
+    PostExec(ReceiptWithBloom<Receipt<T>>),
+    /// Receipt envelope with type flag 126, containing a [deposit] receipt.
+    ///
+    /// [deposit]: https://specs.optimism.io/protocol/deposits.html
+    #[cfg_attr(feature = "serde", serde(rename = "0x7e", alias = "0x7E"))]
+    Deposit(ReceiptWithBloom<OpDepositReceipt<T>>),
+}
+
+impl OpReceiptEnvelope<Log> {
+    /// Creates a new [`OpReceiptEnvelope`] from the given parts.
+    pub fn from_parts<'a>(
+        status: bool,
+        cumulative_gas_used: u64,
+        logs: impl IntoIterator<Item = &'a Log>,
+        tx_type: OpTxType,
+        deposit_nonce: Option<u64>,
+        deposit_receipt_version: Option<u64>,
+    ) -> Self {
+        let logs = logs.into_iter().cloned().collect::<Vec<_>>();
+        let logs_bloom = logs_bloom(&logs);
+        let inner_receipt =
+            Receipt { status: Eip658Value::Eip658(status), cumulative_gas_used, logs };
+        match tx_type {
+            OpTxType::Legacy => {
+                Self::Legacy(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
+            }
+            OpTxType::Eip2930 => {
+                Self::Eip2930(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
+            }
+            OpTxType::Eip1559 => {
+                Self::Eip1559(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
+            }
+            OpTxType::Eip7702 => {
+                Self::Eip7702(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
+            }
+            OpTxType::PostExec => {
+                Self::PostExec(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
+            }
+            OpTxType::Deposit => {
+                let inner = OpDepositReceiptWithBloom {
+                    receipt: OpDepositReceipt {
+                        inner: inner_receipt,
+                        deposit_nonce,
+                        deposit_receipt_version,
+                    },
+                    logs_bloom,
+                };
+                Self::Deposit(inner)
+            }
+        }
+    }
+}
+
+impl<T> OpReceiptEnvelope<T> {
+    /// Return the [`OpTxType`] of the inner receipt.
+    pub const fn tx_type(&self) -> OpTxType {
+        match self {
+            Self::Legacy(_) => OpTxType::Legacy,
+            Self::Eip2930(_) => OpTxType::Eip2930,
+            Self::Eip1559(_) => OpTxType::Eip1559,
+            Self::Eip7702(_) => OpTxType::Eip7702,
+            Self::PostExec(_) => OpTxType::PostExec,
+            Self::Deposit(_) => OpTxType::Deposit,
+        }
+    }
+
+    /// Return true if the transaction was successful.
+    pub const fn is_success(&self) -> bool {
+        self.status()
+    }
+
+    /// Returns the success status of the receipt's transaction.
+    pub const fn status(&self) -> bool {
+        self.as_receipt().unwrap().status.coerce_status()
+    }
+
+    /// Returns the cumulative gas used at this receipt.
+    pub const fn cumulative_gas_used(&self) -> u64 {
+        self.as_receipt().unwrap().cumulative_gas_used
+    }
+
+    /// Converts the receipt's log type by applying a function to each log.
+    ///
+    /// Returns the receipt with the new log type.
+    pub fn map_logs<U>(self, f: impl FnMut(T) -> U) -> OpReceiptEnvelope<U> {
+        match self {
+            Self::Legacy(r) => OpReceiptEnvelope::Legacy(r.map_logs(f)),
+            Self::Eip2930(r) => OpReceiptEnvelope::Eip2930(r.map_logs(f)),
+            Self::Eip1559(r) => OpReceiptEnvelope::Eip1559(r.map_logs(f)),
+            Self::Eip7702(r) => OpReceiptEnvelope::Eip7702(r.map_logs(f)),
+            Self::PostExec(r) => OpReceiptEnvelope::PostExec(r.map_logs(f)),
+            Self::Deposit(r) => OpReceiptEnvelope::Deposit(r.map_receipt(|r| r.map_logs(f))),
+        }
+    }
+
+    /// Return the receipt logs.
+    pub fn logs(&self) -> &[T] {
+        &self.as_receipt().unwrap().logs
+    }
+
+    /// Consumes the type and returns the logs.
+    pub fn into_logs(self) -> Vec<T> {
+        self.into_receipt().logs
+    }
+
+    /// Return the receipt's bloom.
+    pub const fn logs_bloom(&self) -> &Bloom {
+        match self {
+            Self::Legacy(t)
+            | Self::Eip2930(t)
+            | Self::Eip1559(t)
+            | Self::Eip7702(t)
+            | Self::PostExec(t) => &t.logs_bloom,
+            Self::Deposit(t) => &t.logs_bloom,
+        }
+    }
+
+    /// Return the receipt's `deposit_nonce` if it is a deposit receipt.
+    pub fn deposit_nonce(&self) -> Option<u64> {
+        self.as_deposit_receipt().and_then(|r| r.deposit_nonce)
+    }
+
+    /// Return the receipt's deposit version if it is a deposit receipt.
+    pub fn deposit_receipt_version(&self) -> Option<u64> {
+        self.as_deposit_receipt().and_then(|r| r.deposit_receipt_version)
+    }
+
+    /// Returns the deposit receipt if it is a deposit receipt.
+    pub const fn as_deposit_receipt_with_bloom(&self) -> Option<&OpDepositReceiptWithBloom<T>> {
+        match self {
+            Self::Deposit(t) => Some(t),
+            _ => None,
+        }
+    }
+
+    /// Returns the deposit receipt if it is a deposit receipt.
+    pub const fn as_deposit_receipt(&self) -> Option<&OpDepositReceipt<T>> {
+        match self {
+            Self::Deposit(t) => Some(&t.receipt),
+            _ => None,
+        }
+    }
+
+    /// Consumes the type and returns the underlying [`Receipt`].
+    pub fn into_receipt(self) -> Receipt<T> {
+        match self {
+            Self::Legacy(t)
+            | Self::Eip2930(t)
+            | Self::Eip1559(t)
+            | Self::Eip7702(t)
+            | Self::PostExec(t) => t.receipt,
+            Self::Deposit(t) => t.receipt.into_inner(),
+        }
+    }
+
+    /// Return the inner receipt. Currently this is infallible, however, future
+    /// receipt types may be added.
+    pub const fn as_receipt(&self) -> Option<&Receipt<T>> {
+        match self {
+            Self::Legacy(t)
+            | Self::Eip2930(t)
+            | Self::Eip1559(t)
+            | Self::Eip7702(t)
+            | Self::PostExec(t) => Some(&t.receipt),
+            Self::Deposit(t) => Some(&t.receipt.inner),
+        }
+    }
+}
+
+impl OpReceiptEnvelope {
+    /// Get the length of the inner receipt in the 2718 encoding.
+    pub fn inner_length(&self) -> usize {
+        match self {
+            Self::Legacy(t)
+            | Self::Eip2930(t)
+            | Self::Eip1559(t)
+            | Self::Eip7702(t)
+            | Self::PostExec(t) => t.length(),
+            Self::Deposit(t) => t.length(),
+        }
+    }
+
+    /// Calculate the length of the rlp payload of the network encoded receipt.
+    pub fn rlp_payload_length(&self) -> usize {
+        let length = self.inner_length();
+        match self {
+            Self::Legacy(_) => length,
+            _ => length + 1,
+        }
+    }
+}
+
+impl<T> TxReceipt for OpReceiptEnvelope<T>
+where
+    T: Clone + core::fmt::Debug + PartialEq + Eq + Send + Sync,
+{
+    type Log = T;
+
+    fn status_or_post_state(&self) -> Eip658Value {
+        self.as_receipt().unwrap().status
+    }
+
+    fn status(&self) -> bool {
+        self.as_receipt().unwrap().status.coerce_status()
+    }
+
+    /// Return the receipt's bloom.
+    fn bloom(&self) -> Bloom {
+        *self.logs_bloom()
+    }
+
+    fn bloom_cheap(&self) -> Option<Bloom> {
+        Some(self.bloom())
+    }
+
+    /// Returns the cumulative gas used at this receipt.
+    fn cumulative_gas_used(&self) -> u64 {
+        self.as_receipt().unwrap().cumulative_gas_used
+    }
+
+    /// Return the receipt logs.
+    fn logs(&self) -> &[T] {
+        &self.as_receipt().unwrap().logs
+    }
+}
+
+impl Encodable for OpReceiptEnvelope {
+    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        self.network_encode(out)
+    }
+
+    fn length(&self) -> usize {
+        let mut payload_length = self.rlp_payload_length();
+        if !self.is_legacy() {
+            payload_length += length_of_length(payload_length);
+        }
+        payload_length
+    }
+}
+
+impl Decodable for OpReceiptEnvelope {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Self::network_decode(buf)
+            .map_or_else(|_| Err(alloy_rlp::Error::Custom("Unexpected type")), Ok)
+    }
+}
+
+impl Typed2718 for OpReceiptEnvelope {
+    fn ty(&self) -> u8 {
+        let ty = match self {
+            Self::Legacy(_) => OpTxType::Legacy,
+            Self::Eip2930(_) => OpTxType::Eip2930,
+            Self::Eip1559(_) => OpTxType::Eip1559,
+            Self::Eip7702(_) => OpTxType::Eip7702,
+            Self::PostExec(_) => OpTxType::PostExec,
+            Self::Deposit(_) => OpTxType::Deposit,
+        };
+        ty as u8
+    }
+}
+
+impl IsTyped2718 for OpReceiptEnvelope {
+    fn is_type(type_id: u8) -> bool {
+        <OpTxType as IsTyped2718>::is_type(type_id)
+    }
+}
+
+impl Encodable2718 for OpReceiptEnvelope {
+    fn encode_2718_len(&self) -> usize {
+        self.inner_length() + !self.is_legacy() as usize
+    }
+
+    fn encode_2718(&self, out: &mut dyn BufMut) {
+        match self.type_flag() {
+            None => {}
+            Some(ty) => out.put_u8(ty),
+        }
+        match self {
+            Self::Deposit(t) => t.encode(out),
+            Self::Legacy(t)
+            | Self::Eip2930(t)
+            | Self::Eip1559(t)
+            | Self::Eip7702(t)
+            | Self::PostExec(t) => t.encode(out),
+        }
+    }
+}
+
+impl Decodable2718 for OpReceiptEnvelope {
+    fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
+        match ty.try_into().map_err(|_| Eip2718Error::UnexpectedType(ty))? {
+            OpTxType::Legacy => {
+                Err(alloy_rlp::Error::Custom("type-0 eip2718 transactions are not supported")
+                    .into())
+            }
+            OpTxType::Eip1559 => Ok(Self::Eip1559(Decodable::decode(buf)?)),
+            OpTxType::Eip7702 => Ok(Self::Eip7702(Decodable::decode(buf)?)),
+            OpTxType::Eip2930 => Ok(Self::Eip2930(Decodable::decode(buf)?)),
+            OpTxType::PostExec => Ok(Self::PostExec(Decodable::decode(buf)?)),
+            OpTxType::Deposit => Ok(Self::Deposit(Decodable::decode(buf)?)),
+        }
+    }
+
+    fn fallback_decode(buf: &mut &[u8]) -> Eip2718Result<Self> {
+        Ok(Self::Legacy(Decodable::decode(buf)?))
+    }
+}
+
+impl<T> From<T> for OpReceiptEnvelope<T>
+where
+    T: Into<ReceiptWithBloom<OpDepositReceipt<T>>>,
+{
+    fn from(value: T) -> Self {
+        Self::Deposit(value.into())
+    }
+}
+
+impl<T> From<OpReceiptEnvelope<T>> for Receipt<T> {
+    fn from(receipt: OpReceiptEnvelope<T>) -> Self {
+        receipt.into_receipt()
+    }
+}
+
+#[cfg(all(test, feature = "arbitrary"))]
+impl<'a, T> arbitrary::Arbitrary<'a> for OpReceiptEnvelope<T>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        match u.int_in_range(0..=5)? {
+            0 => Ok(Self::Legacy(ReceiptWithBloom::arbitrary(u)?)),
+            1 => Ok(Self::Eip2930(ReceiptWithBloom::arbitrary(u)?)),
+            2 => Ok(Self::Eip1559(ReceiptWithBloom::arbitrary(u)?)),
+            3 => Ok(Self::Eip7702(ReceiptWithBloom::arbitrary(u)?)),
+            4 => Ok(Self::PostExec(ReceiptWithBloom::arbitrary(u)?)),
+            _ => Ok(Self::Deposit(OpDepositReceiptWithBloom::arbitrary(u)?)),
+        }
+    }
+}

--- a/crates/op/op-alloy-consensus/src/receipts/mod.rs
+++ b/crates/op/op-alloy-consensus/src/receipts/mod.rs
@@ -1,0 +1,21 @@
+//! Receipt types for Optimism.
+
+use alloy_consensus::TxReceipt;
+
+mod envelope;
+pub use envelope::OpReceiptEnvelope;
+
+pub(crate) mod deposit;
+pub use deposit::{OpDepositReceipt, OpDepositReceiptWithBloom};
+
+pub(crate) mod receipt;
+pub use receipt::OpReceipt;
+
+/// Receipt is the result of a transaction execution.
+pub trait OpTxReceipt: TxReceipt {
+    /// Returns the deposit nonce of the transaction.
+    fn deposit_nonce(&self) -> Option<u64>;
+
+    /// Returns the deposit receipt version of the transaction.
+    fn deposit_receipt_version(&self) -> Option<u64>;
+}

--- a/crates/op/op-alloy-consensus/src/receipts/receipt.rs
+++ b/crates/op/op-alloy-consensus/src/receipts/receipt.rs
@@ -1,0 +1,491 @@
+//! Optimism receipt type for execution and storage.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use core::fmt::Debug;
+
+use super::{OpDepositReceipt, OpTxReceipt};
+use crate::{OpReceiptEnvelope, OpTxType};
+use alloy_consensus::{
+    Eip658Value, Eip2718DecodableReceipt, Eip2718EncodableReceipt, Receipt, ReceiptWithBloom,
+    RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt, Typed2718,
+};
+use alloy_eips::eip2718::{Eip2718Error, Eip2718Result, IsTyped2718};
+use alloy_primitives::{Bloom, Log};
+use alloy_rlp::{Buf, BufMut, Decodable, Encodable, Header};
+
+/// Typed Optimism transaction receipt.
+///
+/// Receipt containing result of transaction execution.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
+pub enum OpReceipt<T = Log> {
+    /// Legacy receipt
+    #[cfg_attr(feature = "serde", serde(rename = "0x0", alias = "0x00"))]
+    Legacy(Receipt<T>),
+    /// EIP-2930 receipt
+    #[cfg_attr(feature = "serde", serde(rename = "0x1", alias = "0x01"))]
+    Eip2930(Receipt<T>),
+    /// EIP-1559 receipt
+    #[cfg_attr(feature = "serde", serde(rename = "0x2", alias = "0x02"))]
+    Eip1559(Receipt<T>),
+    /// EIP-7702 receipt
+    #[cfg_attr(feature = "serde", serde(rename = "0x4", alias = "0x04"))]
+    Eip7702(Receipt<T>),
+    /// Post-exec receipt
+    #[cfg_attr(feature = "serde", serde(rename = "0x7d", alias = "0x7D"))]
+    PostExec(Receipt<T>),
+    /// Deposit receipt
+    #[cfg_attr(feature = "serde", serde(rename = "0x7e", alias = "0x7E"))]
+    Deposit(OpDepositReceipt<T>),
+}
+
+impl<T> OpReceipt<T> {
+    /// Returns [`OpTxType`] of the receipt.
+    pub const fn tx_type(&self) -> OpTxType {
+        match self {
+            Self::Legacy(_) => OpTxType::Legacy,
+            Self::Eip2930(_) => OpTxType::Eip2930,
+            Self::Eip1559(_) => OpTxType::Eip1559,
+            Self::Eip7702(_) => OpTxType::Eip7702,
+            Self::PostExec(_) => OpTxType::PostExec,
+            Self::Deposit(_) => OpTxType::Deposit,
+        }
+    }
+
+    /// Returns inner [`Receipt`].
+    pub const fn as_receipt(&self) -> &Receipt<T> {
+        match self {
+            Self::Legacy(receipt)
+            | Self::Eip2930(receipt)
+            | Self::Eip1559(receipt)
+            | Self::Eip7702(receipt)
+            | Self::PostExec(receipt) => receipt,
+            Self::Deposit(receipt) => &receipt.inner,
+        }
+    }
+
+    /// Returns a mutable reference to the inner [`Receipt`].
+    pub const fn as_receipt_mut(&mut self) -> &mut Receipt<T> {
+        match self {
+            Self::Legacy(receipt)
+            | Self::Eip2930(receipt)
+            | Self::Eip1559(receipt)
+            | Self::Eip7702(receipt)
+            | Self::PostExec(receipt) => receipt,
+            Self::Deposit(receipt) => &mut receipt.inner,
+        }
+    }
+
+    /// Consumes this and returns the inner [`Receipt`].
+    pub fn into_receipt(self) -> Receipt<T> {
+        match self {
+            Self::Legacy(receipt)
+            | Self::Eip2930(receipt)
+            | Self::Eip1559(receipt)
+            | Self::Eip7702(receipt)
+            | Self::PostExec(receipt) => receipt,
+            Self::Deposit(receipt) => receipt.inner,
+        }
+    }
+
+    /// Converts the receipt's log type by applying a function to each log.
+    ///
+    /// Returns the receipt with the new log type
+    pub fn map_logs<U>(self, f: impl FnMut(T) -> U) -> OpReceipt<U> {
+        match self {
+            Self::Legacy(receipt) => OpReceipt::Legacy(receipt.map_logs(f)),
+            Self::Eip2930(receipt) => OpReceipt::Eip2930(receipt.map_logs(f)),
+            Self::Eip1559(receipt) => OpReceipt::Eip1559(receipt.map_logs(f)),
+            Self::Eip7702(receipt) => OpReceipt::Eip7702(receipt.map_logs(f)),
+            Self::PostExec(receipt) => OpReceipt::PostExec(receipt.map_logs(f)),
+            Self::Deposit(receipt) => OpReceipt::Deposit(receipt.map_logs(f)),
+        }
+    }
+
+    /// Returns length of RLP-encoded receipt fields with the given [`Bloom`] without an RLP header.
+    pub fn rlp_encoded_fields_length(&self, bloom: &Bloom) -> usize
+    where
+        T: Encodable,
+    {
+        match self {
+            Self::Legacy(receipt)
+            | Self::Eip2930(receipt)
+            | Self::Eip1559(receipt)
+            | Self::Eip7702(receipt)
+            | Self::PostExec(receipt) => receipt.rlp_encoded_fields_length_with_bloom(bloom),
+            Self::Deposit(receipt) => receipt.rlp_encoded_fields_length_with_bloom(bloom),
+        }
+    }
+
+    /// RLP-encodes receipt fields with the given [`Bloom`] without an RLP header.
+    pub fn rlp_encode_fields(&self, bloom: &Bloom, out: &mut dyn BufMut)
+    where
+        T: Encodable,
+    {
+        match self {
+            Self::Legacy(receipt)
+            | Self::Eip2930(receipt)
+            | Self::Eip1559(receipt)
+            | Self::Eip7702(receipt)
+            | Self::PostExec(receipt) => receipt.rlp_encode_fields_with_bloom(bloom, out),
+            Self::Deposit(receipt) => receipt.rlp_encode_fields_with_bloom(bloom, out),
+        }
+    }
+
+    /// Returns RLP header for inner encoding.
+    pub fn rlp_header_inner(&self, bloom: &Bloom) -> Header
+    where
+        T: Encodable,
+    {
+        Header { list: true, payload_length: self.rlp_encoded_fields_length(bloom) }
+    }
+
+    /// Returns RLP header for inner encoding without bloom.
+    pub fn rlp_header_without_bloom(&self) -> Header
+    where
+        T: Encodable,
+    {
+        Header { list: true, payload_length: self.rlp_encoded_fields_length_without_bloom() }
+    }
+
+    /// RLP-decodes the receipt from the provided buffer. This does not expect a type byte or
+    /// network header.
+    pub fn rlp_decode_inner(
+        buf: &mut &[u8],
+        tx_type: OpTxType,
+    ) -> alloy_rlp::Result<ReceiptWithBloom<Self>>
+    where
+        T: Decodable,
+    {
+        match tx_type {
+            OpTxType::Legacy => {
+                let ReceiptWithBloom { receipt, logs_bloom } =
+                    RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
+                Ok(ReceiptWithBloom { receipt: Self::Legacy(receipt), logs_bloom })
+            }
+            OpTxType::Eip2930 => {
+                let ReceiptWithBloom { receipt, logs_bloom } =
+                    RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
+                Ok(ReceiptWithBloom { receipt: Self::Eip2930(receipt), logs_bloom })
+            }
+            OpTxType::Eip1559 => {
+                let ReceiptWithBloom { receipt, logs_bloom } =
+                    RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
+                Ok(ReceiptWithBloom { receipt: Self::Eip1559(receipt), logs_bloom })
+            }
+            OpTxType::Eip7702 => {
+                let ReceiptWithBloom { receipt, logs_bloom } =
+                    RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
+                Ok(ReceiptWithBloom { receipt: Self::Eip7702(receipt), logs_bloom })
+            }
+            OpTxType::PostExec => {
+                let ReceiptWithBloom { receipt, logs_bloom } =
+                    RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
+                Ok(ReceiptWithBloom { receipt: Self::PostExec(receipt), logs_bloom })
+            }
+            OpTxType::Deposit => {
+                let ReceiptWithBloom { receipt, logs_bloom } =
+                    RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
+                Ok(ReceiptWithBloom { receipt: Self::Deposit(receipt), logs_bloom })
+            }
+        }
+    }
+
+    /// RLP-encodes receipt fields without an RLP header.
+    pub fn rlp_encode_fields_without_bloom(&self, out: &mut dyn BufMut)
+    where
+        T: Encodable,
+    {
+        self.tx_type().encode(out);
+        match self {
+            Self::Legacy(receipt)
+            | Self::Eip2930(receipt)
+            | Self::Eip1559(receipt)
+            | Self::Eip7702(receipt)
+            | Self::PostExec(receipt) => {
+                receipt.status.encode(out);
+                receipt.cumulative_gas_used.encode(out);
+                receipt.logs.encode(out);
+            }
+            Self::Deposit(receipt) => {
+                receipt.inner.status.encode(out);
+                receipt.inner.cumulative_gas_used.encode(out);
+                receipt.inner.logs.encode(out);
+                if let Some(nonce) = receipt.deposit_nonce {
+                    nonce.encode(out);
+                }
+                if let Some(version) = receipt.deposit_receipt_version {
+                    version.encode(out);
+                }
+            }
+        }
+    }
+
+    /// Returns length of RLP-encoded receipt fields without an RLP header.
+    pub fn rlp_encoded_fields_length_without_bloom(&self) -> usize
+    where
+        T: Encodable,
+    {
+        self.tx_type().length()
+            + match self {
+                Self::Legacy(receipt)
+                | Self::Eip2930(receipt)
+                | Self::Eip1559(receipt)
+                | Self::Eip7702(receipt)
+                | Self::PostExec(receipt) => {
+                    receipt.status.length()
+                        + receipt.cumulative_gas_used.length()
+                        + receipt.logs.length()
+                }
+                Self::Deposit(receipt) => {
+                    receipt.inner.status.length()
+                        + receipt.inner.cumulative_gas_used.length()
+                        + receipt.inner.logs.length()
+                        + receipt.deposit_nonce.map_or(0, |nonce| nonce.length())
+                        + receipt.deposit_receipt_version.map_or(0, |version| version.length())
+                }
+            }
+    }
+
+    /// RLP-decodes the receipt from the provided buffer without bloom.
+    pub fn rlp_decode_fields_without_bloom(buf: &mut &[u8]) -> alloy_rlp::Result<Self>
+    where
+        T: Decodable,
+    {
+        let tx_type = OpTxType::decode(buf)?;
+        let status = Decodable::decode(buf)?;
+        let cumulative_gas_used = Decodable::decode(buf)?;
+        let logs = Decodable::decode(buf)?;
+
+        let mut deposit_nonce = None;
+        let mut deposit_receipt_version = None;
+
+        // For deposit receipts, try to decode nonce and version if they exist
+        if tx_type == OpTxType::Deposit && !buf.is_empty() {
+            deposit_nonce = Some(Decodable::decode(buf)?);
+            if !buf.is_empty() {
+                deposit_receipt_version = Some(Decodable::decode(buf)?);
+            }
+        }
+
+        match tx_type {
+            OpTxType::Legacy => Ok(Self::Legacy(Receipt { status, cumulative_gas_used, logs })),
+            OpTxType::Eip2930 => Ok(Self::Eip2930(Receipt { status, cumulative_gas_used, logs })),
+            OpTxType::Eip1559 => Ok(Self::Eip1559(Receipt { status, cumulative_gas_used, logs })),
+            OpTxType::Eip7702 => Ok(Self::Eip7702(Receipt { status, cumulative_gas_used, logs })),
+            OpTxType::PostExec => Ok(Self::PostExec(Receipt { status, cumulative_gas_used, logs })),
+            OpTxType::Deposit => Ok(Self::Deposit(OpDepositReceipt {
+                inner: Receipt { status, cumulative_gas_used, logs },
+                deposit_nonce,
+                deposit_receipt_version,
+            })),
+        }
+    }
+}
+
+impl<T: Encodable> Eip2718EncodableReceipt for OpReceipt<T> {
+    fn eip2718_encoded_length_with_bloom(&self, bloom: &Bloom) -> usize {
+        !self.tx_type().is_legacy() as usize + self.rlp_header_inner(bloom).length_with_payload()
+    }
+
+    fn eip2718_encode_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut) {
+        if !self.tx_type().is_legacy() {
+            out.put_u8(self.tx_type() as u8);
+        }
+        self.rlp_header_inner(bloom).encode(out);
+        self.rlp_encode_fields(bloom, out);
+    }
+}
+
+impl<T: Decodable> Eip2718DecodableReceipt for OpReceipt<T> {
+    fn typed_decode_with_bloom(ty: u8, buf: &mut &[u8]) -> Eip2718Result<ReceiptWithBloom<Self>> {
+        let tx_type = OpTxType::try_from(ty).map_err(|_| Eip2718Error::UnexpectedType(ty))?;
+        Ok(Self::rlp_decode_inner(buf, tx_type)?)
+    }
+
+    fn fallback_decode_with_bloom(buf: &mut &[u8]) -> Eip2718Result<ReceiptWithBloom<Self>> {
+        Ok(Self::rlp_decode_inner(buf, OpTxType::Legacy)?)
+    }
+}
+
+impl<T: Encodable> RlpEncodableReceipt for OpReceipt<T> {
+    fn rlp_encoded_length_with_bloom(&self, bloom: &Bloom) -> usize {
+        let mut len = self.eip2718_encoded_length_with_bloom(bloom);
+        if !self.tx_type().is_legacy() {
+            len += Header {
+                list: false,
+                payload_length: self.eip2718_encoded_length_with_bloom(bloom),
+            }
+            .length();
+        }
+
+        len
+    }
+
+    fn rlp_encode_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut) {
+        if !self.tx_type().is_legacy() {
+            Header { list: false, payload_length: self.eip2718_encoded_length_with_bloom(bloom) }
+                .encode(out);
+        }
+        self.eip2718_encode_with_bloom(bloom, out);
+    }
+}
+
+impl<T: Decodable> RlpDecodableReceipt for OpReceipt<T> {
+    fn rlp_decode_with_bloom(buf: &mut &[u8]) -> alloy_rlp::Result<ReceiptWithBloom<Self>> {
+        let header_buf = &mut &**buf;
+        let header = Header::decode(header_buf)?;
+
+        // Legacy receipt, reuse initial buffer without advancing
+        if header.list {
+            return Self::rlp_decode_inner(buf, OpTxType::Legacy);
+        }
+
+        // Otherwise, advance the buffer and try decoding type flag followed by receipt
+        *buf = *header_buf;
+
+        let remaining = buf.len();
+        let tx_type = OpTxType::decode(buf)?;
+        let this = Self::rlp_decode_inner(buf, tx_type)?;
+
+        if buf.len() + header.payload_length != remaining {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        Ok(this)
+    }
+}
+
+impl<T: Encodable + Send + Sync> Encodable for OpReceipt<T> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.rlp_header_without_bloom().encode(out);
+        self.rlp_encode_fields_without_bloom(out);
+    }
+
+    fn length(&self) -> usize {
+        self.rlp_header_without_bloom().length_with_payload()
+    }
+}
+
+impl<T: Decodable> Decodable for OpReceipt<T> {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+
+        if buf.len() < header.payload_length {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+        let mut fields_buf = &buf[..header.payload_length];
+        let this = Self::rlp_decode_fields_without_bloom(&mut fields_buf)?;
+
+        if !fields_buf.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        buf.advance(header.payload_length);
+
+        Ok(this)
+    }
+}
+
+impl<T: Send + Sync + Clone + Debug + Eq + AsRef<Log>> TxReceipt for OpReceipt<T> {
+    type Log = T;
+
+    fn status_or_post_state(&self) -> Eip658Value {
+        self.as_receipt().status_or_post_state()
+    }
+
+    fn status(&self) -> bool {
+        self.as_receipt().status()
+    }
+
+    fn bloom(&self) -> Bloom {
+        self.as_receipt().bloom()
+    }
+
+    fn cumulative_gas_used(&self) -> u64 {
+        self.as_receipt().cumulative_gas_used()
+    }
+
+    fn logs(&self) -> &[Self::Log] {
+        self.as_receipt().logs()
+    }
+
+    fn into_logs(self) -> Vec<Self::Log> {
+        match self {
+            Self::Legacy(receipt)
+            | Self::Eip2930(receipt)
+            | Self::Eip1559(receipt)
+            | Self::Eip7702(receipt)
+            | Self::PostExec(receipt) => receipt.logs,
+            Self::Deposit(receipt) => receipt.inner.logs,
+        }
+    }
+}
+
+impl<T> Typed2718 for OpReceipt<T> {
+    fn ty(&self) -> u8 {
+        self.tx_type().into()
+    }
+}
+
+impl<T> IsTyped2718 for OpReceipt<T> {
+    fn is_type(type_id: u8) -> bool {
+        <OpTxType as IsTyped2718>::is_type(type_id)
+    }
+}
+
+impl<T: Send + Sync + Clone + Debug + Eq + AsRef<Log>> OpTxReceipt for OpReceipt<T> {
+    fn deposit_nonce(&self) -> Option<u64> {
+        match self {
+            Self::Deposit(receipt) => receipt.deposit_nonce,
+            _ => None,
+        }
+    }
+
+    fn deposit_receipt_version(&self) -> Option<u64> {
+        match self {
+            Self::Deposit(receipt) => receipt.deposit_receipt_version,
+            _ => None,
+        }
+    }
+}
+
+impl From<super::OpReceiptEnvelope> for OpReceipt {
+    fn from(envelope: super::OpReceiptEnvelope) -> Self {
+        match envelope {
+            super::OpReceiptEnvelope::Legacy(receipt) => Self::Legacy(receipt.receipt),
+            super::OpReceiptEnvelope::Eip2930(receipt) => Self::Eip2930(receipt.receipt),
+            super::OpReceiptEnvelope::Eip1559(receipt) => Self::Eip1559(receipt.receipt),
+            super::OpReceiptEnvelope::Eip7702(receipt) => Self::Eip7702(receipt.receipt),
+            super::OpReceiptEnvelope::PostExec(receipt) => Self::PostExec(receipt.receipt),
+            super::OpReceiptEnvelope::Deposit(receipt) => Self::Deposit(OpDepositReceipt {
+                deposit_nonce: receipt.receipt.deposit_nonce,
+                deposit_receipt_version: receipt.receipt.deposit_receipt_version,
+                inner: receipt.receipt.inner,
+            }),
+        }
+    }
+}
+
+impl<T> From<ReceiptWithBloom<OpReceipt<T>>> for OpReceiptEnvelope<T> {
+    fn from(value: ReceiptWithBloom<OpReceipt<T>>) -> Self {
+        let (receipt, logs_bloom) = value.into_components();
+        match receipt {
+            OpReceipt::Legacy(receipt) => Self::Legacy(ReceiptWithBloom { receipt, logs_bloom }),
+            OpReceipt::Eip2930(receipt) => Self::Eip2930(ReceiptWithBloom { receipt, logs_bloom }),
+            OpReceipt::Eip1559(receipt) => Self::Eip1559(ReceiptWithBloom { receipt, logs_bloom }),
+            OpReceipt::Eip7702(receipt) => Self::Eip7702(ReceiptWithBloom { receipt, logs_bloom }),
+            OpReceipt::PostExec(receipt) => {
+                Self::PostExec(ReceiptWithBloom { receipt, logs_bloom })
+            }
+            OpReceipt::Deposit(receipt) => Self::Deposit(ReceiptWithBloom { receipt, logs_bloom }),
+        }
+    }
+}

--- a/crates/op/op-alloy-consensus/src/transaction/deposit.rs
+++ b/crates/op/op-alloy-consensus/src/transaction/deposit.rs
@@ -1,0 +1,419 @@
+//! Deposit Transaction type.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use super::OpTxType;
+use alloy_consensus::{Sealable, Transaction, Typed2718};
+use alloy_eips::{
+    eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718, IsTyped2718},
+    eip2930::AccessList,
+};
+use alloy_primitives::{Address, B256, Bytes, ChainId, Signature, TxHash, TxKind, U256, keccak256};
+use alloy_rlp::{BufMut, Decodable, Encodable, Header};
+use core::mem;
+
+/// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct TxDeposit {
+    /// Hash that uniquely identifies the source of the deposit.
+    pub source_hash: B256,
+    /// The address of the sender account.
+    pub from: Address,
+    /// The address of the recipient account, or the null (zero-length) address if the deposited
+    /// transaction is a contract creation.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "TxKind::is_create"))]
+    pub to: TxKind,
+    /// The ETH value to mint on L2.
+    #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity"))]
+    pub mint: u128,
+    ///  The ETH value to send to the recipient account.
+    pub value: U256,
+    /// The gas limit for the L2 transaction.
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", rename = "gas"))]
+    pub gas_limit: u64,
+    /// Field indicating if this transaction is exempt from the L2 gas limit.
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            with = "alloy_serde::quantity",
+            rename = "isSystemTx",
+            skip_serializing_if = "core::ops::Not::not"
+        )
+    )]
+    pub is_system_transaction: bool,
+    /// Input has two uses depending if transaction is Create or Call (if `to` field is None or
+    /// Some).
+    pub input: Bytes,
+}
+
+impl TxDeposit {
+    /// Decodes the inner [`TxDeposit`] fields from RLP bytes.
+    ///
+    /// NOTE: This assumes a RLP header has already been decoded, and _just_ decodes the following
+    /// RLP fields in the following order:
+    ///
+    /// - `source_hash`
+    /// - `from`
+    /// - `to`
+    /// - `mint`
+    /// - `value`
+    /// - `gas_limit`
+    /// - `is_system_transaction`
+    /// - `input`
+    pub fn rlp_decode_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(Self {
+            source_hash: Decodable::decode(buf)?,
+            from: Decodable::decode(buf)?,
+            to: Decodable::decode(buf)?,
+            mint: Decodable::decode(buf)?,
+            value: Decodable::decode(buf)?,
+            gas_limit: Decodable::decode(buf)?,
+            is_system_transaction: Decodable::decode(buf)?,
+            input: Decodable::decode(buf)?,
+        })
+    }
+
+    /// Decodes the transaction from RLP bytes.
+    pub fn rlp_decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let remaining = buf.len();
+
+        if header.payload_length > remaining {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+
+        let this = Self::rlp_decode_fields(buf)?;
+
+        if buf.len() + header.payload_length != remaining {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        Ok(this)
+    }
+
+    /// Outputs the length of the transaction's fields, without a RLP header or length of the
+    /// eip155 fields.
+    pub(crate) fn rlp_encoded_fields_length(&self) -> usize {
+        self.source_hash.length()
+            + self.from.length()
+            + self.to.length()
+            + self.mint.length()
+            + self.value.length()
+            + self.gas_limit.length()
+            + self.is_system_transaction.length()
+            + self.input.0.length()
+    }
+
+    /// Encodes only the transaction's fields into the desired buffer, without a RLP header.
+    /// <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md#the-deposited-transaction-type>
+    pub(crate) fn rlp_encode_fields(&self, out: &mut dyn alloy_rlp::BufMut) {
+        self.source_hash.encode(out);
+        self.from.encode(out);
+        self.to.encode(out);
+        self.mint.encode(out);
+        self.value.encode(out);
+        self.gas_limit.encode(out);
+        self.is_system_transaction.encode(out);
+        self.input.encode(out);
+    }
+
+    /// Calculates a heuristic for the in-memory size of the [`TxDeposit`] transaction.
+    #[inline]
+    pub fn size(&self) -> usize {
+        mem::size_of::<B256>() + // source_hash
+        mem::size_of::<Address>() + // from
+        self.to.size() + // to
+        mem::size_of::<u128>() + // mint
+        mem::size_of::<U256>() + // value
+        mem::size_of::<u128>() + // gas_limit
+        mem::size_of::<bool>() + // is_system_transaction
+        self.input.len() // input
+    }
+
+    /// Get the transaction type
+    pub(crate) const fn tx_type(&self) -> OpTxType {
+        OpTxType::Deposit
+    }
+
+    /// Create an rlp header for the transaction.
+    fn rlp_header(&self) -> Header {
+        Header { list: true, payload_length: self.rlp_encoded_fields_length() }
+    }
+
+    /// RLP encodes the transaction.
+    pub fn rlp_encode(&self, out: &mut dyn BufMut) {
+        self.rlp_header().encode(out);
+        self.rlp_encode_fields(out);
+    }
+
+    /// Get the length of the transaction when RLP encoded.
+    pub fn rlp_encoded_length(&self) -> usize {
+        self.rlp_header().length_with_payload()
+    }
+
+    /// Get the length of the transaction when EIP-2718 encoded. This is the
+    /// 1 byte type flag + the length of the RLP encoded transaction.
+    pub fn eip2718_encoded_length(&self) -> usize {
+        self.rlp_encoded_length() + 1
+    }
+
+    fn network_header(&self) -> Header {
+        Header { list: false, payload_length: self.eip2718_encoded_length() }
+    }
+
+    /// Get the length of the transaction when network encoded. This is the
+    /// EIP-2718 encoded length with an outer RLP header.
+    pub fn network_encoded_length(&self) -> usize {
+        self.network_header().length_with_payload()
+    }
+
+    /// Network encode the transaction with the given signature.
+    pub fn network_encode(&self, out: &mut dyn BufMut) {
+        self.network_header().encode(out);
+        self.encode_2718(out);
+    }
+
+    /// Calculate the transaction hash.
+    pub fn tx_hash(&self) -> TxHash {
+        let mut buf = Vec::with_capacity(self.eip2718_encoded_length());
+        self.encode_2718(&mut buf);
+        keccak256(&buf)
+    }
+
+    /// Returns the signature for the optimism deposit transactions, which don't include a
+    /// signature.
+    pub const fn signature() -> Signature {
+        Signature::new(U256::ZERO, U256::ZERO, false)
+    }
+}
+
+impl Typed2718 for TxDeposit {
+    fn ty(&self) -> u8 {
+        OpTxType::Deposit as u8
+    }
+}
+
+impl IsTyped2718 for TxDeposit {
+    fn is_type(ty: u8) -> bool {
+        OpTxType::Deposit as u8 == ty
+    }
+}
+
+impl Transaction for TxDeposit {
+    fn chain_id(&self) -> Option<ChainId> {
+        None
+    }
+
+    fn nonce(&self) -> u64 {
+        0u64
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.gas_limit
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        None
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        0
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        None
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        0
+    }
+
+    fn effective_gas_price(&self, _: Option<u64>) -> u128 {
+        0
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        false
+    }
+
+    fn kind(&self) -> TxKind {
+        self.to
+    }
+
+    fn is_create(&self) -> bool {
+        self.to.is_create()
+    }
+
+    fn value(&self) -> U256 {
+        self.value
+    }
+
+    fn input(&self) -> &Bytes {
+        &self.input
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        None
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        None
+    }
+
+    fn authorization_list(&self) -> Option<&[alloy_eips::eip7702::SignedAuthorization]> {
+        None
+    }
+}
+
+impl Encodable2718 for TxDeposit {
+    fn type_flag(&self) -> Option<u8> {
+        Some(OpTxType::Deposit as u8)
+    }
+
+    fn encode_2718_len(&self) -> usize {
+        self.eip2718_encoded_length()
+    }
+
+    fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
+        out.put_u8(self.tx_type() as u8);
+        self.rlp_encode(out);
+    }
+}
+
+impl Decodable2718 for TxDeposit {
+    fn typed_decode(ty: u8, data: &mut &[u8]) -> Eip2718Result<Self> {
+        let ty: OpTxType = ty.try_into().map_err(|_| Eip2718Error::UnexpectedType(ty))?;
+        if ty != OpTxType::Deposit as u8 {
+            return Err(Eip2718Error::UnexpectedType(ty as u8));
+        }
+        let tx = Self::decode(data)?;
+        Ok(tx)
+    }
+
+    fn fallback_decode(data: &mut &[u8]) -> Eip2718Result<Self> {
+        let tx = Self::decode(data)?;
+        Ok(tx)
+    }
+}
+
+impl Encodable for TxDeposit {
+    fn encode(&self, out: &mut dyn BufMut) {
+        Header { list: true, payload_length: self.rlp_encoded_fields_length() }.encode(out);
+        self.rlp_encode_fields(out);
+    }
+
+    fn length(&self) -> usize {
+        let payload_length = self.rlp_encoded_fields_length();
+        Header { list: true, payload_length }.length() + payload_length
+    }
+}
+
+impl Decodable for TxDeposit {
+    fn decode(data: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Self::rlp_decode(data)
+    }
+}
+
+impl Sealable for TxDeposit {
+    fn hash_slow(&self) -> B256 {
+        self.tx_hash()
+    }
+}
+
+#[cfg(feature = "alloy-compat")]
+impl From<TxDeposit> for alloy_rpc_types_eth::TransactionRequest {
+    fn from(tx: TxDeposit) -> Self {
+        let TxDeposit {
+            source_hash: _,
+            from,
+            to,
+            mint: _,
+            value,
+            gas_limit,
+            is_system_transaction: _,
+            input,
+        } = tx;
+
+        Self {
+            from: Some(from),
+            to: Some(to),
+            value: Some(value),
+            gas: Some(gas_limit),
+            input: input.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// A trait representing a deposit transaction with specific attributes.
+pub trait DepositTransaction: Transaction {
+    /// Returns the hash that uniquely identifies the source of the deposit.
+    ///
+    /// # Returns
+    /// An `Option<B256>` containing the source hash if available.
+    fn source_hash(&self) -> Option<B256>;
+
+    /// Returns the optional mint value of the deposit transaction.
+    ///
+    /// # Returns
+    /// An `u128` representing the ETH value to mint on L2, if any.
+    fn mint(&self) -> u128;
+
+    /// Indicates whether the transaction is exempt from the L2 gas limit.
+    ///
+    /// # Returns
+    /// A `bool` indicating if the transaction is a system transaction.
+    fn is_system_transaction(&self) -> bool;
+}
+
+impl DepositTransaction for TxDeposit {
+    #[inline]
+    fn source_hash(&self) -> Option<B256> {
+        Some(self.source_hash)
+    }
+
+    #[inline]
+    fn mint(&self) -> u128 {
+        self.mint
+    }
+
+    #[inline]
+    fn is_system_transaction(&self) -> bool {
+        self.is_system_transaction
+    }
+}
+
+/// Deposit transactions don't have a signature, however, we include an empty signature in the
+/// response for better compatibility.
+///
+/// This function can be used as `serialize_with` serde attribute for the [`TxDeposit`] and will
+/// flatten [`TxDeposit::signature`] into response.
+#[cfg(feature = "serde")]
+pub fn serde_deposit_tx_rpc<T: serde::Serialize, S: serde::Serializer>(
+    value: &T,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct SerdeHelper<'a, T> {
+        #[serde(flatten)]
+        value: &'a T,
+        #[serde(flatten)]
+        signature: Signature,
+    }
+
+    SerdeHelper { value, signature: TxDeposit::signature() }.serialize(serializer)
+}

--- a/crates/op/op-alloy-consensus/src/transaction/envelope.rs
+++ b/crates/op/op-alloy-consensus/src/transaction/envelope.rs
@@ -1,0 +1,564 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use crate::{
+    TxDeposit, TxPostExec,
+    transaction::{OpDepositInfo, OpTransactionInfo},
+};
+use alloy_consensus::{
+    EthereumTxEnvelope, Extended, Sealable, Sealed, SignableTransaction, Signed,
+    TransactionEnvelope, TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy,
+    error::ValueError,
+    transaction::{TransactionInfo, TxHashRef},
+};
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{B256, Bytes, Signature, TxHash};
+
+/// The Ethereum [EIP-2718] Transaction Envelope, modified for OP Stack chains.
+///
+/// # Note:
+///
+/// This enum distinguishes between tagged and untagged legacy transactions, as
+/// the in-protocol merkle tree may commit to EITHER 0-prefixed or raw.
+/// Therefore we must ensure that encoding returns the precise byte-array that
+/// was decoded, preserving the presence or absence of the `TransactionType`
+/// flag.
+///
+/// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+#[derive(Debug, Clone, TransactionEnvelope)]
+#[envelope(tx_type_name = OpTxType, typed = OpTypedTransaction, serde_cfg(feature = "serde"))]
+pub enum OpTxEnvelope {
+    /// An untagged [`TxLegacy`].
+    #[envelope(ty = 0)]
+    Legacy(Signed<TxLegacy>),
+    /// A [`TxEip2930`] tagged with type 1.
+    #[envelope(ty = 1)]
+    Eip2930(Signed<TxEip2930>),
+    /// A [`TxEip1559`] tagged with type 2.
+    #[envelope(ty = 2)]
+    Eip1559(Signed<TxEip1559>),
+    /// A [`TxEip7702`] tagged with type 4.
+    #[envelope(ty = 4)]
+    Eip7702(Signed<TxEip7702>),
+    /// A [`TxDeposit`] tagged with type 0x7E.
+    #[envelope(ty = 126)]
+    #[serde(serialize_with = "crate::serde_deposit_tx_rpc")]
+    Deposit(Sealed<TxDeposit>),
+    /// A [`TxPostExec`] tagged with type 0x7D.
+    #[envelope(ty = 0x7D)]
+    #[serde(serialize_with = "crate::post_exec::serde_post_exec_tx_rpc")]
+    PostExec(Sealed<TxPostExec>),
+}
+
+/// Represents an Optimism transaction envelope.
+///
+/// Compared to Ethereum it can tell whether the transaction is a deposit or post-exec synthetic
+/// transaction.
+pub trait OpTransaction {
+    /// Returns `true` if the transaction is a deposit.
+    fn is_deposit(&self) -> bool;
+
+    /// Returns `Some` if the transaction is a deposit.
+    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>>;
+
+    /// Returns `Some` if the transaction is a post-exec transaction.
+    fn as_post_exec(&self) -> Option<&Sealed<TxPostExec>>;
+}
+
+impl OpTransaction for OpTxEnvelope {
+    fn is_deposit(&self) -> bool {
+        self.is_deposit()
+    }
+
+    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        self.as_deposit()
+    }
+
+    fn as_post_exec(&self) -> Option<&Sealed<TxPostExec>> {
+        self.as_post_exec()
+    }
+}
+
+impl<B, T> OpTransaction for Extended<B, T>
+where
+    B: OpTransaction,
+    T: OpTransaction,
+{
+    fn is_deposit(&self) -> bool {
+        match self {
+            Self::BuiltIn(b) => b.is_deposit(),
+            Self::Other(t) => t.is_deposit(),
+        }
+    }
+
+    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        match self {
+            Self::BuiltIn(b) => b.as_deposit(),
+            Self::Other(t) => t.as_deposit(),
+        }
+    }
+
+    fn as_post_exec(&self) -> Option<&Sealed<TxPostExec>> {
+        match self {
+            Self::BuiltIn(b) => b.as_post_exec(),
+            Self::Other(t) => t.as_post_exec(),
+        }
+    }
+}
+
+impl AsRef<Self> for OpTxEnvelope {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl From<Signed<TxLegacy>> for OpTxEnvelope {
+    fn from(v: Signed<TxLegacy>) -> Self {
+        Self::Legacy(v)
+    }
+}
+
+impl From<Signed<TxEip2930>> for OpTxEnvelope {
+    fn from(v: Signed<TxEip2930>) -> Self {
+        Self::Eip2930(v)
+    }
+}
+
+impl From<Signed<TxEip1559>> for OpTxEnvelope {
+    fn from(v: Signed<TxEip1559>) -> Self {
+        Self::Eip1559(v)
+    }
+}
+
+impl From<Signed<TxEip7702>> for OpTxEnvelope {
+    fn from(v: Signed<TxEip7702>) -> Self {
+        Self::Eip7702(v)
+    }
+}
+
+impl From<TxDeposit> for OpTxEnvelope {
+    fn from(v: TxDeposit) -> Self {
+        v.seal_slow().into()
+    }
+}
+
+impl From<Signed<OpTypedTransaction>> for OpTxEnvelope {
+    fn from(value: Signed<OpTypedTransaction>) -> Self {
+        let (tx, sig, hash) = value.into_parts();
+        match tx {
+            OpTypedTransaction::Legacy(tx_legacy) => {
+                let tx = Signed::new_unchecked(tx_legacy, sig, hash);
+                Self::Legacy(tx)
+            }
+            OpTypedTransaction::Eip2930(tx_eip2930) => {
+                let tx = Signed::new_unchecked(tx_eip2930, sig, hash);
+                Self::Eip2930(tx)
+            }
+            OpTypedTransaction::Eip1559(tx_eip1559) => {
+                let tx = Signed::new_unchecked(tx_eip1559, sig, hash);
+                Self::Eip1559(tx)
+            }
+            OpTypedTransaction::Eip7702(tx_eip7702) => {
+                let tx = Signed::new_unchecked(tx_eip7702, sig, hash);
+                Self::Eip7702(tx)
+            }
+            OpTypedTransaction::Deposit(tx) => Self::Deposit(Sealed::new_unchecked(tx, hash)),
+            OpTypedTransaction::PostExec(tx) => Self::PostExec(Sealed::new_unchecked(tx, hash)),
+        }
+    }
+}
+
+impl From<(OpTypedTransaction, Signature)> for OpTxEnvelope {
+    fn from(value: (OpTypedTransaction, Signature)) -> Self {
+        Self::new_unhashed(value.0, value.1)
+    }
+}
+
+impl From<Sealed<TxDeposit>> for OpTxEnvelope {
+    fn from(v: Sealed<TxDeposit>) -> Self {
+        Self::Deposit(v)
+    }
+}
+
+impl From<TxPostExec> for OpTxEnvelope {
+    fn from(v: TxPostExec) -> Self {
+        v.seal_slow().into()
+    }
+}
+
+impl From<Sealed<TxPostExec>> for OpTxEnvelope {
+    fn from(v: Sealed<TxPostExec>) -> Self {
+        Self::PostExec(v)
+    }
+}
+
+impl<Tx> From<OpTxEnvelope> for Extended<OpTxEnvelope, Tx> {
+    fn from(value: OpTxEnvelope) -> Self {
+        Self::BuiltIn(value)
+    }
+}
+
+impl<T> TryFrom<EthereumTxEnvelope<T>> for OpTxEnvelope {
+    type Error = EthereumTxEnvelope<T>;
+
+    fn try_from(value: EthereumTxEnvelope<T>) -> Result<Self, Self::Error> {
+        Self::try_from_eth_envelope(value)
+    }
+}
+
+impl TryFrom<OpTxEnvelope> for TxEnvelope {
+    type Error = ValueError<OpTxEnvelope>;
+
+    fn try_from(value: OpTxEnvelope) -> Result<Self, Self::Error> {
+        value.try_into_eth_envelope()
+    }
+}
+
+#[cfg(feature = "alloy-compat")]
+impl From<OpTxEnvelope> for alloy_rpc_types_eth::TransactionRequest {
+    fn from(value: OpTxEnvelope) -> Self {
+        match value {
+            OpTxEnvelope::Eip2930(tx) => tx.into_parts().0.into(),
+            OpTxEnvelope::Eip1559(tx) => tx.into_parts().0.into(),
+            OpTxEnvelope::Eip7702(tx) => tx.into_parts().0.into(),
+            OpTxEnvelope::Deposit(tx) => tx.into_inner().into(),
+            OpTxEnvelope::PostExec(tx) => tx.into_inner().into(),
+            OpTxEnvelope::Legacy(tx) => tx.into_parts().0.into(),
+        }
+    }
+}
+
+impl OpTxEnvelope {
+    /// Creates a new enveloped transaction from the given transaction, signature and hash.
+    ///
+    /// Caution: This assumes the given hash is the correct transaction hash.
+    pub fn new_unchecked(
+        transaction: OpTypedTransaction,
+        signature: Signature,
+        hash: B256,
+    ) -> Self {
+        Signed::new_unchecked(transaction, signature, hash).into()
+    }
+
+    /// Creates a new signed transaction from the given typed transaction and signature without the
+    /// hash.
+    ///
+    /// Note: this only calculates the hash on the first [`OpTxEnvelope::hash`] call.
+    pub fn new_unhashed(transaction: OpTypedTransaction, signature: Signature) -> Self {
+        transaction.into_signed(signature).into()
+    }
+
+    /// Returns true if the transaction is a legacy transaction.
+    #[inline]
+    pub const fn is_legacy(&self) -> bool {
+        matches!(self, Self::Legacy(_))
+    }
+
+    /// Returns true if the transaction is an EIP-2930 transaction.
+    #[inline]
+    pub const fn is_eip2930(&self) -> bool {
+        matches!(self, Self::Eip2930(_))
+    }
+
+    /// Returns true if the transaction is an EIP-1559 transaction.
+    #[inline]
+    pub const fn is_eip1559(&self) -> bool {
+        matches!(self, Self::Eip1559(_))
+    }
+
+    /// Returns true if the transaction is a system transaction.
+    #[inline]
+    pub const fn is_system_transaction(&self) -> bool {
+        match self {
+            Self::Deposit(tx) => tx.inner().is_system_transaction,
+            _ => false,
+        }
+    }
+
+    /// Attempts to convert the optimism variant into an ethereum [`TxEnvelope`].
+    ///
+    /// Returns the envelope as error if it is a variant unsupported on ethereum: [`TxDeposit`]
+    pub fn try_into_eth_envelope(self) -> Result<TxEnvelope, ValueError<Self>> {
+        match self {
+            Self::Legacy(tx) => Ok(tx.into()),
+            Self::Eip2930(tx) => Ok(tx.into()),
+            Self::Eip1559(tx) => Ok(tx.into()),
+            Self::Eip7702(tx) => Ok(tx.into()),
+            tx @ Self::Deposit(_) => Err(ValueError::new(
+                tx,
+                "Deposit transactions cannot be converted to ethereum transaction",
+            )),
+            tx @ Self::PostExec(_) => Err(ValueError::new(
+                tx,
+                "PostExec transactions cannot be converted to ethereum transaction",
+            )),
+        }
+    }
+
+    /// Helper that creates [`OpTransactionInfo`] by adding [`OpDepositInfo`] obtained from the
+    /// given closure if this transaction is a deposit and return the [`OpTransactionInfo`].
+    pub fn try_to_tx_info<F, E>(
+        &self,
+        tx_info: TransactionInfo,
+        f: F,
+    ) -> Result<OpTransactionInfo, E>
+    where
+        F: FnOnce(TxHash) -> Result<Option<OpDepositInfo>, E>,
+    {
+        let deposit_meta =
+            if self.is_deposit() { f(self.tx_hash())? } else { None }.unwrap_or_default();
+
+        Ok(OpTransactionInfo::new(tx_info, deposit_meta))
+    }
+
+    /// Attempts to convert an ethereum [`TxEnvelope`] into the optimism variant.
+    ///
+    /// Returns the given envelope as error if [`OpTxEnvelope`] doesn't support the variant
+    /// (EIP-4844)
+    pub fn try_from_eth_envelope<T>(
+        tx: EthereumTxEnvelope<T>,
+    ) -> Result<Self, EthereumTxEnvelope<T>> {
+        match tx {
+            EthereumTxEnvelope::Legacy(tx) => Ok(tx.into()),
+            EthereumTxEnvelope::Eip2930(tx) => Ok(tx.into()),
+            EthereumTxEnvelope::Eip1559(tx) => Ok(tx.into()),
+            tx @ EthereumTxEnvelope::<T>::Eip4844(_) => Err(tx),
+            EthereumTxEnvelope::Eip7702(tx) => Ok(tx.into()),
+        }
+    }
+
+    /// Returns mutable access to the input bytes.
+    ///
+    /// Caution: modifying this will cause side-effects on the hash.
+    ///
+    /// For [`TxPostExec`], this mutates the cached encoded payload bytes directly and may leave
+    /// them out of sync with [`TxPostExec::payload`]. Rebuild the transaction with
+    /// [`TxPostExec::new`] if you need to restore that invariant after mutating the input.
+    #[doc(hidden)]
+    pub const fn input_mut(&mut self) -> &mut Bytes {
+        match self {
+            Self::Eip1559(tx) => &mut tx.tx_mut().input,
+            Self::Eip2930(tx) => &mut tx.tx_mut().input,
+            Self::Legacy(tx) => &mut tx.tx_mut().input,
+            Self::Eip7702(tx) => &mut tx.tx_mut().input,
+            Self::Deposit(tx) => &mut tx.inner_mut().input,
+            Self::PostExec(tx) => &mut tx.inner_mut().input,
+        }
+    }
+
+    /// Attempts to convert an ethereum [`TxEnvelope`] into the optimism variant.
+    ///
+    /// Returns the given envelope as error if [`OpTxEnvelope`] doesn't support the variant
+    /// (EIP-4844)
+    #[cfg(feature = "alloy-compat")]
+    pub fn try_from_any_envelope(
+        tx: alloy_network::AnyTxEnvelope,
+    ) -> Result<Self, alloy_network::AnyTxEnvelope> {
+        match tx.try_into_envelope() {
+            Ok(eth) => {
+                Self::try_from_eth_envelope(eth).map_err(alloy_network::AnyTxEnvelope::Ethereum)
+            }
+            Err(err) => match err.into_value() {
+                alloy_network::AnyTxEnvelope::Unknown(unknown) => {
+                    let Ok(deposit) = unknown.inner.clone().try_into() else {
+                        return Err(alloy_network::AnyTxEnvelope::Unknown(unknown));
+                    };
+                    Ok(Self::Deposit(Sealed::new_unchecked(deposit, unknown.hash)))
+                }
+                unsupported => Err(unsupported),
+            },
+        }
+    }
+
+    /// Returns true if the transaction is a deposit transaction.
+    #[inline]
+    pub const fn is_deposit(&self) -> bool {
+        matches!(self, Self::Deposit(_))
+    }
+
+    /// Returns true if the transaction is a post-exec transaction.
+    #[inline]
+    pub const fn is_post_exec(&self) -> bool {
+        matches!(self, Self::PostExec(_))
+    }
+
+    /// Returns the [`TxLegacy`] variant if the transaction is a legacy transaction.
+    pub const fn as_legacy(&self) -> Option<&Signed<TxLegacy>> {
+        match self {
+            Self::Legacy(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxEip2930`] variant if the transaction is an EIP-2930 transaction.
+    pub const fn as_eip2930(&self) -> Option<&Signed<TxEip2930>> {
+        match self {
+            Self::Eip2930(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxEip1559`] variant if the transaction is an EIP-1559 transaction.
+    pub const fn as_eip1559(&self) -> Option<&Signed<TxEip1559>> {
+        match self {
+            Self::Eip1559(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxDeposit`] variant if the transaction is a deposit transaction.
+    pub const fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        match self {
+            Self::Deposit(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxPostExec`] variant if the transaction is a post-exec transaction.
+    pub const fn as_post_exec(&self) -> Option<&Sealed<TxPostExec>> {
+        match self {
+            Self::PostExec(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Return the reference to signature.
+    ///
+    /// Returns `None` for unsigned variants: [`TxDeposit`] and [`TxPostExec`].
+    pub const fn signature(&self) -> Option<&Signature> {
+        match self {
+            Self::Legacy(tx) => Some(tx.signature()),
+            Self::Eip2930(tx) => Some(tx.signature()),
+            Self::Eip1559(tx) => Some(tx.signature()),
+            Self::Eip7702(tx) => Some(tx.signature()),
+            Self::Deposit(_) | Self::PostExec(_) => None,
+        }
+    }
+
+    /// Return the [`OpTxType`] of the inner txn.
+    pub const fn tx_type(&self) -> OpTxType {
+        match self {
+            Self::Legacy(_) => OpTxType::Legacy,
+            Self::Eip2930(_) => OpTxType::Eip2930,
+            Self::Eip1559(_) => OpTxType::Eip1559,
+            Self::Eip7702(_) => OpTxType::Eip7702,
+            Self::Deposit(_) => OpTxType::Deposit,
+            Self::PostExec(_) => OpTxType::PostExec,
+        }
+    }
+
+    /// Returns the inner transaction hash.
+    pub fn hash(&self) -> &B256 {
+        match self {
+            Self::Legacy(tx) => tx.hash(),
+            Self::Eip1559(tx) => tx.hash(),
+            Self::Eip2930(tx) => tx.hash(),
+            Self::Eip7702(tx) => tx.hash(),
+            Self::Deposit(tx) => tx.hash_ref(),
+            Self::PostExec(tx) => tx.hash_ref(),
+        }
+    }
+
+    /// Returns the inner transaction hash.
+    pub fn tx_hash(&self) -> B256 {
+        *self.hash()
+    }
+
+    /// Return the length of the inner txn, including type byte length
+    pub fn eip2718_encoded_length(&self) -> usize {
+        match self {
+            Self::Legacy(t) => t.eip2718_encoded_length(),
+            Self::Eip2930(t) => t.eip2718_encoded_length(),
+            Self::Eip1559(t) => t.eip2718_encoded_length(),
+            Self::Eip7702(t) => t.eip2718_encoded_length(),
+            Self::Deposit(t) => t.eip2718_encoded_length(),
+            Self::PostExec(t) => t.eip2718_encoded_length(),
+        }
+    }
+}
+
+impl TxHashRef for OpTxEnvelope {
+    fn tx_hash(&self) -> &B256 {
+        Self::hash(self)
+    }
+}
+
+#[cfg(feature = "k256")]
+impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
+    fn recover_signer(
+        &self,
+    ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
+        let signature_hash = match self {
+            Self::Legacy(tx) => tx.signature_hash(),
+            Self::Eip2930(tx) => tx.signature_hash(),
+            Self::Eip1559(tx) => tx.signature_hash(),
+            Self::Eip7702(tx) => tx.signature_hash(),
+            // Optimism's Deposit transaction does not have a signature. Directly return the
+            // `from` address.
+            Self::Deposit(tx) => return Ok(tx.from),
+            // Post-exec transactions are unsigned synthetic system transactions. They use a
+            // canonical zero-address signer rather than a cryptographic signature.
+            Self::PostExec(tx) => return Ok(tx.inner().signer_address()),
+        };
+        let signature = match self {
+            Self::Legacy(tx) => tx.signature(),
+            Self::Eip2930(tx) => tx.signature(),
+            Self::Eip1559(tx) => tx.signature(),
+            Self::Eip7702(tx) => tx.signature(),
+            // Deposit and PostExec are unsigned and handled via early return above.
+            Self::Deposit(_) | Self::PostExec(_) => {
+                unreachable!("non-signed transactions should not be handled here")
+            }
+        };
+        alloy_consensus::crypto::secp256k1::recover_signer(signature, signature_hash)
+    }
+
+    fn recover_signer_unchecked(
+        &self,
+    ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
+        let signature_hash = match self {
+            Self::Legacy(tx) => tx.signature_hash(),
+            Self::Eip2930(tx) => tx.signature_hash(),
+            Self::Eip1559(tx) => tx.signature_hash(),
+            Self::Eip7702(tx) => tx.signature_hash(),
+            // Optimism's Deposit transaction does not have a signature. Directly return the
+            // `from` address.
+            Self::Deposit(tx) => return Ok(tx.from),
+            // Post-exec transactions are unsigned synthetic system transactions. They use a
+            // canonical zero-address signer rather than a cryptographic signature.
+            Self::PostExec(tx) => return Ok(tx.inner().signer_address()),
+        };
+        let signature = match self {
+            Self::Legacy(tx) => tx.signature(),
+            Self::Eip2930(tx) => tx.signature(),
+            Self::Eip1559(tx) => tx.signature(),
+            Self::Eip7702(tx) => tx.signature(),
+            // Deposit and PostExec are unsigned and handled via early return above.
+            Self::Deposit(_) | Self::PostExec(_) => unreachable!(),
+        };
+        alloy_consensus::crypto::secp256k1::recover_signer_unchecked(signature, signature_hash)
+    }
+
+    fn recover_unchecked_with_buf(
+        &self,
+        buf: &mut Vec<u8>,
+    ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
+        match self {
+            Self::Legacy(tx) => {
+                alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
+            }
+            Self::Eip2930(tx) => {
+                alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
+            }
+            Self::Eip1559(tx) => {
+                alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
+            }
+            Self::Eip7702(tx) => {
+                alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
+            }
+            // Deposit and PostExec are unsigned; return their canonical signer directly.
+            Self::Deposit(tx) => Ok(tx.from),
+            Self::PostExec(tx) => Ok(tx.inner().signer_address()),
+        }
+    }
+}

--- a/crates/op/op-alloy-consensus/src/transaction/meta.rs
+++ b/crates/op/op-alloy-consensus/src/transaction/meta.rs
@@ -1,0 +1,32 @@
+//! Commonly used types that contain metadata about a transaction.
+
+use alloy_consensus::transaction::TransactionInfo;
+
+/// Additional receipt metadata required for deposit transactions.
+///
+/// These fields are used to provide additional context for deposit transactions in RPC responses
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub struct OpDepositInfo {
+    /// Nonce for deposit transactions. Only present in RPC responses.
+    pub deposit_nonce: Option<u64>,
+    /// Deposit receipt version for deposit transactions post-canyon
+    pub deposit_receipt_version: Option<u64>,
+}
+
+/// Additional fields in the context of a block that contains this transaction and its deposit
+/// metadata if the transaction is a deposit.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct OpTransactionInfo {
+    /// Additional transaction information.
+    pub inner: TransactionInfo,
+    /// Additional metadata for deposit transactions.
+    pub deposit_meta: OpDepositInfo,
+}
+
+impl OpTransactionInfo {
+    /// Creates a new [`OpTransactionInfo`] with the given [`TransactionInfo`] and
+    /// [`OpDepositInfo`].
+    pub const fn new(inner: TransactionInfo, deposit_meta: OpDepositInfo) -> Self {
+        Self { inner, deposit_meta }
+    }
+}

--- a/crates/op/op-alloy-consensus/src/transaction/mod.rs
+++ b/crates/op/op-alloy-consensus/src/transaction/mod.rs
@@ -1,0 +1,19 @@
+//! Transaction types for Optimism.
+
+mod deposit;
+pub use deposit::{DepositTransaction, TxDeposit};
+
+mod tx_type;
+pub use tx_type::DEPOSIT_TX_TYPE_ID;
+
+mod envelope;
+pub use envelope::{OpTransaction, OpTxEnvelope, OpTxType};
+
+mod typed;
+pub use typed::OpTypedTransaction;
+
+#[cfg(feature = "serde")]
+pub use deposit::serde_deposit_tx_rpc;
+
+mod meta;
+pub use meta::{OpDepositInfo, OpTransactionInfo};

--- a/crates/op/op-alloy-consensus/src/transaction/tx_type.rs
+++ b/crates/op/op-alloy-consensus/src/transaction/tx_type.rs
@@ -1,0 +1,38 @@
+//! Contains the transaction type identifier for Optimism.
+
+use crate::transaction::envelope::OpTxType;
+use core::fmt::Display;
+
+/// Identifier for an Optimism deposit transaction
+pub const DEPOSIT_TX_TYPE_ID: u8 = 126; // 0x7E
+
+#[allow(clippy::derivable_impls)]
+impl Default for OpTxType {
+    fn default() -> Self {
+        Self::Legacy
+    }
+}
+
+impl Display for OpTxType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Legacy => write!(f, "legacy"),
+            Self::Eip2930 => write!(f, "eip2930"),
+            Self::Eip1559 => write!(f, "eip1559"),
+            Self::Eip7702 => write!(f, "eip7702"),
+            Self::Deposit => write!(f, "deposit"),
+            Self::PostExec => write!(f, "post-exec"),
+        }
+    }
+}
+
+impl OpTxType {
+    /// List of all variants.
+    pub const ALL: [Self; 6] =
+        [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Eip7702, Self::Deposit, Self::PostExec];
+
+    /// Returns `true` if the type is [`OpTxType::Deposit`].
+    pub const fn is_deposit(&self) -> bool {
+        matches!(self, Self::Deposit)
+    }
+}

--- a/crates/op/op-alloy-consensus/src/transaction/typed.rs
+++ b/crates/op/op-alloy-consensus/src/transaction/typed.rs
@@ -1,0 +1,336 @@
+pub use crate::transaction::envelope::OpTypedTransaction;
+use crate::{OpTxEnvelope, OpTxType, TxDeposit, TxPostExec};
+use alloy_consensus::{
+    EthereumTypedTransaction, SignableTransaction, Signed, TxEip1559, TxEip2930, TxEip7702,
+    TxLegacy, Typed2718, TypedTransaction, error::ValueError, transaction::RlpEcdsaEncodableTx,
+};
+use alloy_eips::Encodable2718;
+use alloy_primitives::{B256, ChainId, Signature, TxHash, bytes::BufMut};
+
+impl From<TxLegacy> for OpTypedTransaction {
+    fn from(tx: TxLegacy) -> Self {
+        Self::Legacy(tx)
+    }
+}
+
+impl From<TxEip2930> for OpTypedTransaction {
+    fn from(tx: TxEip2930) -> Self {
+        Self::Eip2930(tx)
+    }
+}
+
+impl From<TxEip1559> for OpTypedTransaction {
+    fn from(tx: TxEip1559) -> Self {
+        Self::Eip1559(tx)
+    }
+}
+
+impl From<TxEip7702> for OpTypedTransaction {
+    fn from(tx: TxEip7702) -> Self {
+        Self::Eip7702(tx)
+    }
+}
+
+impl From<TxDeposit> for OpTypedTransaction {
+    fn from(tx: TxDeposit) -> Self {
+        Self::Deposit(tx)
+    }
+}
+
+impl From<TxPostExec> for OpTypedTransaction {
+    fn from(tx: TxPostExec) -> Self {
+        Self::PostExec(tx)
+    }
+}
+
+impl From<OpTxEnvelope> for OpTypedTransaction {
+    fn from(envelope: OpTxEnvelope) -> Self {
+        match envelope {
+            OpTxEnvelope::Legacy(tx) => Self::Legacy(tx.strip_signature()),
+            OpTxEnvelope::Eip2930(tx) => Self::Eip2930(tx.strip_signature()),
+            OpTxEnvelope::Eip1559(tx) => Self::Eip1559(tx.strip_signature()),
+            OpTxEnvelope::Eip7702(tx) => Self::Eip7702(tx.strip_signature()),
+            OpTxEnvelope::Deposit(tx) => Self::Deposit(tx.into_inner()),
+            OpTxEnvelope::PostExec(tx) => Self::PostExec(tx.into_inner()),
+        }
+    }
+}
+
+impl<Eip4844> TryFrom<OpTypedTransaction> for EthereumTypedTransaction<Eip4844> {
+    type Error = ValueError<OpTypedTransaction>;
+
+    fn try_from(value: OpTypedTransaction) -> Result<Self, Self::Error> {
+        value.try_into_eth_variant()
+    }
+}
+
+#[cfg(feature = "alloy-compat")]
+impl From<OpTypedTransaction> for alloy_rpc_types_eth::TransactionRequest {
+    fn from(tx: OpTypedTransaction) -> Self {
+        match tx {
+            OpTypedTransaction::Legacy(tx) => tx.into(),
+            OpTypedTransaction::Eip2930(tx) => tx.into(),
+            OpTypedTransaction::Eip1559(tx) => tx.into(),
+            OpTypedTransaction::Eip7702(tx) => tx.into(),
+            OpTypedTransaction::Deposit(tx) => tx.into(),
+            OpTypedTransaction::PostExec(tx) => tx.into(),
+        }
+    }
+}
+
+impl OpTypedTransaction {
+    /// Return the [`OpTxType`] of the inner txn.
+    pub const fn tx_type(&self) -> OpTxType {
+        match self {
+            Self::Legacy(_) => OpTxType::Legacy,
+            Self::Eip2930(_) => OpTxType::Eip2930,
+            Self::Eip1559(_) => OpTxType::Eip1559,
+            Self::Eip7702(_) => OpTxType::Eip7702,
+            Self::Deposit(_) => OpTxType::Deposit,
+            Self::PostExec(_) => OpTxType::PostExec,
+        }
+    }
+
+    /// Calculates the signing hash for the transaction.
+    ///
+    /// Returns `None` for unsigned transaction variants: [`TxDeposit`] and [`TxPostExec`].
+    pub fn checked_signature_hash(&self) -> Option<B256> {
+        match self {
+            Self::Legacy(tx) => Some(tx.signature_hash()),
+            Self::Eip2930(tx) => Some(tx.signature_hash()),
+            Self::Eip1559(tx) => Some(tx.signature_hash()),
+            Self::Eip7702(tx) => Some(tx.signature_hash()),
+            // Deposit and PostExec are unsigned synthetic transactions with no signature hash.
+            Self::Deposit(_) | Self::PostExec(_) => None,
+        }
+    }
+
+    /// Return the inner legacy transaction if it exists.
+    pub const fn legacy(&self) -> Option<&TxLegacy> {
+        match self {
+            Self::Legacy(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Return the inner EIP-2930 transaction if it exists.
+    pub const fn eip2930(&self) -> Option<&TxEip2930> {
+        match self {
+            Self::Eip2930(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Return the inner EIP-1559 transaction if it exists.
+    pub const fn eip1559(&self) -> Option<&TxEip1559> {
+        match self {
+            Self::Eip1559(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Return the inner deposit transaction if it exists.
+    pub const fn deposit(&self) -> Option<&TxDeposit> {
+        match self {
+            Self::Deposit(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Return the inner post-exec transaction if it exists.
+    pub const fn post_exec(&self) -> Option<&TxPostExec> {
+        match self {
+            Self::PostExec(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if transaction is deposit transaction.
+    pub const fn is_deposit(&self) -> bool {
+        matches!(self, Self::Deposit(_))
+    }
+
+    /// Calculate the transaction hash for the given signature.
+    ///
+    /// Note: returns the regular transaction hash for unsigned variants: [`TxDeposit`] and
+    /// [`TxPostExec`]. In those cases the provided signature is ignored.
+    pub fn tx_hash(&self, signature: &Signature) -> TxHash {
+        match self {
+            Self::Legacy(tx) => tx.tx_hash(signature),
+            Self::Eip2930(tx) => tx.tx_hash(signature),
+            Self::Eip1559(tx) => tx.tx_hash(signature),
+            Self::Eip7702(tx) => tx.tx_hash(signature),
+            Self::Deposit(tx) => tx.tx_hash(),
+            Self::PostExec(tx) => tx.tx_hash(),
+        }
+    }
+
+    /// Convenience function to convert this typed transaction into an [`OpTxEnvelope`].
+    ///
+    /// Note: for unsigned variants ([`OpTypedTransaction::Deposit`] and
+    /// [`OpTypedTransaction::PostExec`]), the provided signature is ignored.
+    pub fn into_envelope(self, signature: Signature) -> OpTxEnvelope {
+        self.into_signed(signature).into()
+    }
+
+    /// Attempts to convert the optimism variant into an ethereum [`TypedTransaction`].
+    ///
+    /// Returns the typed transaction as an error if it is a variant unsupported on ethereum:
+    /// [`TxDeposit`] or [`TxPostExec`].
+    pub fn try_into_eth(self) -> Result<TypedTransaction, ValueError<Self>> {
+        self.try_into_eth_variant()
+    }
+
+    /// Attempts to convert the optimism variant into an ethereum [`TypedTransaction`].
+    ///
+    /// Returns the typed transaction as an error if it is a variant unsupported on ethereum:
+    /// [`TxDeposit`] or [`TxPostExec`].
+    pub fn try_into_eth_variant<Eip4844>(
+        self,
+    ) -> Result<EthereumTypedTransaction<Eip4844>, ValueError<Self>> {
+        match self {
+            Self::Legacy(tx) => Ok(tx.into()),
+            Self::Eip2930(tx) => Ok(tx.into()),
+            Self::Eip1559(tx) => Ok(tx.into()),
+            Self::Eip7702(tx) => Ok(tx.into()),
+            tx @ Self::Deposit(_) => Err(ValueError::new(
+                tx,
+                "Deposit transactions cannot be converted to ethereum transaction",
+            )),
+            tx @ Self::PostExec(_) => Err(ValueError::new(
+                tx,
+                "PostExec transactions cannot be converted to ethereum transaction",
+            )),
+        }
+    }
+}
+
+impl RlpEcdsaEncodableTx for OpTypedTransaction {
+    fn rlp_encoded_fields_length(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.rlp_encoded_fields_length(),
+            Self::Eip2930(tx) => tx.rlp_encoded_fields_length(),
+            Self::Eip1559(tx) => tx.rlp_encoded_fields_length(),
+            Self::Eip7702(tx) => tx.rlp_encoded_fields_length(),
+            Self::Deposit(tx) => tx.rlp_encoded_fields_length(),
+            Self::PostExec(tx) => tx.rlp_encoded_fields_length(),
+        }
+    }
+
+    fn rlp_encode_fields(&self, out: &mut dyn alloy_rlp::BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.rlp_encode_fields(out),
+            Self::Eip2930(tx) => tx.rlp_encode_fields(out),
+            Self::Eip1559(tx) => tx.rlp_encode_fields(out),
+            Self::Eip7702(tx) => tx.rlp_encode_fields(out),
+            Self::Deposit(tx) => tx.rlp_encode_fields(out),
+            Self::PostExec(tx) => tx.rlp_encode_fields(out),
+        }
+    }
+
+    fn eip2718_encode_with_type(&self, signature: &Signature, _ty: u8, out: &mut dyn BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
+            Self::Eip2930(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
+            Self::Eip1559(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
+            Self::Eip7702(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
+            Self::Deposit(tx) => tx.encode_2718(out),
+            Self::PostExec(tx) => tx.encode_2718(out),
+        }
+    }
+
+    fn eip2718_encode(&self, signature: &Signature, out: &mut dyn BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.eip2718_encode(signature, out),
+            Self::Eip2930(tx) => tx.eip2718_encode(signature, out),
+            Self::Eip1559(tx) => tx.eip2718_encode(signature, out),
+            Self::Eip7702(tx) => tx.eip2718_encode(signature, out),
+            Self::Deposit(tx) => tx.encode_2718(out),
+            Self::PostExec(tx) => tx.encode_2718(out),
+        }
+    }
+
+    fn network_encode_with_type(&self, signature: &Signature, _ty: u8, out: &mut dyn BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
+            Self::Eip2930(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
+            Self::Eip1559(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
+            Self::Eip7702(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
+            Self::Deposit(tx) => tx.network_encode(out),
+            Self::PostExec(tx) => tx.network_encode(out),
+        }
+    }
+
+    fn network_encode(&self, signature: &Signature, out: &mut dyn BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.network_encode(signature, out),
+            Self::Eip2930(tx) => tx.network_encode(signature, out),
+            Self::Eip1559(tx) => tx.network_encode(signature, out),
+            Self::Eip7702(tx) => tx.network_encode(signature, out),
+            Self::Deposit(tx) => tx.network_encode(out),
+            Self::PostExec(tx) => tx.network_encode(out),
+        }
+    }
+
+    fn tx_hash_with_type(&self, signature: &Signature, _ty: u8) -> TxHash {
+        match self {
+            Self::Legacy(tx) => tx.tx_hash_with_type(signature, tx.ty()),
+            Self::Eip2930(tx) => tx.tx_hash_with_type(signature, tx.ty()),
+            Self::Eip1559(tx) => tx.tx_hash_with_type(signature, tx.ty()),
+            Self::Eip7702(tx) => tx.tx_hash_with_type(signature, tx.ty()),
+            Self::Deposit(tx) => tx.tx_hash(),
+            Self::PostExec(tx) => tx.tx_hash(),
+        }
+    }
+
+    fn tx_hash(&self, signature: &Signature) -> TxHash {
+        match self {
+            Self::Legacy(tx) => tx.tx_hash(signature),
+            Self::Eip2930(tx) => tx.tx_hash(signature),
+            Self::Eip1559(tx) => tx.tx_hash(signature),
+            Self::Eip7702(tx) => tx.tx_hash(signature),
+            Self::Deposit(tx) => tx.tx_hash(),
+            Self::PostExec(tx) => tx.tx_hash(),
+        }
+    }
+}
+
+impl SignableTransaction<Signature> for OpTypedTransaction {
+    fn set_chain_id(&mut self, chain_id: ChainId) {
+        match self {
+            Self::Legacy(tx) => tx.set_chain_id(chain_id),
+            Self::Eip2930(tx) => tx.set_chain_id(chain_id),
+            Self::Eip1559(tx) => tx.set_chain_id(chain_id),
+            Self::Eip7702(tx) => tx.set_chain_id(chain_id),
+            Self::Deposit(_) | Self::PostExec(_) => {}
+        }
+    }
+
+    fn encode_for_signing(&self, out: &mut dyn BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.encode_for_signing(out),
+            Self::Eip2930(tx) => tx.encode_for_signing(out),
+            Self::Eip1559(tx) => tx.encode_for_signing(out),
+            Self::Eip7702(tx) => tx.encode_for_signing(out),
+            Self::Deposit(_) | Self::PostExec(_) => {}
+        }
+    }
+
+    fn payload_len_for_signature(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.payload_len_for_signature(),
+            Self::Eip2930(tx) => tx.payload_len_for_signature(),
+            Self::Eip1559(tx) => tx.payload_len_for_signature(),
+            Self::Eip7702(tx) => tx.payload_len_for_signature(),
+            Self::Deposit(_) | Self::PostExec(_) => 0,
+        }
+    }
+
+    fn into_signed(self, signature: Signature) -> Signed<Self, Signature>
+    where
+        Self: Sized,
+    {
+        let hash = self.tx_hash(&signature);
+        Signed::new_unchecked(self, signature, hash)
+    }
+}

--- a/crates/op/op-alloy-network/Cargo.toml
+++ b/crates/op/op-alloy-network/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "op-alloy-network"
+description = "Optimism blockchain RPC behavior abstraction"
+
+version = "0.24.0"
+edition.workspace = true
+rust-version.workspace = true
+authors = ["Alloy Contributors"]
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/ethereum-optimism/optimism"
+repository = "https://github.com/ethereum-optimism/optimism"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Workspace
+op-alloy-consensus = { workspace = true, features = ["alloy-compat"] }
+op-alloy-rpc-types = { workspace = true, features = ["std"] }
+
+# Alloy
+alloy-consensus.workspace = true
+alloy-network.workspace = true
+alloy-provider.workspace = true
+alloy-rpc-types-eth.workspace = true
+
+[features]
+std = [
+	"op-alloy-consensus/std",
+	"op-alloy-rpc-types/std",
+	"alloy-consensus/std",
+	"alloy-rpc-types-eth/std"
+]
+serde = [
+	"op-alloy-consensus/serde",
+	"op-alloy-rpc-types/serde",
+	"alloy-consensus/serde",
+	"alloy-rpc-types-eth/serde"
+]

--- a/crates/op/op-alloy-network/src/lib.rs
+++ b/crates/op/op-alloy-network/src/lib.rs
@@ -1,0 +1,114 @@
+//! Optimism network types.
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+pub use alloy_network::*;
+
+use alloy_consensus::{ReceiptWithBloom, TxType};
+use op_alloy_consensus::{OpReceipt, OpTxType, OpTypedTransaction};
+use op_alloy_rpc_types::OpTransactionRequest;
+
+/// Types for an Op-stack network.
+#[derive(Clone, Copy, Debug)]
+pub struct Optimism {
+    _private: (),
+}
+
+impl Network for Optimism {
+    type TxType = OpTxType;
+
+    type TxEnvelope = op_alloy_consensus::OpTxEnvelope;
+
+    type UnsignedTx = op_alloy_consensus::OpTypedTransaction;
+
+    type ReceiptEnvelope = ReceiptWithBloom<OpReceipt>;
+
+    type Header = alloy_consensus::Header;
+
+    type TransactionRequest = op_alloy_rpc_types::OpTransactionRequest;
+
+    type TransactionResponse = op_alloy_rpc_types::Transaction;
+
+    type ReceiptResponse = op_alloy_rpc_types::OpTransactionReceipt;
+
+    type HeaderResponse = alloy_rpc_types_eth::Header;
+
+    type BlockResponse =
+        alloy_rpc_types_eth::Block<Self::TransactionResponse, Self::HeaderResponse>;
+}
+
+impl NetworkTransactionBuilder<Optimism> for OpTransactionRequest {
+    fn complete_type(&self, ty: OpTxType) -> Result<(), Vec<&'static str>> {
+        match ty {
+            OpTxType::Deposit => Err(vec!["not implemented for deposit tx"]),
+            OpTxType::PostExec => Err(vec!["not implemented for post-exec tx"]),
+            _ => {
+                let ty = TxType::try_from(ty as u8).unwrap();
+                NetworkTransactionBuilder::<Ethereum>::complete_type(self.as_ref(), ty)
+            }
+        }
+    }
+
+    fn can_submit(&self) -> bool {
+        NetworkTransactionBuilder::<Ethereum>::can_submit(self.as_ref())
+    }
+
+    fn can_build(&self) -> bool {
+        NetworkTransactionBuilder::<Ethereum>::can_build(self.as_ref())
+    }
+
+    #[doc(alias = "output_transaction_type")]
+    fn output_tx_type(&self) -> OpTxType {
+        match NetworkTransactionBuilder::<Ethereum>::output_tx_type(self.as_ref()) {
+            TxType::Eip1559 | TxType::Eip4844 => OpTxType::Eip1559,
+            TxType::Eip2930 => OpTxType::Eip2930,
+            TxType::Eip7702 => OpTxType::Eip7702,
+            TxType::Legacy => OpTxType::Legacy,
+        }
+    }
+
+    #[doc(alias = "output_transaction_type_checked")]
+    fn output_tx_type_checked(&self) -> Option<OpTxType> {
+        NetworkTransactionBuilder::<Ethereum>::output_tx_type_checked(self.as_ref()).map(|tx_ty| {
+            match tx_ty {
+                TxType::Eip1559 | TxType::Eip4844 => OpTxType::Eip1559,
+                TxType::Eip2930 => OpTxType::Eip2930,
+                TxType::Eip7702 => OpTxType::Eip7702,
+                TxType::Legacy => OpTxType::Legacy,
+            }
+        })
+    }
+
+    fn prep_for_submission(&mut self) {
+        NetworkTransactionBuilder::<Ethereum>::prep_for_submission(self.as_mut());
+    }
+
+    fn build_unsigned(self) -> BuildResult<OpTypedTransaction, Optimism> {
+        if let Err((tx_type, missing)) = self.as_ref().missing_keys() {
+            let tx_type = OpTxType::try_from(tx_type as u8).unwrap();
+            return Err(TransactionBuilderError::InvalidTransactionRequest(tx_type, missing)
+                .into_unbuilt(self));
+        }
+        Ok(self.build_typed_tx().expect("checked by missing_keys"))
+    }
+
+    async fn build<W: NetworkWallet<Optimism>>(
+        self,
+        wallet: &W,
+    ) -> Result<<Optimism as Network>::TxEnvelope, TransactionBuilderError<Optimism>> {
+        Ok(wallet.sign_request(self).await?)
+    }
+}
+
+use alloy_provider::fillers::{
+    ChainIdFiller, GasFiller, JoinFill, NonceFiller, RecommendedFillers,
+};
+
+impl RecommendedFillers for Optimism {
+    type RecommendedFillers = JoinFill<GasFiller, JoinFill<NonceFiller, ChainIdFiller>>;
+
+    fn recommended_fillers() -> Self::RecommendedFillers {
+        Default::default()
+    }
+}

--- a/crates/op/op-alloy-rpc-types/Cargo.toml
+++ b/crates/op/op-alloy-rpc-types/Cargo.toml
@@ -1,0 +1,73 @@
+[package]
+name = "op-alloy-rpc-types"
+description = "Optimism RPC types"
+
+version = "0.24.0"
+edition.workspace = true
+rust-version.workspace = true
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/ethereum-optimism/optimism"
+authors = ["Alloy Contributors"]
+repository = "https://github.com/ethereum-optimism/optimism"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Workspace
+op-alloy-consensus = { workspace = true, features = ["serde"] }
+
+# Alloy
+alloy-serde.workspace = true
+alloy-consensus.workspace = true
+alloy-network-primitives.workspace = true
+alloy-network = { workspace = true, optional = true }
+alloy-eips = { workspace = true, features = ["serde"] }
+alloy-rpc-types-eth = { workspace = true, features = ["serde"] }
+alloy-primitives = { workspace = true, features = ["map", "rlp", "serde"] }
+
+# Serde
+serde_json.workspace = true
+serde = { workspace = true, features = ["derive"] }
+
+# arbitrary
+arbitrary = { version = "1", features = ["derive"], optional = true }
+
+# misc
+derive_more = { workspace = true, features = ["as_ref", "deref_mut", "try_from"] }
+
+[features]
+default = ["std"]
+std = [
+	"dep:alloy-network",
+	"alloy-network-primitives/std",
+	"alloy-eips/std",
+	"alloy-primitives/std",
+	"alloy-rpc-types-eth/std",
+	"op-alloy-consensus/std",
+	"alloy-consensus/std",
+	"alloy-serde/std",
+	"derive_more/std",
+	"serde/std",
+	"serde_json/std",
+]
+arbitrary = [
+	"std",
+	"dep:arbitrary",
+	"alloy-primitives/arbitrary",
+	"alloy-rpc-types-eth/arbitrary",
+	"op-alloy-consensus/arbitrary",
+	"alloy-consensus/arbitrary",
+	"alloy-eips/arbitrary",
+	"alloy-serde/arbitrary"
+]
+k256 = ["alloy-rpc-types-eth/k256", "op-alloy-consensus/k256"]
+serde = [
+	"op-alloy-consensus/serde",
+	"alloy-consensus/serde",
+	"alloy-eips/serde",
+	"alloy-network-primitives/serde",
+	"alloy-primitives/serde",
+	"alloy-rpc-types-eth/serde"
+]
+

--- a/crates/op/op-alloy-rpc-types/src/lib.rs
+++ b/crates/op/op-alloy-rpc-types/src/lib.rs
@@ -1,0 +1,17 @@
+//! Optimism RPC types.
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(feature = "arbitrary")]
+use arbitrary as _;
+
+mod receipt;
+pub use receipt::{L1BlockInfo, OpTransactionReceipt, OpTransactionReceiptFields};
+
+mod transaction;
+pub use transaction::{OpTransactionFields, OpTransactionRequest, Transaction};

--- a/crates/op/op-alloy-rpc-types/src/receipt.rs
+++ b/crates/op/op-alloy-rpc-types/src/receipt.rs
@@ -1,0 +1,260 @@
+//! Receipt types for RPC
+
+use alloy_consensus::{Receipt, ReceiptWithBloom, TxReceipt};
+use alloy_rpc_types_eth::Log;
+use alloy_serde::OtherFields;
+use op_alloy_consensus::{
+    OpDepositReceipt, OpDepositReceiptWithBloom, OpReceipt, OpReceiptEnvelope,
+};
+use serde::{Deserialize, Serialize};
+
+/// OP Transaction Receipt type
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[doc(alias = "OpTxReceipt")]
+pub struct OpTransactionReceipt {
+    /// Regular eth transaction receipt including deposit receipts
+    #[serde(flatten)]
+    pub inner: alloy_rpc_types_eth::TransactionReceipt<ReceiptWithBloom<OpReceipt<Log>>>,
+    /// L1 block info of the transaction.
+    #[serde(flatten)]
+    pub l1_block_info: L1BlockInfo,
+    /// Per-transaction gas refund from post-exec block-level warming.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub op_gas_refund: Option<u64>,
+}
+
+impl alloy_network_primitives::ReceiptResponse for OpTransactionReceipt {
+    fn contract_address(&self) -> Option<alloy_primitives::Address> {
+        self.inner.contract_address
+    }
+
+    fn status(&self) -> bool {
+        self.inner.inner.status()
+    }
+
+    fn block_hash(&self) -> Option<alloy_primitives::BlockHash> {
+        self.inner.block_hash
+    }
+
+    fn block_number(&self) -> Option<u64> {
+        self.inner.block_number
+    }
+
+    fn transaction_hash(&self) -> alloy_primitives::TxHash {
+        self.inner.transaction_hash
+    }
+
+    fn transaction_index(&self) -> Option<u64> {
+        self.inner.transaction_index()
+    }
+
+    fn gas_used(&self) -> u64 {
+        self.inner.gas_used()
+    }
+
+    fn effective_gas_price(&self) -> u128 {
+        self.inner.effective_gas_price()
+    }
+
+    fn blob_gas_used(&self) -> Option<u64> {
+        self.inner.blob_gas_used()
+    }
+
+    fn blob_gas_price(&self) -> Option<u128> {
+        self.inner.blob_gas_price()
+    }
+
+    fn from(&self) -> alloy_primitives::Address {
+        self.inner.from()
+    }
+
+    fn to(&self) -> Option<alloy_primitives::Address> {
+        self.inner.to()
+    }
+
+    fn cumulative_gas_used(&self) -> u64 {
+        self.inner.cumulative_gas_used()
+    }
+
+    fn state_root(&self) -> Option<alloy_primitives::B256> {
+        self.inner.state_root()
+    }
+}
+
+/// Additional fields for Optimism transaction receipts: <https://github.com/ethereum-optimism/op-geth/blob/f2e69450c6eec9c35d56af91389a1c47737206ca/core/types/receipt.go#L87-L87>
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[doc(alias = "OptimismTxReceiptFields")]
+pub struct OpTransactionReceiptFields {
+    /// L1 block info.
+    #[serde(flatten)]
+    pub l1_block_info: L1BlockInfo,
+    /// Per-transaction gas refund from post-exec block-level warming.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub op_gas_refund: Option<u64>,
+    /* --------------------------------------- Regolith --------------------------------------- */
+    /// Deposit nonce for deposit transactions.
+    ///
+    /// Always null prior to the Regolith hardfork.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub deposit_nonce: Option<u64>,
+    /* ---------------------------------------- Canyon ---------------------------------------- */
+    /// Deposit receipt version for deposit transactions.
+    ///
+    /// Always null prior to the Canyon hardfork.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub deposit_receipt_version: Option<u64>,
+}
+
+/// Serialize/Deserialize l1FeeScalar to/from string
+mod l1_fee_scalar_serde {
+    #[cfg(not(feature = "std"))]
+    use alloc::string::{String, ToString};
+
+    use serde::{Deserialize, de};
+
+    pub(super) fn serialize<S>(value: &Option<f64>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if let Some(v) = value {
+            return s.serialize_str(&v.to_string());
+        }
+        s.serialize_none()
+    }
+
+    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: Option<String> = Option::deserialize(deserializer)?;
+        if let Some(s) = s {
+            return Ok(Some(s.parse::<f64>().map_err(de::Error::custom)?));
+        }
+
+        Ok(None)
+    }
+}
+
+impl From<OpTransactionReceiptFields> for OtherFields {
+    fn from(value: OpTransactionReceiptFields) -> Self {
+        serde_json::to_value(value).unwrap().try_into().unwrap()
+    }
+}
+
+/// L1 block info extracted from input of first transaction in every block.
+///
+/// The subset of [`OpTransactionReceiptFields`], that encompasses L1 block
+/// info:
+/// <https://github.com/ethereum-optimism/op-geth/blob/f2e69450c6eec9c35d56af91389a1c47737206ca/core/types/receipt.go#L87-L87>
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct L1BlockInfo {
+    /// L1 base fee is the minimum price per unit of gas.
+    ///
+    /// Present from pre-bedrock as de facto L1 price per unit of gas. L1 base fee after Bedrock.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub l1_gas_price: Option<u128>,
+    /// L1 gas used.
+    ///
+    /// Present from pre-bedrock, deprecated as of Fjord.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub l1_gas_used: Option<u128>,
+    /// L1 fee for the transaction.
+    ///
+    /// Present from pre-bedrock.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub l1_fee: Option<u128>,
+    /// L1 fee scalar for the transaction
+    ///
+    /// Present from pre-bedrock to Ecotone. Null after Ecotone.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "l1_fee_scalar_serde")]
+    pub l1_fee_scalar: Option<f64>,
+    /* ---------------------------------------- Ecotone ---------------------------------------- */
+    /// L1 base fee scalar. Applied to base fee to compute weighted gas price multiplier.
+    ///
+    /// Always null prior to the Ecotone hardfork.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub l1_base_fee_scalar: Option<u128>,
+    /// L1 blob base fee.
+    ///
+    /// Always null prior to the Ecotone hardfork.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub l1_blob_base_fee: Option<u128>,
+    /// L1 blob base fee scalar. Applied to blob base fee to compute weighted gas price multiplier.
+    ///
+    /// Always null prior to the Ecotone hardfork.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub l1_blob_base_fee_scalar: Option<u128>,
+    /* ---------------------------------------- Isthmus ---------------------------------------- */
+    /// Operator fee scalar.
+    ///
+    /// Always null prior to the Isthmus hardfork.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub operator_fee_scalar: Option<u128>,
+    /// Operator fee constant.
+    ///
+    /// Always null prior to the Isthmus hardfork.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub operator_fee_constant: Option<u128>,
+    /* ---------------------------------------- Jovian ---------------------------------------- */
+    /// DA footprint gas scalar. Used to set the DA footprint block limit on the L2.
+    ///
+    /// Always null prior to the Jovian hardfork.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub da_footprint_gas_scalar: Option<u16>,
+}
+
+impl Eq for L1BlockInfo {}
+
+impl From<OpTransactionReceipt> for OpReceiptEnvelope<alloy_primitives::Log> {
+    fn from(value: OpTransactionReceipt) -> Self {
+        let inner_envelope = value.inner.inner.into();
+
+        /// Helper function to convert the inner logs within a [`ReceiptWithBloom`] from RPC to
+        /// consensus types.
+        #[inline(always)]
+        fn convert_standard_receipt(
+            receipt: ReceiptWithBloom<Receipt<alloy_rpc_types_eth::Log>>,
+        ) -> ReceiptWithBloom<Receipt<alloy_primitives::Log>> {
+            let ReceiptWithBloom { logs_bloom, receipt } = receipt;
+
+            let consensus_logs = receipt.logs.into_iter().map(|log| log.inner).collect();
+            ReceiptWithBloom {
+                receipt: Receipt {
+                    status: receipt.status,
+                    cumulative_gas_used: receipt.cumulative_gas_used,
+                    logs: consensus_logs,
+                },
+                logs_bloom,
+            }
+        }
+
+        match inner_envelope {
+            OpReceiptEnvelope::Legacy(receipt) => Self::Legacy(convert_standard_receipt(receipt)),
+            OpReceiptEnvelope::Eip2930(receipt) => Self::Eip2930(convert_standard_receipt(receipt)),
+            OpReceiptEnvelope::Eip1559(receipt) => Self::Eip1559(convert_standard_receipt(receipt)),
+            OpReceiptEnvelope::Eip7702(receipt) => Self::Eip7702(convert_standard_receipt(receipt)),
+            OpReceiptEnvelope::PostExec(receipt) => {
+                Self::PostExec(convert_standard_receipt(receipt))
+            }
+            OpReceiptEnvelope::Deposit(OpDepositReceiptWithBloom { logs_bloom, receipt }) => {
+                let consensus_logs = receipt.inner.logs.into_iter().map(|log| log.inner).collect();
+                let consensus_receipt = OpDepositReceiptWithBloom {
+                    receipt: OpDepositReceipt {
+                        inner: Receipt {
+                            status: receipt.inner.status,
+                            cumulative_gas_used: receipt.inner.cumulative_gas_used,
+                            logs: consensus_logs,
+                        },
+                        deposit_nonce: receipt.deposit_nonce,
+                        deposit_receipt_version: receipt.deposit_receipt_version,
+                    },
+                    logs_bloom,
+                };
+                Self::Deposit(consensus_receipt)
+            }
+        }
+    }
+}

--- a/crates/op/op-alloy-rpc-types/src/transaction.rs
+++ b/crates/op/op-alloy-rpc-types/src/transaction.rs
@@ -1,0 +1,343 @@
+//! Optimism specific types related to transactions.
+
+use alloy_consensus::{Transaction as TransactionTrait, Typed2718, transaction::Recovered};
+use alloy_eips::{Encodable2718, eip2930::AccessList, eip7702::SignedAuthorization};
+use alloy_primitives::{Address, B256, BlockHash, Bytes, ChainId, TxKind, U256};
+use alloy_serde::OtherFields;
+use op_alloy_consensus::{OpTransaction, OpTxEnvelope, transaction::OpTransactionInfo};
+use serde::{Deserialize, Serialize};
+
+mod request;
+pub use request::OpTransactionRequest;
+
+/// OP Transaction type
+#[derive(
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, derive_more::Deref, derive_more::DerefMut,
+)]
+#[cfg_attr(all(any(test, feature = "arbitrary"), feature = "k256"), derive(arbitrary::Arbitrary))]
+#[serde(
+    try_from = "tx_serde::TransactionSerdeHelper<T>",
+    into = "tx_serde::TransactionSerdeHelper<T>",
+    bound = "T: TransactionTrait + OpTransaction + Clone + serde::Serialize + serde::de::DeserializeOwned"
+)]
+pub struct Transaction<T = OpTxEnvelope> {
+    /// Ethereum Transaction Types
+    #[deref]
+    #[deref_mut]
+    pub inner: alloy_rpc_types_eth::Transaction<T>,
+
+    /// Nonce for deposit transactions. Only present in RPC responses.
+    pub deposit_nonce: Option<u64>,
+
+    /// Deposit receipt version for deposit transactions post-canyon
+    pub deposit_receipt_version: Option<u64>,
+}
+
+impl<T: OpTransaction + TransactionTrait> Transaction<T> {
+    /// Converts a consensus `tx` with an additional context `tx_info` into an RPC [`Transaction`].
+    pub fn from_transaction(tx: Recovered<T>, tx_info: OpTransactionInfo) -> Self {
+        let base_fee = tx_info.inner.base_fee;
+        let effective_gas_price = if tx.is_deposit() {
+            // For deposits, we must always set the `gasPrice` field to 0 in rpc
+            // deposit tx don't have a gas price field, but serde of `Transaction` will take care of
+            // it
+            0
+        } else {
+            base_fee
+                .map(|base_fee| {
+                    tx.effective_tip_per_gas(base_fee).unwrap_or_default() + base_fee as u128
+                })
+                .unwrap_or_else(|| tx.max_fee_per_gas())
+        };
+
+        Self {
+            inner: alloy_rpc_types_eth::Transaction {
+                inner: tx,
+                block_hash: tx_info.inner.block_hash,
+                block_number: tx_info.inner.block_number,
+                transaction_index: tx_info.inner.index,
+                effective_gas_price: Some(effective_gas_price),
+                block_timestamp: tx_info.inner.block_timestamp,
+            },
+            deposit_nonce: tx_info.deposit_meta.deposit_nonce,
+            deposit_receipt_version: tx_info.deposit_meta.deposit_receipt_version,
+        }
+    }
+}
+
+impl<T: Typed2718> Typed2718 for Transaction<T> {
+    fn ty(&self) -> u8 {
+        self.inner.ty()
+    }
+}
+
+impl<T: TransactionTrait> TransactionTrait for Transaction<T> {
+    fn chain_id(&self) -> Option<ChainId> {
+        self.inner.chain_id()
+    }
+
+    fn nonce(&self) -> u64 {
+        self.inner.nonce()
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.inner.gas_limit()
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        self.inner.gas_price()
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        self.inner.max_fee_per_gas()
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        self.inner.max_priority_fee_per_gas()
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        self.inner.max_fee_per_blob_gas()
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        self.inner.priority_fee_or_price()
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        self.inner.effective_gas_price(base_fee)
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        self.inner.is_dynamic_fee()
+    }
+
+    fn kind(&self) -> TxKind {
+        self.inner.kind()
+    }
+
+    fn is_create(&self) -> bool {
+        self.inner.is_create()
+    }
+
+    fn to(&self) -> Option<Address> {
+        self.inner.to()
+    }
+
+    fn value(&self) -> U256 {
+        self.inner.value()
+    }
+
+    fn input(&self) -> &Bytes {
+        self.inner.input()
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        self.inner.access_list()
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        self.inner.blob_versioned_hashes()
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        self.inner.authorization_list()
+    }
+}
+
+impl<T: TransactionTrait + Encodable2718> alloy_network_primitives::TransactionResponse
+    for Transaction<T>
+{
+    fn tx_hash(&self) -> alloy_primitives::TxHash {
+        self.inner.tx_hash()
+    }
+
+    fn block_hash(&self) -> Option<BlockHash> {
+        self.inner.block_hash()
+    }
+
+    fn block_number(&self) -> Option<u64> {
+        self.inner.block_number()
+    }
+
+    fn transaction_index(&self) -> Option<u64> {
+        self.inner.transaction_index()
+    }
+
+    fn from(&self) -> Address {
+        self.inner.from()
+    }
+}
+
+/// Optimism specific transaction fields
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[doc(alias = "OptimismTxFields")]
+#[serde(rename_all = "camelCase")]
+pub struct OpTransactionFields {
+    /// The ETH value to mint on L2
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub mint: Option<u128>,
+    /// Hash that uniquely identifies the source of the deposit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_hash: Option<B256>,
+    /// Field indicating whether the transaction is a system transaction, and therefore
+    /// exempt from the L2 gas limit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_system_tx: Option<bool>,
+    /// Deposit receipt version for deposit transactions post-canyon
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub deposit_receipt_version: Option<u64>,
+}
+
+impl From<OpTransactionFields> for OtherFields {
+    fn from(value: OpTransactionFields) -> Self {
+        serde_json::to_value(value).unwrap().try_into().unwrap()
+    }
+}
+
+impl<T> AsRef<T> for Transaction<T> {
+    fn as_ref(&self) -> &T {
+        self.inner.as_ref()
+    }
+}
+
+mod tx_serde {
+    //! Helper module for serializing and deserializing OP [`Transaction`].
+    //!
+    //! This is needed because we might need to deserialize the `from` field into both
+    //! [`alloy_consensus::transaction::Recovered::signer`] which resides in
+    //! [`alloy_rpc_types_eth::Transaction::inner`] and [`op_alloy_consensus::TxDeposit::from`].
+    //!
+    //! Additionally, we need similar logic for the `gasPrice` field
+    use super::*;
+    use serde::de::Error;
+
+    /// Helper struct which will be flattened into the transaction and will only contain `from`
+    /// field if inner [`OpTxEnvelope`] did not consume it.
+    #[derive(Serialize, Deserialize)]
+    struct OptionalFields {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        from: Option<Address>,
+        #[serde(
+            default,
+            rename = "gasPrice",
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )]
+        effective_gas_price: Option<u128>,
+        #[serde(
+            default,
+            rename = "nonce",
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )]
+        deposit_nonce: Option<u64>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub(crate) struct TransactionSerdeHelper<T> {
+        #[serde(flatten)]
+        inner: T,
+        #[serde(default)]
+        block_hash: Option<BlockHash>,
+        #[serde(default, with = "alloy_serde::quantity::opt")]
+        block_number: Option<u64>,
+        #[serde(default, with = "alloy_serde::quantity::opt")]
+        transaction_index: Option<u64>,
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )]
+        block_timestamp: Option<u64>,
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )]
+        deposit_receipt_version: Option<u64>,
+
+        #[serde(flatten)]
+        other: OptionalFields,
+    }
+
+    impl<T: TransactionTrait + OpTransaction> From<Transaction<T>> for TransactionSerdeHelper<T> {
+        fn from(value: Transaction<T>) -> Self {
+            let Transaction {
+                inner:
+                    alloy_rpc_types_eth::Transaction {
+                        inner,
+                        block_hash,
+                        block_number,
+                        transaction_index,
+                        effective_gas_price,
+                        block_timestamp,
+                    },
+                deposit_receipt_version,
+                deposit_nonce,
+            } = value;
+
+            // if inner transaction is a deposit, then don't serialize `from` directly
+            let from = if inner.as_deposit().is_some() { None } else { Some(inner.signer()) };
+
+            // if inner transaction has its own `gasPrice` don't serialize it in this struct.
+            let effective_gas_price = effective_gas_price.filter(|_| inner.gas_price().is_none());
+
+            Self {
+                inner: inner.into_inner(),
+                block_hash,
+                block_number,
+                transaction_index,
+                block_timestamp,
+                deposit_receipt_version,
+                other: OptionalFields { from, effective_gas_price, deposit_nonce },
+            }
+        }
+    }
+
+    impl<T: TransactionTrait + OpTransaction> TryFrom<TransactionSerdeHelper<T>> for Transaction<T> {
+        type Error = serde_json::Error;
+
+        fn try_from(value: TransactionSerdeHelper<T>) -> Result<Self, Self::Error> {
+            let TransactionSerdeHelper {
+                inner,
+                block_hash,
+                block_number,
+                transaction_index,
+                block_timestamp,
+                deposit_receipt_version,
+                other,
+            } = value;
+
+            // Try to get `from` field from inner envelope or from `MaybeFrom`, otherwise return
+            // error
+            let from = if let Some(from) = other.from {
+                from
+            } else {
+                inner
+                    .as_deposit()
+                    .map(|v| v.from)
+                    .ok_or_else(|| serde_json::Error::custom("missing `from` field"))?
+            };
+
+            // Only serialize deposit_nonce if inner transaction is deposit to avoid duplicated keys
+            let deposit_nonce = other.deposit_nonce.filter(|_| inner.is_deposit());
+
+            let effective_gas_price = other.effective_gas_price.or_else(|| inner.gas_price());
+
+            Ok(Self {
+                inner: alloy_rpc_types_eth::Transaction {
+                    inner: Recovered::new_unchecked(inner, from),
+                    block_hash,
+                    block_number,
+                    transaction_index,
+                    effective_gas_price,
+                    block_timestamp,
+                },
+                deposit_receipt_version,
+                deposit_nonce,
+            })
+        }
+    }
+}

--- a/crates/op/op-alloy-rpc-types/src/transaction/request.rs
+++ b/crates/op/op-alloy-rpc-types/src/transaction/request.rs
@@ -1,0 +1,339 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use alloy_consensus::{
+    Sealed, SignableTransaction, Signed, TxEip1559, TxEip4844, TypedTransaction,
+};
+use alloy_eips::eip7702::SignedAuthorization;
+use alloy_network_primitives::TransactionBuilder7702;
+use alloy_primitives::{Address, Signature, TxKind, U256};
+#[cfg(feature = "std")]
+use alloy_primitives::{Bytes, ChainId};
+use alloy_rpc_types_eth::{AccessList, TransactionInput, TransactionRequest};
+use op_alloy_consensus::{
+    OpTxEnvelope, OpTypedTransaction, POST_EXEC_TX_TYPE_ID, TxDeposit, TxPostExec,
+};
+use serde::{Deserialize, Serialize};
+
+/// Builder for [`OpTypedTransaction`].
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    derive_more::From,
+    derive_more::AsRef,
+    derive_more::AsMut,
+    Serialize,
+    Deserialize,
+)]
+#[serde(transparent)]
+pub struct OpTransactionRequest(TransactionRequest);
+
+impl OpTransactionRequest {
+    /// Sets the `from` field in the call to the provided address
+    #[inline]
+    pub const fn from(mut self, from: Address) -> Self {
+        self.0.from = Some(from);
+        self
+    }
+
+    /// Sets the transactions type for the transactions.
+    #[doc(alias = "tx_type")]
+    pub const fn transaction_type(mut self, transaction_type: u8) -> Self {
+        self.0.transaction_type = Some(transaction_type);
+        self
+    }
+
+    /// Sets the gas limit for the transaction.
+    pub const fn gas_limit(mut self, gas_limit: u64) -> Self {
+        self.0.gas = Some(gas_limit);
+        self
+    }
+
+    /// Sets the nonce for the transaction.
+    pub const fn nonce(mut self, nonce: u64) -> Self {
+        self.0.nonce = Some(nonce);
+        self
+    }
+
+    /// Sets the maximum fee per gas for the transaction.
+    pub const fn max_fee_per_gas(mut self, max_fee_per_gas: u128) -> Self {
+        self.0.max_fee_per_gas = Some(max_fee_per_gas);
+        self
+    }
+
+    /// Sets the maximum priority fee per gas for the transaction.
+    pub const fn max_priority_fee_per_gas(mut self, max_priority_fee_per_gas: u128) -> Self {
+        self.0.max_priority_fee_per_gas = Some(max_priority_fee_per_gas);
+        self
+    }
+
+    /// Sets the recipient address for the transaction.
+    #[inline]
+    pub const fn to(mut self, to: Address) -> Self {
+        self.0.to = Some(TxKind::Call(to));
+        self
+    }
+
+    /// Sets the value (amount) for the transaction.
+    pub const fn value(mut self, value: U256) -> Self {
+        self.0.value = Some(value);
+        self
+    }
+
+    /// Sets the access list for the transaction.
+    pub fn access_list(mut self, access_list: AccessList) -> Self {
+        self.0.access_list = Some(access_list);
+        self
+    }
+
+    /// Sets the input data for the transaction.
+    pub fn input(mut self, input: TransactionInput) -> Self {
+        self.0.input = input;
+        self
+    }
+
+    /// Builds [`OpTypedTransaction`] from this builder. See [`TransactionRequest::build_typed_tx`]
+    /// for more info.
+    ///
+    /// Note that EIP-4844 transactions are not supported by Optimism and will be converted into
+    /// EIP-1559 transactions.
+    pub fn build_typed_tx(self) -> Result<OpTypedTransaction, Self> {
+        let tx = self.0.build_typed_tx().map_err(Self)?;
+        match tx {
+            TypedTransaction::Legacy(tx) => Ok(OpTypedTransaction::Legacy(tx)),
+            TypedTransaction::Eip1559(tx) => Ok(OpTypedTransaction::Eip1559(tx)),
+            TypedTransaction::Eip2930(tx) => Ok(OpTypedTransaction::Eip2930(tx)),
+            TypedTransaction::Eip4844(tx) => {
+                let tx: TxEip4844 = tx.into();
+                Ok(OpTypedTransaction::Eip1559(TxEip1559 {
+                    chain_id: tx.chain_id,
+                    nonce: tx.nonce,
+                    gas_limit: tx.gas_limit,
+                    max_priority_fee_per_gas: tx.max_priority_fee_per_gas,
+                    max_fee_per_gas: tx.max_fee_per_gas,
+                    to: TxKind::Call(tx.to),
+                    value: tx.value,
+                    access_list: tx.access_list,
+                    input: tx.input,
+                }))
+            }
+            TypedTransaction::Eip7702(tx) => Ok(OpTypedTransaction::Eip7702(tx)),
+        }
+    }
+}
+
+impl From<OpTransactionRequest> for TransactionRequest {
+    fn from(value: OpTransactionRequest) -> Self {
+        value.0
+    }
+}
+
+impl From<TxDeposit> for OpTransactionRequest {
+    fn from(tx: TxDeposit) -> Self {
+        let TxDeposit {
+            source_hash: _,
+            from,
+            to,
+            mint: _,
+            value,
+            gas_limit,
+            is_system_transaction: _,
+            input,
+        } = tx;
+
+        Self(TransactionRequest {
+            from: Some(from),
+            to: Some(to),
+            value: Some(value),
+            gas: Some(gas_limit),
+            input: input.into(),
+            ..Default::default()
+        })
+    }
+}
+
+impl From<Sealed<TxDeposit>> for OpTransactionRequest {
+    fn from(value: Sealed<TxDeposit>) -> Self {
+        value.into_inner().into()
+    }
+}
+
+impl From<TxPostExec> for OpTransactionRequest {
+    fn from(tx: TxPostExec) -> Self {
+        Self(TransactionRequest {
+            from: Some(tx.signer_address()),
+            transaction_type: Some(POST_EXEC_TX_TYPE_ID),
+            gas: Some(0),
+            nonce: Some(0),
+            value: Some(U256::ZERO),
+            input: tx.input.into(),
+            ..Default::default()
+        })
+    }
+}
+
+impl<T> From<Signed<T, Signature>> for OpTransactionRequest
+where
+    T: SignableTransaction<Signature> + Into<TransactionRequest>,
+{
+    fn from(value: Signed<T, Signature>) -> Self {
+        #[cfg(feature = "k256")]
+        let from = value.recover_signer().ok();
+        #[cfg(not(feature = "k256"))]
+        let from = None;
+
+        let mut inner: TransactionRequest = value.strip_signature().into();
+        inner.from = from;
+
+        Self(inner)
+    }
+}
+
+impl From<OpTypedTransaction> for OpTransactionRequest {
+    fn from(tx: OpTypedTransaction) -> Self {
+        match tx {
+            OpTypedTransaction::Legacy(tx) => Self(tx.into()),
+            OpTypedTransaction::Eip2930(tx) => Self(tx.into()),
+            OpTypedTransaction::Eip1559(tx) => Self(tx.into()),
+            OpTypedTransaction::Eip7702(tx) => Self(tx.into()),
+            OpTypedTransaction::Deposit(tx) => tx.into(),
+            OpTypedTransaction::PostExec(tx) => tx.into(),
+        }
+    }
+}
+
+impl From<OpTxEnvelope> for OpTransactionRequest {
+    fn from(value: OpTxEnvelope) -> Self {
+        match value {
+            OpTxEnvelope::Eip2930(tx) => tx.into(),
+            OpTxEnvelope::Eip1559(tx) => tx.into(),
+            OpTxEnvelope::Eip7702(tx) => tx.into(),
+            OpTxEnvelope::Deposit(tx) => tx.into(),
+            OpTxEnvelope::PostExec(tx) => tx.into_inner().into(),
+            _ => Default::default(),
+        }
+    }
+}
+
+impl From<super::Transaction> for OpTransactionRequest {
+    fn from(tx: super::Transaction) -> Self {
+        let recovered = tx.inner.into_recovered();
+        let from = recovered.signer();
+        let mut req: Self = recovered.into_inner().into();
+        req.0.from = Some(from);
+        req
+    }
+}
+
+impl TransactionBuilder7702 for OpTransactionRequest {
+    fn authorization_list(&self) -> Option<&Vec<SignedAuthorization>> {
+        self.as_ref().authorization_list()
+    }
+
+    fn set_authorization_list(&mut self, authorization_list: Vec<SignedAuthorization>) {
+        self.as_mut().set_authorization_list(authorization_list);
+    }
+}
+
+#[cfg(feature = "std")]
+impl alloy_network::TransactionBuilder for OpTransactionRequest {
+    fn chain_id(&self) -> Option<ChainId> {
+        self.as_ref().chain_id()
+    }
+
+    fn set_chain_id(&mut self, chain_id: ChainId) {
+        self.as_mut().set_chain_id(chain_id);
+    }
+
+    fn nonce(&self) -> Option<u64> {
+        self.as_ref().nonce()
+    }
+
+    fn set_nonce(&mut self, nonce: u64) {
+        self.as_mut().set_nonce(nonce);
+    }
+
+    fn take_nonce(&mut self) -> Option<u64> {
+        self.as_mut().nonce.take()
+    }
+
+    fn input(&self) -> Option<&Bytes> {
+        self.as_ref().input()
+    }
+
+    fn set_input<T: Into<Bytes>>(&mut self, input: T) {
+        self.as_mut().set_input(input);
+    }
+
+    fn from(&self) -> Option<Address> {
+        self.as_ref().from()
+    }
+
+    fn set_from(&mut self, from: Address) {
+        self.as_mut().set_from(from);
+    }
+
+    fn kind(&self) -> Option<TxKind> {
+        self.as_ref().kind()
+    }
+
+    fn clear_kind(&mut self) {
+        self.as_mut().clear_kind();
+    }
+
+    fn set_kind(&mut self, kind: TxKind) {
+        self.as_mut().set_kind(kind);
+    }
+
+    fn value(&self) -> Option<U256> {
+        self.as_ref().value()
+    }
+
+    fn set_value(&mut self, value: U256) {
+        self.as_mut().set_value(value);
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        self.as_ref().gas_price()
+    }
+
+    fn set_gas_price(&mut self, gas_price: u128) {
+        self.as_mut().set_gas_price(gas_price);
+    }
+
+    fn max_fee_per_gas(&self) -> Option<u128> {
+        self.as_ref().max_fee_per_gas()
+    }
+
+    fn set_max_fee_per_gas(&mut self, max_fee_per_gas: u128) {
+        self.as_mut().set_max_fee_per_gas(max_fee_per_gas);
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        self.as_ref().max_priority_fee_per_gas()
+    }
+
+    fn set_max_priority_fee_per_gas(&mut self, max_priority_fee_per_gas: u128) {
+        self.as_mut().set_max_priority_fee_per_gas(max_priority_fee_per_gas);
+    }
+
+    fn gas_limit(&self) -> Option<u64> {
+        self.as_ref().gas_limit()
+    }
+
+    fn set_gas_limit(&mut self, gas_limit: u64) {
+        self.as_mut().set_gas_limit(gas_limit);
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        self.as_ref().access_list()
+    }
+
+    fn set_access_list(&mut self, access_list: AccessList) {
+        self.as_mut().set_access_list(access_list);
+    }
+}

--- a/crates/op/op-revm/Cargo.toml
+++ b/crates/op/op-revm/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "op-revm"
+description = "Optimism variant of Revm"
+version = "17.0.0"
+authors = ["Foundry Contributors"]
+edition.workspace = true
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/foundry-rs/foundry-core"
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# revm
+revm.workspace = true
+auto_impl.workspace = true
+
+# Optional
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
+
+[features]
+default = ["std", "c-kzg", "secp256k1", "portable", "blst"]
+std = [
+	"serde?/std",
+	"revm/std",
+]
+serde = ["dep:serde", "revm/serde"]
+portable = ["revm/portable"]
+
+dev = [
+	"revm/dev",
+	"memory_limit",
+	"optional_balance_check",
+	"optional_block_gas_limit",
+	"optional_eip3541",
+	"optional_eip3607",
+	"optional_no_base_fee",
+]
+memory_limit = ["revm/memory_limit"]
+optional_balance_check = ["revm/optional_balance_check"]
+optional_block_gas_limit = ["revm/optional_block_gas_limit"]
+optional_eip3541 = ["revm/optional_eip3541"]
+optional_eip3607 = ["revm/optional_eip3607"]
+optional_no_base_fee = ["revm/optional_no_base_fee"]
+optional_fee_charge = ["revm/optional_fee_charge"]
+
+# See comments in `revm-precompile`
+secp256k1 = ["revm/secp256k1"]
+c-kzg = ["revm/c-kzg"]
+blst = ["revm/blst"]
+bn = ["revm/bn"]

--- a/crates/op/op-revm/src/api.rs
+++ b/crates/op/op-revm/src/api.rs
@@ -1,0 +1,9 @@
+//! Optimism API types.
+
+pub mod builder;
+pub mod default_ctx;
+pub mod exec;
+
+pub use builder::OpBuilder;
+pub use default_ctx::DefaultOp;
+pub use exec::{OpContextTr, OpError};

--- a/crates/op/op-revm/src/api/builder.rs
+++ b/crates/op/op-revm/src/api/builder.rs
@@ -1,0 +1,45 @@
+//! Optimism builder trait [`OpBuilder`] used to build [`OpEvm`].
+use crate::{L1BlockInfo, OpSpecId, evm::OpEvm, precompiles::OpPrecompiles, transaction::OpTxTr};
+use revm::{
+    Context, Database,
+    context::Cfg,
+    context_interface::{Block, JournalTr},
+    handler::instructions::EthInstructions,
+    interpreter::interpreter::EthInterpreter,
+    state::EvmState,
+};
+
+/// Type alias for default `OpEvm`
+pub type DefaultOpEvm<CTX, INSP = ()> =
+    OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, OpPrecompiles>;
+
+/// Trait that allows for optimism `OpEvm` to be built.
+pub trait OpBuilder: Sized {
+    /// Type of the context.
+    type Context;
+
+    /// Build the op.
+    fn build_op(self) -> DefaultOpEvm<Self::Context>;
+
+    /// Build the op with an inspector.
+    fn build_op_with_inspector<INSP>(self, inspector: INSP) -> DefaultOpEvm<Self::Context, INSP>;
+}
+
+impl<BLOCK, TX, CFG, DB, JOURNAL> OpBuilder for Context<BLOCK, TX, CFG, DB, JOURNAL, L1BlockInfo>
+where
+    BLOCK: Block,
+    TX: OpTxTr,
+    CFG: Cfg<Spec = OpSpecId>,
+    DB: Database,
+    JOURNAL: JournalTr<Database = DB, State = EvmState>,
+{
+    type Context = Self;
+
+    fn build_op(self) -> DefaultOpEvm<Self::Context> {
+        OpEvm::new(self, ())
+    }
+
+    fn build_op_with_inspector<INSP>(self, inspector: INSP) -> DefaultOpEvm<Self::Context, INSP> {
+        OpEvm::new(self, inspector)
+    }
+}

--- a/crates/op/op-revm/src/api/default_ctx.rs
+++ b/crates/op/op-revm/src/api/default_ctx.rs
@@ -1,0 +1,26 @@
+//! Contains trait [`DefaultOp`] used to create a default context.
+use crate::{L1BlockInfo, OpSpecId, OpTransaction};
+use revm::{
+    Context, Journal, MainContext,
+    context::{BlockEnv, CfgEnv, TxEnv},
+    database_interface::EmptyDB,
+};
+
+/// Type alias for the default context type of the `OpEvm`.
+pub type OpContext<DB> =
+    Context<BlockEnv, OpTransaction<TxEnv>, CfgEnv<OpSpecId>, DB, Journal<DB>, L1BlockInfo>;
+
+/// Trait that allows for a default context to be created.
+pub trait DefaultOp {
+    /// Create a default context.
+    fn op() -> OpContext<EmptyDB>;
+}
+
+impl DefaultOp for OpContext<EmptyDB> {
+    fn op() -> Self {
+        Context::mainnet()
+            .with_tx(OpTransaction::default())
+            .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK))
+            .with_chain(L1BlockInfo::default())
+    }
+}

--- a/crates/op/op-revm/src/api/exec.rs
+++ b/crates/op/op-revm/src/api/exec.rs
@@ -1,0 +1,169 @@
+//! Implementation of the [`ExecuteEvm`] trait for the [`OpEvm`].
+use crate::{
+    L1BlockInfo, OpHaltReason, OpSpecId, OpTransactionError, evm::OpEvm, handler::OpHandler,
+    transaction::OpTxTr,
+};
+use revm::{
+    DatabaseCommit, ExecuteCommitEvm, ExecuteEvm,
+    context::{ContextSetters, result::ExecResultAndState},
+    context_interface::{
+        Cfg, ContextTr, Database, JournalTr,
+        result::{EVMError, ExecutionResult},
+    },
+    handler::{
+        EthFrame, Handler, PrecompileProvider, SystemCallTx, instructions::EthInstructions,
+        system_call::SystemCallEvm,
+    },
+    inspector::{
+        InspectCommitEvm, InspectEvm, InspectSystemCallEvm, Inspector, InspectorHandler, JournalExt,
+    },
+    interpreter::{InterpreterResult, interpreter::EthInterpreter},
+    primitives::{Address, Bytes},
+    state::EvmState,
+};
+
+/// Type alias for Optimism context
+pub trait OpContextTr:
+    ContextTr<
+        Journal: JournalTr<State = EvmState>,
+        Tx: OpTxTr,
+        Cfg: Cfg<Spec = OpSpecId>,
+        Chain = L1BlockInfo,
+    >
+{
+}
+
+impl<T> OpContextTr for T where
+    T: ContextTr<
+            Journal: JournalTr<State = EvmState>,
+            Tx: OpTxTr,
+            Cfg: Cfg<Spec = OpSpecId>,
+            Chain = L1BlockInfo,
+        >
+{
+}
+
+/// Type alias for the error type of the `OpEvm`.
+pub type OpError<CTX> = EVMError<<<CTX as ContextTr>::Db as Database>::Error, OpTransactionError>;
+
+impl<CTX, INSP, PRECOMPILE> ExecuteEvm
+    for OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILE>
+where
+    CTX: OpContextTr + ContextSetters,
+    PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
+{
+    type Tx = <CTX as ContextTr>::Tx;
+    type Block = <CTX as ContextTr>::Block;
+    type State = EvmState;
+    type Error = OpError<CTX>;
+    type ExecutionResult = ExecutionResult<OpHaltReason>;
+
+    fn set_block(&mut self, block: Self::Block) {
+        self.0.ctx.set_block(block);
+    }
+
+    fn transact_one(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
+        self.0.ctx.set_tx(tx);
+        let mut h = OpHandler::<_, _, EthFrame<EthInterpreter>>::new();
+        h.run(self)
+    }
+
+    fn finalize(&mut self) -> Self::State {
+        self.0.ctx.journal_mut().finalize()
+    }
+
+    fn replay(
+        &mut self,
+    ) -> Result<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
+        let mut h = OpHandler::<_, _, EthFrame<EthInterpreter>>::new();
+        h.run(self).map(|result| {
+            let state = self.finalize();
+            ExecResultAndState::new(result, state)
+        })
+    }
+}
+
+impl<CTX, INSP, PRECOMPILE> ExecuteCommitEvm
+    for OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILE>
+where
+    CTX: OpContextTr<Db: DatabaseCommit> + ContextSetters,
+    PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
+{
+    fn commit(&mut self, state: Self::State) {
+        self.0.ctx.db_mut().commit(state);
+    }
+}
+
+impl<CTX, INSP, PRECOMPILE> InspectEvm
+    for OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILE>
+where
+    CTX: OpContextTr<Journal: JournalExt> + ContextSetters,
+    INSP: Inspector<CTX, EthInterpreter>,
+    PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
+{
+    type Inspector = INSP;
+
+    fn set_inspector(&mut self, inspector: Self::Inspector) {
+        self.0.inspector = inspector;
+    }
+
+    fn inspect_one_tx(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
+        self.0.ctx.set_tx(tx);
+        let mut h = OpHandler::<_, _, EthFrame<EthInterpreter>>::new();
+        h.inspect_run(self)
+    }
+}
+
+impl<CTX, INSP, PRECOMPILE> InspectCommitEvm
+    for OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILE>
+where
+    CTX: OpContextTr<Journal: JournalExt, Db: DatabaseCommit> + ContextSetters,
+    INSP: Inspector<CTX, EthInterpreter>,
+    PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
+{
+}
+
+impl<CTX, INSP, PRECOMPILE> SystemCallEvm
+    for OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILE>
+where
+    CTX: OpContextTr<Tx: SystemCallTx> + ContextSetters,
+    PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
+{
+    fn system_call_one_with_caller(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Result<Self::ExecutionResult, Self::Error> {
+        self.0.ctx.set_tx(CTX::Tx::new_system_tx_with_caller(
+            caller,
+            system_contract_address,
+            data,
+        ));
+        let mut h = OpHandler::<_, _, EthFrame<EthInterpreter>>::new();
+        h.run_system_call(self)
+    }
+}
+
+impl<CTX, INSP, PRECOMPILE> InspectSystemCallEvm
+    for OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILE>
+where
+    CTX: OpContextTr<Journal: JournalExt, Tx: SystemCallTx> + ContextSetters,
+    INSP: Inspector<CTX, EthInterpreter>,
+    PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
+{
+    fn inspect_one_system_call_with_caller(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Result<Self::ExecutionResult, Self::Error> {
+        self.0.ctx.set_tx(CTX::Tx::new_system_tx_with_caller(
+            caller,
+            system_contract_address,
+            data,
+        ));
+        let mut h = OpHandler::<_, _, EthFrame<EthInterpreter>>::new();
+        h.inspect_run_system_call(self)
+    }
+}

--- a/crates/op/op-revm/src/constants.rs
+++ b/crates/op/op-revm/src/constants.rs
@@ -1,0 +1,70 @@
+//! Optimism constants used in the Optimism EVM.
+use revm::primitives::{Address, U256, address};
+
+/// The cost of a non-zero byte in the EVM.
+pub const NON_ZERO_BYTE_COST: u64 = 16;
+
+/// The two 4-byte Ecotone fee scalar values are packed into the same storage slot as the 8-byte
+/// sequence number. Byte offset within the storage slot of the 4-byte baseFeeScalar attribute.
+pub const BASE_FEE_SCALAR_OFFSET: usize = 16;
+/// The two 4-byte Ecotone fee scalar values are packed into the same storage slot as the 8-byte
+/// sequence number. Byte offset within the storage slot of the 4-byte blobBaseFeeScalar attribute.
+pub const BLOB_BASE_FEE_SCALAR_OFFSET: usize = 20;
+
+/// The Isthmus operator fee scalar values are similarly packed. Byte offset within
+/// the storage slot of the 4-byte operatorFeeScalar attribute.
+pub const OPERATOR_FEE_SCALAR_OFFSET: usize = 20;
+/// The Isthmus operator fee scalar values are similarly packed. Byte offset within
+/// the storage slot of the 8-byte operatorFeeConstant attribute.
+pub const OPERATOR_FEE_CONSTANT_OFFSET: usize = 24;
+
+/// The Jovian daFootprintGasScalar value is packed into a single storage slot. Byte offset within
+/// the storage slot of the 16-byte daFootprintGasScalar attribute.
+pub const DA_FOOTPRINT_GAS_SCALAR_OFFSET: usize = 18;
+
+/// The fixed point decimal scaling factor associated with the operator fee scalar.
+///
+/// Allows users to use 6 decimal points of precision when specifying the `operator_fee_scalar`.
+pub const OPERATOR_FEE_SCALAR_DECIMAL: u64 = 1_000_000;
+
+/// The Jovian multiplier applied to the operator fee scalar component.
+pub const OPERATOR_FEE_JOVIAN_MULTIPLIER: u64 = 100;
+
+/// The L1 base fee slot.
+pub const L1_BASE_FEE_SLOT: U256 = U256::from_limbs([1u64, 0, 0, 0]);
+/// The L1 overhead slot.
+pub const L1_OVERHEAD_SLOT: U256 = U256::from_limbs([5u64, 0, 0, 0]);
+/// The L1 scalar slot.
+pub const L1_SCALAR_SLOT: U256 = U256::from_limbs([6u64, 0, 0, 0]);
+
+/// [`ECOTONE_L1_BLOB_BASE_FEE_SLOT`] was added in the Ecotone upgrade and stores the L1 blobBaseFee
+/// attribute.
+pub const ECOTONE_L1_BLOB_BASE_FEE_SLOT: U256 = U256::from_limbs([7u64, 0, 0, 0]);
+
+/// As of the ecotone upgrade, this storage slot stores the 32-bit basefeeScalar and
+/// blobBaseFeeScalar attributes at offsets [`BASE_FEE_SCALAR_OFFSET`] and
+/// [`BLOB_BASE_FEE_SCALAR_OFFSET`] respectively.
+pub const ECOTONE_L1_FEE_SCALARS_SLOT: U256 = U256::from_limbs([3u64, 0, 0, 0]);
+
+/// This storage slot stores the 32-bit operatorFeeScalar and operatorFeeConstant attributes at
+/// offsets [`OPERATOR_FEE_SCALAR_OFFSET`] and [`OPERATOR_FEE_CONSTANT_OFFSET`] respectively.
+pub const OPERATOR_FEE_SCALARS_SLOT: U256 = U256::from_limbs([8u64, 0, 0, 0]);
+
+/// As of the Jovian upgrade, this storage slot stores the 16-bit daFootprintGasScalar attribute at
+/// offset [`DA_FOOTPRINT_GAS_SCALAR_OFFSET`].
+pub const DA_FOOTPRINT_GAS_SCALAR_SLOT: U256 = U256::from_limbs([8u64, 0, 0, 0]);
+
+/// An empty 64-bit set of scalar values.
+pub const EMPTY_SCALARS: [u8; 8] = [0u8; 8];
+
+/// The address of L1 fee recipient.
+pub const L1_FEE_RECIPIENT: Address = address!("0x420000000000000000000000000000000000001A");
+
+/// The address of the operator fee recipient.
+pub const OPERATOR_FEE_RECIPIENT: Address = address!("0x420000000000000000000000000000000000001B");
+
+/// The address of the base fee recipient.
+pub const BASE_FEE_RECIPIENT: Address = address!("0x4200000000000000000000000000000000000019");
+
+/// The address of the `L1Block` contract.
+pub const L1_BLOCK_CONTRACT: Address = address!("0x4200000000000000000000000000000000000015");

--- a/crates/op/op-revm/src/evm.rs
+++ b/crates/op/op-revm/src/evm.rs
@@ -1,0 +1,163 @@
+//! Contains the `[OpEvm]` type and its implementation of the execution EVM traits.
+use crate::{OpSpecId, precompiles::OpPrecompiles};
+use revm::{
+    Database, Inspector,
+    context::{Cfg, ContextError, ContextSetters, Evm, FrameStack},
+    context_interface::ContextTr,
+    handler::{
+        EthFrame, EvmTr, FrameInitOrResult, ItemOrResult, PrecompileProvider,
+        evm::FrameTr,
+        instructions::{EthInstructions, InstructionProvider},
+    },
+    inspector::{InspectorEvmTr, JournalExt},
+    interpreter::{InterpreterResult, interpreter::EthInterpreter},
+};
+
+/// Optimism EVM extends the [`Evm`] type with Optimism specific types and logic.
+#[derive(Debug, Clone)]
+pub struct OpEvm<
+    CTX,
+    INSP,
+    I = EthInstructions<EthInterpreter, CTX>,
+    P = OpPrecompiles,
+    F = EthFrame<EthInterpreter>,
+>(
+    /// Inner EVM type.
+    pub Evm<CTX, INSP, I, P, F>,
+);
+
+impl<CTX: ContextTr<Cfg: Cfg<Spec: Into<OpSpecId> + Clone>>, INSP>
+    OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, OpPrecompiles>
+{
+    /// Create a new Optimism EVM.
+    pub fn new(ctx: CTX, inspector: INSP) -> Self {
+        let spec: OpSpecId = ctx.cfg().spec().into();
+        Self(Evm {
+            ctx,
+            inspector,
+            instruction: EthInstructions::new_mainnet_with_spec(spec.into()),
+            precompiles: OpPrecompiles::new_with_spec(spec),
+            frame_stack: FrameStack::new_prealloc(8),
+        })
+    }
+
+    /// Consumes self and returns the inner context.
+    pub fn into_context(self) -> CTX {
+        self.0.ctx
+    }
+}
+
+impl<CTX, INSP, I, P> OpEvm<CTX, INSP, I, P> {
+    /// Consumed self and returns a new Evm type with given Inspector.
+    pub fn with_inspector<OINSP>(self, inspector: OINSP) -> OpEvm<CTX, OINSP, I, P> {
+        OpEvm(self.0.with_inspector(inspector))
+    }
+
+    /// Consumes self and returns a new Evm type with given Precompiles.
+    pub fn with_precompiles<OP>(self, precompiles: OP) -> OpEvm<CTX, INSP, I, OP> {
+        OpEvm(self.0.with_precompiles(precompiles))
+    }
+
+    /// Consumes self and returns the inner Inspector.
+    pub fn into_inspector(self) -> INSP {
+        self.0.into_inspector()
+    }
+}
+
+impl<CTX, INSP, I, P> InspectorEvmTr for OpEvm<CTX, INSP, I, P>
+where
+    CTX: ContextTr<Journal: JournalExt> + ContextSetters,
+    I: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
+    P: PrecompileProvider<CTX, Output = InterpreterResult>,
+    INSP: Inspector<CTX, I::InterpreterTypes>,
+{
+    type Inspector = INSP;
+
+    #[inline]
+    fn all_inspector(
+        &self,
+    ) -> (
+        &Self::Context,
+        &Self::Instructions,
+        &Self::Precompiles,
+        &FrameStack<Self::Frame>,
+        &Self::Inspector,
+    ) {
+        self.0.all_inspector()
+    }
+
+    #[inline]
+    fn all_mut_inspector(
+        &mut self,
+    ) -> (
+        &mut Self::Context,
+        &mut Self::Instructions,
+        &mut Self::Precompiles,
+        &mut FrameStack<Self::Frame>,
+        &mut Self::Inspector,
+    ) {
+        self.0.all_mut_inspector()
+    }
+}
+
+impl<CTX, INSP, I, P> EvmTr for OpEvm<CTX, INSP, I, P, EthFrame<EthInterpreter>>
+where
+    CTX: ContextTr,
+    I: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
+    P: PrecompileProvider<CTX, Output = InterpreterResult>,
+{
+    type Context = CTX;
+    type Instructions = I;
+    type Precompiles = P;
+    type Frame = EthFrame<EthInterpreter>;
+
+    #[inline]
+    fn all(
+        &self,
+    ) -> (&Self::Context, &Self::Instructions, &Self::Precompiles, &FrameStack<Self::Frame>) {
+        self.0.all()
+    }
+
+    #[inline]
+    fn all_mut(
+        &mut self,
+    ) -> (
+        &mut Self::Context,
+        &mut Self::Instructions,
+        &mut Self::Precompiles,
+        &mut FrameStack<Self::Frame>,
+    ) {
+        self.0.all_mut()
+    }
+
+    fn frame_init(
+        &mut self,
+        frame_input: <Self::Frame as FrameTr>::FrameInit,
+    ) -> Result<
+        ItemOrResult<&mut Self::Frame, <Self::Frame as FrameTr>::FrameResult>,
+        ContextError<<<Self::Context as ContextTr>::Db as Database>::Error>,
+    > {
+        self.0.frame_init(frame_input)
+    }
+
+    fn frame_run(
+        &mut self,
+    ) -> Result<
+        FrameInitOrResult<Self::Frame>,
+        ContextError<<<Self::Context as ContextTr>::Db as Database>::Error>,
+    > {
+        self.0.frame_run()
+    }
+
+    #[doc = " Returns the result of the frame to the caller. Frame is popped from the frame stack."]
+    #[doc = " Consumes the frame result or returns it if there is more frames to run."]
+    fn frame_return_result(
+        &mut self,
+        result: <Self::Frame as FrameTr>::FrameResult,
+    ) -> Result<
+        Option<<Self::Frame as FrameTr>::FrameResult>,
+        ContextError<<<Self::Context as ContextTr>::Db as Database>::Error>,
+    > {
+        self.0.frame_return_result(result)
+    }
+}

--- a/crates/op/op-revm/src/fast_lz.rs
+++ b/crates/op/op-revm/src/fast_lz.rs
@@ -1,0 +1,97 @@
+//! Contains the `[flz_compress_len]` function.
+
+/// Returns the length of the data after compression through `FastLZ`, based on
+/// <https://github.com/Vectorized/solady/blob/5315d937d79b335c668896d7533ac603adac5315/js/solady.js>
+///
+/// The u32s match op-geth's Go port:
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#L411>
+pub(crate) fn flz_compress_len(input: &[u8]) -> u32 {
+    let mut idx: u32 = 2;
+
+    let idx_limit: u32 = if input.len() < 13 { 0 } else { input.len() as u32 - 13 };
+
+    let mut anchor = 0;
+
+    let mut size = 0;
+
+    let mut htab = [0; 8192];
+
+    while idx < idx_limit {
+        let mut r: u32;
+        let mut distance: u32;
+
+        loop {
+            let seq = u24(input, idx);
+            let hash = hash(seq);
+            r = htab[hash as usize];
+            htab[hash as usize] = idx;
+            distance = idx - r;
+            if idx >= idx_limit {
+                break;
+            }
+            idx += 1;
+            if distance < 8192 && seq == u24(input, r) {
+                break;
+            }
+        }
+
+        if idx >= idx_limit {
+            break;
+        }
+
+        idx -= 1;
+
+        if idx > anchor {
+            size = literals(idx - anchor, size);
+        }
+
+        let len = cmp(input, r + 3, idx + 3, idx_limit + 9);
+        size = flz_match(len, size);
+
+        idx = set_next_hash(&mut htab, input, idx + len);
+        idx = set_next_hash(&mut htab, input, idx);
+        anchor = idx;
+    }
+
+    literals(input.len() as u32 - anchor, size)
+}
+
+const fn literals(r: u32, size: u32) -> u32 {
+    let size = size + 0x21 * (r / 0x20);
+    let r = r % 0x20;
+    if r != 0 { size + r + 1 } else { size }
+}
+
+fn cmp(input: &[u8], p: u32, q: u32, r: u32) -> u32 {
+    let mut l = 0;
+    let mut r = r - q;
+    while l < r {
+        if input[(p + l) as usize] != input[(q + l) as usize] {
+            r = 0;
+        }
+        l += 1;
+    }
+    l
+}
+
+const fn flz_match(l: u32, size: u32) -> u32 {
+    let l = l - 1;
+    let size = size + (3 * (l / 262));
+    if l % 262 >= 6 { size + 3 } else { size + 2 }
+}
+
+fn set_next_hash(htab: &mut [u32; 8192], input: &[u8], idx: u32) -> u32 {
+    htab[hash(u24(input, idx)) as usize] = idx;
+    idx + 1
+}
+
+const fn hash(v: u32) -> u16 {
+    let hash = (v as u64 * 2654435769) >> 19;
+    hash as u16 & 0x1fff
+}
+
+fn u24(input: &[u8], idx: u32) -> u32 {
+    u32::from(input[idx as usize])
+        + (u32::from(input[(idx + 1) as usize]) << 8)
+        + (u32::from(input[(idx + 2) as usize]) << 16)
+}

--- a/crates/op/op-revm/src/handler.rs
+++ b/crates/op/op-revm/src/handler.rs
@@ -1,0 +1,439 @@
+//!Handler related to Optimism chain
+#[cfg(not(feature = "std"))]
+use std::{boxed::Box, vec::Vec};
+
+use crate::{
+    L1BlockInfo, OpHaltReason, OpSpecId,
+    api::exec::OpContextTr,
+    constants::{BASE_FEE_RECIPIENT, L1_FEE_RECIPIENT, OPERATOR_FEE_RECIPIENT},
+    transaction::{OpTransactionError, OpTxTr, deposit::DEPOSIT_TRANSACTION_TYPE},
+};
+use revm::{
+    context::{
+        LocalContextTr,
+        journaled_state::{JournalCheckpoint, account::JournaledAccountTr},
+        result::InvalidTransaction,
+    },
+    context_interface::{
+        Block, Cfg, ContextTr, JournalTr, Transaction,
+        context::take_error,
+        result::{EVMError, ExecutionResult, FromStringError, ResultGas},
+    },
+    handler::{
+        EthFrame, EvmTr, FrameResult, Handler, MainnetHandler,
+        evm::FrameTr,
+        handler::EvmTrError,
+        post_execution::{self, reimburse_caller},
+        pre_execution::{calculate_caller_fee, validate_account_nonce_and_code_with_components},
+    },
+    inspector::{Inspector, InspectorEvmTr, InspectorHandler},
+    interpreter::{Gas, interpreter::EthInterpreter, interpreter_action::FrameInit},
+    primitives::{U256, hardfork::SpecId},
+};
+
+/// Optimism handler extends the [`Handler`] with Optimism specific logic.
+#[derive(Debug, Clone)]
+pub struct OpHandler<EVM, ERROR, FRAME> {
+    /// Mainnet handler allows us to use functions from the mainnet handler inside optimism
+    /// handler. So we dont duplicate the logic
+    pub mainnet: MainnetHandler<EVM, ERROR, FRAME>,
+}
+
+impl<EVM, ERROR, FRAME> OpHandler<EVM, ERROR, FRAME> {
+    /// Create a new Optimism handler.
+    pub fn new() -> Self {
+        Self { mainnet: MainnetHandler::default() }
+    }
+}
+
+impl<EVM, ERROR, FRAME> Default for OpHandler<EVM, ERROR, FRAME> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Trait to check if the error is a transaction error.
+///
+/// Used in `cache_error` handler to catch deposit transaction that was halted.
+pub trait IsTxError {
+    /// Check if the error is a transaction error.
+    fn is_tx_error(&self) -> bool;
+}
+
+impl<DB, TX> IsTxError for EVMError<DB, TX> {
+    fn is_tx_error(&self) -> bool {
+        matches!(self, Self::Transaction(_))
+    }
+}
+
+impl<EVM, ERROR, FRAME> Handler for OpHandler<EVM, ERROR, FRAME>
+where
+    EVM: EvmTr<Context: OpContextTr, Frame = FRAME>,
+    ERROR: EvmTrError<EVM> + From<OpTransactionError> + FromStringError + IsTxError,
+    // TODO `FrameResult` should be a generic trait.
+    // TODO `FrameInit` should be a generic.
+    FRAME: FrameTr<FrameResult = FrameResult, FrameInit = FrameInit>,
+{
+    type Evm = EVM;
+    type Error = ERROR;
+    type HaltReason = OpHaltReason;
+
+    fn validate_env(&self, evm: &mut Self::Evm) -> Result<(), Self::Error> {
+        // Do not perform any extra validation for deposit transactions, they are pre-verified on
+        // L1.
+        let ctx = evm.ctx();
+        let tx = ctx.tx();
+        let tx_type = tx.tx_type();
+        if tx_type == DEPOSIT_TRANSACTION_TYPE {
+            // Do not allow for a system transaction to be processed if Regolith is enabled.
+            if tx.is_system_transaction()
+                && evm.ctx().cfg().spec().is_enabled_in(OpSpecId::REGOLITH)
+            {
+                return Err(OpTransactionError::DepositSystemTxPostRegolith.into());
+            }
+            return Ok(());
+        }
+
+        // Check that non-deposit transactions have enveloped_tx set
+        if tx.enveloped_tx().is_none() {
+            return Err(OpTransactionError::MissingEnvelopedTx.into());
+        }
+
+        self.mainnet.validate_env(evm)
+    }
+
+    fn validate_against_state_and_deduct_caller(
+        &self,
+        evm: &mut Self::Evm,
+        _init_and_floor_gas: &mut revm::interpreter::InitialAndFloorGas,
+    ) -> Result<(), Self::Error> {
+        let (block, tx, cfg, journal, chain, _) = evm.ctx().all_mut();
+        let spec = cfg.spec();
+
+        if tx.tx_type() == DEPOSIT_TRANSACTION_TYPE {
+            let basefee = block.basefee() as u128;
+            let blob_price = block.blob_gasprice().unwrap_or_default();
+            // deposit skips max fee check and just deducts the effective balance spending.
+
+            let mut caller = journal.load_account_with_code_mut(tx.caller())?.data;
+
+            let effective_balance_spending = tx
+                .effective_balance_spending(basefee, blob_price)
+                .expect("Deposit transaction effective balance spending overflow")
+                - tx.value();
+
+            // Mind value should be added first before subtracting the effective balance spending.
+            let mut new_balance = caller
+                .balance()
+                .saturating_add(U256::from(tx.mint().unwrap_or_default()))
+                .saturating_sub(effective_balance_spending);
+
+            if cfg.is_balance_check_disabled() {
+                // Make sure the caller's balance is at least the value of the transaction.
+                // this is not consensus critical, and it is used in testing.
+                new_balance = new_balance.max(tx.value());
+            }
+
+            // set the new balance and bump the nonce if it is a call
+            caller.set_balance(new_balance);
+            if tx.kind().is_call() {
+                caller.bump_nonce();
+            }
+
+            return Ok(());
+        }
+
+        // L1 block info is stored in the context for later use.
+        // and it will be reloaded from the database if it is not for the current block.
+        if chain.l2_block != Some(block.number()) {
+            *chain = L1BlockInfo::try_fetch(journal.db_mut(), block.number(), spec)?;
+        }
+
+        let mut caller_account = journal.load_account_with_code_mut(tx.caller())?.data;
+
+        // validates account nonce and code
+        validate_account_nonce_and_code_with_components(&caller_account.account().info, tx, cfg)?;
+
+        // check additional cost and deduct it from the caller's balances
+        let mut balance = caller_account.account().info.balance;
+
+        if !cfg.is_fee_charge_disabled() {
+            let Some(additional_cost) = chain.tx_cost_with_tx(tx, spec) else {
+                return Err(OpTransactionError::MissingEnvelopedTx.into());
+            };
+            let Some(new_balance) = balance.checked_sub(additional_cost) else {
+                return Err(InvalidTransaction::LackOfFundForMaxFee {
+                    fee: Box::new(additional_cost),
+                    balance: Box::new(balance),
+                }
+                .into());
+            };
+            balance = new_balance
+        }
+
+        let balance = calculate_caller_fee(balance, tx, block, cfg)?;
+
+        // make changes to the account
+        caller_account.set_balance(balance);
+        if tx.kind().is_call() {
+            caller_account.bump_nonce();
+        }
+
+        Ok(())
+    }
+
+    fn last_frame_result(
+        &mut self,
+        evm: &mut Self::Evm,
+        frame_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+    ) -> Result<(), Self::Error> {
+        let ctx = evm.ctx();
+        let tx = ctx.tx();
+        let is_deposit = tx.tx_type() == DEPOSIT_TRANSACTION_TYPE;
+        let tx_gas_limit = tx.gas_limit();
+        let is_regolith = ctx.cfg().spec().is_enabled_in(OpSpecId::REGOLITH);
+
+        let instruction_result = frame_result.interpreter_result().result;
+        let gas = frame_result.gas_mut();
+        let remaining = gas.remaining();
+        let refunded = gas.refunded();
+        let reservoir = gas.reservoir();
+        let state_gas_spent = gas.state_gas_spent();
+
+        // Spend the gas limit. Gas is reimbursed when the tx returns successfully.
+        *gas = Gas::new_spent(tx_gas_limit);
+
+        if instruction_result.is_ok() {
+            // On Optimism, deposit transactions report gas usage uniquely to other
+            // transactions due to them being pre-paid on L1.
+            //
+            // Hardfork Behavior:
+            // - Bedrock (success path):
+            //   - Deposit transactions (non-system) report their gas limit as the usage. No
+            //     refunds.
+            //   - Deposit transactions (system) report 0 gas used. No refunds.
+            //   - Regular transactions report gas usage as normal.
+            // - Regolith (success path):
+            //   - Deposit transactions (all) report their gas used as normal. Refunds enabled.
+            //   - Regular transactions report their gas used as normal.
+            if !is_deposit || is_regolith {
+                // For regular transactions prior to Regolith and all transactions after
+                // Regolith, gas is reported as normal.
+                gas.erase_cost(remaining);
+                gas.record_refund(refunded);
+            } else if is_deposit && tx.is_system_transaction() {
+                // System transactions were a special type of deposit transaction in
+                // the Bedrock hardfork that did not incur any gas costs.
+                gas.erase_cost(tx_gas_limit);
+            }
+        } else if instruction_result.is_revert() {
+            // On Optimism, deposit transactions report gas usage uniquely to other
+            // transactions due to them being pre-paid on L1.
+            //
+            // Hardfork Behavior:
+            // - Bedrock (revert path):
+            //   - Deposit transactions (all) report the gas limit as the amount of gas used on
+            //     failure. No refunds.
+            //   - Regular transactions receive a refund on remaining gas as normal.
+            // - Regolith (revert path):
+            //   - Deposit transactions (all) report the actual gas used as the amount of gas used
+            //     on failure. Refunds on remaining gas enabled.
+            //   - Regular transactions receive a refund on remaining gas as normal.
+            if !is_deposit || is_regolith {
+                gas.erase_cost(remaining);
+            }
+        }
+        gas.set_state_gas_spent(state_gas_spent);
+        gas.set_reservoir(reservoir);
+        Ok(())
+    }
+
+    fn reimburse_caller(
+        &self,
+        evm: &mut Self::Evm,
+        frame_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+    ) -> Result<(), Self::Error> {
+        let additional_refund = if evm.ctx().tx().tx_type() != DEPOSIT_TRANSACTION_TYPE
+            && !evm.ctx().cfg().is_fee_charge_disabled()
+        {
+            let spec = evm.ctx().cfg().spec();
+            evm.ctx().chain().operator_fee_refund(frame_result.gas(), spec)
+        } else {
+            U256::ZERO
+        };
+
+        reimburse_caller(evm.ctx(), frame_result.gas(), additional_refund).map_err(From::from)
+    }
+
+    fn refund(
+        &self,
+        evm: &mut Self::Evm,
+        frame_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+        eip7702_refund: i64,
+    ) {
+        frame_result.gas_mut().record_refund(eip7702_refund);
+
+        let is_deposit = evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE;
+        let is_regolith = evm.ctx().cfg().spec().is_enabled_in(OpSpecId::REGOLITH);
+
+        // Prior to Regolith, deposit transactions did not receive gas refunds.
+        let is_gas_refund_disabled = is_deposit && !is_regolith;
+        if !is_gas_refund_disabled {
+            frame_result.gas_mut().set_final_refund(
+                evm.ctx().cfg().spec().into_eth_spec().is_enabled_in(SpecId::LONDON),
+            );
+        }
+    }
+
+    fn reward_beneficiary(
+        &self,
+        evm: &mut Self::Evm,
+        frame_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+    ) -> Result<(), Self::Error> {
+        let is_deposit = evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE;
+
+        // Transfer fee to coinbase/beneficiary.
+        if is_deposit {
+            return Ok(());
+        }
+
+        self.mainnet.reward_beneficiary(evm, frame_result)?;
+        let basefee = evm.ctx().block().basefee() as u128;
+
+        // If the transaction is not a deposit transaction, fees are paid out
+        // to both the Base Fee Vault as well as the L1 Fee Vault.
+        // Use all_mut() to simultaneously borrow tx (immutable) and chain (mutable),
+        // avoiding an unnecessary clone of the enveloped transaction bytes.
+        let (_, tx, cfg, journal, l1_block_info, _) = evm.ctx().all_mut();
+        let spec = cfg.spec();
+
+        let Some(enveloped_tx) = tx.enveloped_tx() else {
+            return Err(OpTransactionError::MissingEnvelopedTx.into());
+        };
+
+        let l1_cost = l1_block_info.calculate_tx_l1_cost(enveloped_tx, spec);
+        let effective_used =
+            frame_result.gas().used().saturating_sub(frame_result.gas().reservoir());
+        let operator_fee_cost = if spec.is_enabled_in(OpSpecId::ISTHMUS) {
+            l1_block_info.operator_fee_charge(enveloped_tx, U256::from(effective_used), spec)
+        } else {
+            U256::ZERO
+        };
+        let base_fee_amount = U256::from(basefee.saturating_mul(effective_used as u128));
+
+        // Send fees to their respective recipients
+        for (recipient, amount) in [
+            (L1_FEE_RECIPIENT, l1_cost),
+            (BASE_FEE_RECIPIENT, base_fee_amount),
+            (OPERATOR_FEE_RECIPIENT, operator_fee_cost),
+        ] {
+            journal.balance_incr(recipient, amount)?;
+        }
+
+        Ok(())
+    }
+
+    fn execution_result(
+        &mut self,
+        evm: &mut Self::Evm,
+        frame_result: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+        result_gas: ResultGas,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        take_error::<Self::Error, _>(evm.ctx().error())?;
+
+        let exec_result = post_execution::output(evm.ctx(), frame_result, result_gas)
+            .map_haltreason(OpHaltReason::Base);
+
+        if exec_result.is_halt() {
+            // Post-regolith, if the transaction is a deposit transaction and it halts,
+            // we bubble up to the global return handler. The mint value will be persisted
+            // and the caller nonce will be incremented there.
+            let is_deposit = evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE;
+            if is_deposit && evm.ctx().cfg().spec().is_enabled_in(OpSpecId::REGOLITH) {
+                return Err(ERROR::from(OpTransactionError::HaltedDepositPostRegolith));
+            }
+        }
+        evm.ctx().journal_mut().commit_tx();
+        evm.ctx().chain_mut().clear_tx_l1_cost();
+        evm.ctx().local_mut().clear();
+        evm.frame_stack().clear();
+
+        Ok(exec_result)
+    }
+
+    fn catch_error(
+        &self,
+        evm: &mut Self::Evm,
+        error: Self::Error,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        let is_deposit = evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE;
+        let is_tx_error = error.is_tx_error();
+        let mut output = Err(error);
+
+        // Deposit transaction can't fail so we manually handle it here.
+        if is_tx_error && is_deposit {
+            let ctx = evm.ctx();
+            let spec = ctx.cfg().spec();
+            let tx = ctx.tx();
+            let caller = tx.caller();
+            let mint = tx.mint();
+            let is_system_tx = tx.is_system_transaction();
+            let gas_limit = tx.gas_limit();
+            let journal = evm.ctx().journal_mut();
+
+            // discard all changes of this transaction
+            // Default JournalCheckpoint is the first checkpoint and will wipe all changes.
+            journal.checkpoint_revert(JournalCheckpoint::default());
+
+            // If the transaction is a deposit transaction and it failed
+            // for any reason, the caller nonce must be bumped, and the
+            // gas reported must be altered depending on the Hardfork. This is
+            // also returned as a special Halt variant so that consumers can more
+            // easily distinguish between a failed deposit and a failed
+            // normal transaction.
+
+            // Increment sender nonce and account balance for the mint amount. Deposits
+            // always persist the mint amount, even if the transaction fails.
+            let mut acc = journal.load_account_mut(caller)?;
+            acc.bump_nonce();
+            acc.incr_balance(U256::from(mint.unwrap_or_default()));
+
+            drop(acc); // Drop acc to avoid borrow checker issues.
+
+            // We can now commit the changes.
+            journal.commit_tx();
+
+            // The gas used of a failed deposit post-regolith is the gas
+            // limit of the transaction. pre-regolith, it is the gas limit
+            // of the transaction for non system transactions and 0 for system
+            // transactions.
+            let gas_used =
+                if spec.is_enabled_in(OpSpecId::REGOLITH) || !is_system_tx { gas_limit } else { 0 };
+            // clear the journal
+            output = Ok(ExecutionResult::Halt {
+                reason: OpHaltReason::FailedDeposit,
+                gas: ResultGas::default().with_total_gas_spent(gas_used),
+                logs: Vec::new(),
+            })
+        }
+
+        // do the cleanup
+        evm.ctx().chain_mut().clear_tx_l1_cost();
+        evm.ctx().local_mut().clear();
+        evm.frame_stack().clear();
+
+        output
+    }
+}
+
+impl<EVM, ERROR> InspectorHandler for OpHandler<EVM, ERROR, EthFrame<EthInterpreter>>
+where
+    EVM: InspectorEvmTr<
+            Context: OpContextTr,
+            Frame = EthFrame<EthInterpreter>,
+            Inspector: Inspector<<<Self as Handler>::Evm as EvmTr>::Context, EthInterpreter>,
+        >,
+    ERROR: EvmTrError<EVM> + From<OpTransactionError> + FromStringError + IsTxError,
+{
+    type IT = EthInterpreter;
+}

--- a/crates/op/op-revm/src/l1block.rs
+++ b/crates/op/op-revm/src/l1block.rs
@@ -1,0 +1,368 @@
+//! Contains the `[L1BlockInfo]` type and its implementation.
+use crate::{
+    OpSpecId,
+    constants::{
+        BASE_FEE_SCALAR_OFFSET, BLOB_BASE_FEE_SCALAR_OFFSET, DA_FOOTPRINT_GAS_SCALAR_OFFSET,
+        DA_FOOTPRINT_GAS_SCALAR_SLOT, ECOTONE_L1_BLOB_BASE_FEE_SLOT, ECOTONE_L1_FEE_SCALARS_SLOT,
+        EMPTY_SCALARS, L1_BASE_FEE_SLOT, L1_BLOCK_CONTRACT, L1_OVERHEAD_SLOT, L1_SCALAR_SLOT,
+        NON_ZERO_BYTE_COST, OPERATOR_FEE_CONSTANT_OFFSET, OPERATOR_FEE_JOVIAN_MULTIPLIER,
+        OPERATOR_FEE_SCALAR_DECIMAL, OPERATOR_FEE_SCALAR_OFFSET, OPERATOR_FEE_SCALARS_SLOT,
+    },
+    transaction::{OpTxTr, estimate_tx_compressed_size},
+};
+use revm::{
+    context_interface::cfg::gas::{NON_ZERO_BYTE_MULTIPLIER_ISTANBUL, STANDARD_TOKEN_COST},
+    database_interface::Database,
+    interpreter::{Gas, gas::get_tokens_in_calldata_istanbul},
+    primitives::U256,
+};
+
+/// L1 block info
+///
+/// We can extract L1 epoch data from each L2 block, by looking at the `setL1BlockValues`
+/// transaction data. This data is then used to calculate the L1 cost of a transaction.
+///
+/// Here is the format of the `setL1BlockValues` transaction data:
+///
+/// setL1BlockValues(uint64 _number, uint64 _timestamp, uint256 _basefee, bytes32 _hash,
+/// uint64 _sequenceNumber, bytes32 _batcherHash, uint256 _l1FeeOverhead, uint256 _l1FeeScalar)
+///
+/// For now, we only care about the fields necessary for L1 cost calculation.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct L1BlockInfo {
+    /// The L2 block number. If not same as the one in the context,
+    /// `L1BlockInfo` is not valid and will be reloaded from the database.
+    pub l2_block: Option<U256>,
+    /// The base fee of the L1 origin block.
+    pub l1_base_fee: U256,
+    /// The current L1 fee overhead. None if Ecotone is activated.
+    pub l1_fee_overhead: Option<U256>,
+    /// The current L1 fee scalar.
+    pub l1_base_fee_scalar: U256,
+    /// The current L1 blob base fee. None if Ecotone is not activated, except if
+    /// `empty_ecotone_scalars` is `true`.
+    pub l1_blob_base_fee: Option<U256>,
+    /// The current L1 blob base fee scalar. None if Ecotone is not activated.
+    pub l1_blob_base_fee_scalar: Option<U256>,
+    /// The operator fee scalar. None if Isthmus is not activated.
+    pub operator_fee_scalar: Option<U256>,
+    /// The operator fee constant. None if Isthmus is not activated.
+    pub operator_fee_constant: Option<U256>,
+    /// Da footprint gas scalar. Used to set the DA footprint block limit on the L2. Always null
+    /// prior to the Jovian hardfork.
+    pub da_footprint_gas_scalar: Option<u16>,
+    /// True if Ecotone is activated, but the L1 fee scalars have not yet been set.
+    pub empty_ecotone_scalars: bool,
+    /// Last calculated l1 fee cost. Uses as a cache between validation and pre execution stages.
+    pub tx_l1_cost: Option<U256>,
+}
+
+impl L1BlockInfo {
+    /// Fetch the DA footprint gas scalar from the database.
+    pub fn fetch_da_footprint_gas_scalar<DB: Database>(db: &mut DB) -> Result<u16, DB::Error> {
+        let da_footprint_gas_scalar_slot =
+            db.storage(L1_BLOCK_CONTRACT, DA_FOOTPRINT_GAS_SCALAR_SLOT)?.to_be_bytes::<32>();
+
+        // Extract the first 2 bytes directly as a u16 in big-endian format
+        let bytes = [
+            da_footprint_gas_scalar_slot[DA_FOOTPRINT_GAS_SCALAR_OFFSET],
+            da_footprint_gas_scalar_slot[DA_FOOTPRINT_GAS_SCALAR_OFFSET + 1],
+        ];
+        Ok(u16::from_be_bytes(bytes))
+    }
+
+    /// Try to fetch the L1 block info from the database, post-Jovian.
+    fn try_fetch_jovian<DB: Database>(&mut self, db: &mut DB) -> Result<(), DB::Error> {
+        self.da_footprint_gas_scalar = Some(Self::fetch_da_footprint_gas_scalar(db)?);
+
+        Ok(())
+    }
+
+    /// Try to fetch the L1 block info from the database, post-Isthmus.
+    fn try_fetch_isthmus<DB: Database>(&mut self, db: &mut DB) -> Result<(), DB::Error> {
+        // Post-isthmus L1 block info
+        let operator_fee_scalars =
+            db.storage(L1_BLOCK_CONTRACT, OPERATOR_FEE_SCALARS_SLOT)?.to_be_bytes::<32>();
+
+        // The `operator_fee_scalar` is stored as a big endian u32 at
+        // OPERATOR_FEE_SCALAR_OFFSET.
+        self.operator_fee_scalar = Some(U256::from_be_slice(
+            operator_fee_scalars[OPERATOR_FEE_SCALAR_OFFSET..OPERATOR_FEE_SCALAR_OFFSET + 4]
+                .as_ref(),
+        ));
+        // The `operator_fee_constant` is stored as a big endian u64 at
+        // OPERATOR_FEE_CONSTANT_OFFSET.
+        self.operator_fee_constant = Some(U256::from_be_slice(
+            operator_fee_scalars[OPERATOR_FEE_CONSTANT_OFFSET..OPERATOR_FEE_CONSTANT_OFFSET + 8]
+                .as_ref(),
+        ));
+
+        Ok(())
+    }
+
+    /// Try to fetch the L1 block info from the database, post-Ecotone.
+    fn try_fetch_ecotone<DB: Database>(&mut self, db: &mut DB) -> Result<(), DB::Error> {
+        self.l1_blob_base_fee = Some(db.storage(L1_BLOCK_CONTRACT, ECOTONE_L1_BLOB_BASE_FEE_SLOT)?);
+
+        let l1_fee_scalars =
+            db.storage(L1_BLOCK_CONTRACT, ECOTONE_L1_FEE_SCALARS_SLOT)?.to_be_bytes::<32>();
+
+        self.l1_base_fee_scalar = U256::from_be_slice(
+            l1_fee_scalars[BASE_FEE_SCALAR_OFFSET..BASE_FEE_SCALAR_OFFSET + 4].as_ref(),
+        );
+
+        let l1_blob_base_fee = U256::from_be_slice(
+            l1_fee_scalars[BLOB_BASE_FEE_SCALAR_OFFSET..BLOB_BASE_FEE_SCALAR_OFFSET + 4].as_ref(),
+        );
+        self.l1_blob_base_fee_scalar = Some(l1_blob_base_fee);
+
+        // Check if the L1 fee scalars are empty. If so, we use the Bedrock cost function.
+        // The L1 fee overhead is only necessary if `empty_ecotone_scalars` is true, as it was
+        // deprecated in Ecotone.
+        self.empty_ecotone_scalars = l1_blob_base_fee.is_zero()
+            && l1_fee_scalars[BASE_FEE_SCALAR_OFFSET..BLOB_BASE_FEE_SCALAR_OFFSET + 4]
+                == EMPTY_SCALARS;
+        self.l1_fee_overhead = self
+            .empty_ecotone_scalars
+            .then(|| db.storage(L1_BLOCK_CONTRACT, L1_OVERHEAD_SLOT))
+            .transpose()?;
+
+        Ok(())
+    }
+
+    /// Try to fetch the L1 block info from the database.
+    pub fn try_fetch<DB: Database>(
+        db: &mut DB,
+        l2_block: U256,
+        spec_id: OpSpecId,
+    ) -> Result<Self, DB::Error> {
+        // Ensure the L1 Block account is loaded into the cache.
+        let _ = db.basic(L1_BLOCK_CONTRACT)?;
+
+        let mut out = Self {
+            l2_block: Some(l2_block),
+            l1_base_fee: db.storage(L1_BLOCK_CONTRACT, L1_BASE_FEE_SLOT)?,
+            ..Default::default()
+        };
+
+        // Post-Ecotone
+        if !spec_id.is_enabled_in(OpSpecId::ECOTONE) {
+            out.l1_base_fee_scalar = db.storage(L1_BLOCK_CONTRACT, L1_SCALAR_SLOT)?;
+            out.l1_fee_overhead = Some(db.storage(L1_BLOCK_CONTRACT, L1_OVERHEAD_SLOT)?);
+
+            return Ok(out);
+        }
+
+        out.try_fetch_ecotone(db)?;
+
+        // Post-Isthmus L1 block info
+        if spec_id.is_enabled_in(OpSpecId::ISTHMUS) {
+            out.try_fetch_isthmus(db)?;
+        }
+
+        // Pre-Jovian
+        if spec_id.is_enabled_in(OpSpecId::JOVIAN) {
+            out.try_fetch_jovian(db)?;
+        }
+
+        Ok(out)
+    }
+
+    /// Calculate the operator fee for executing this transaction.
+    ///
+    /// Introduced in isthmus. Prior to isthmus, the operator fee is always zero.
+    pub fn operator_fee_charge(&self, input: &[u8], gas_limit: U256, spec_id: OpSpecId) -> U256 {
+        // If the input is a deposit transaction or empty, the default value is zero.
+        if input.is_empty() || input.first() == Some(&0x7E) {
+            return U256::ZERO;
+        }
+
+        self.operator_fee_charge_inner(gas_limit, spec_id)
+    }
+
+    /// Calculate the operator fee for the given `gas`.
+    fn operator_fee_charge_inner(&self, gas: U256, spec_id: OpSpecId) -> U256 {
+        let operator_fee_scalar =
+            self.operator_fee_scalar.expect("Missing operator fee scalar for isthmus L1 Block");
+        let operator_fee_constant =
+            self.operator_fee_constant.expect("Missing operator fee constant for isthmus L1 Block");
+
+        let product = if spec_id.is_enabled_in(OpSpecId::JOVIAN) {
+            gas.saturating_mul(operator_fee_scalar)
+                .saturating_mul(U256::from(OPERATOR_FEE_JOVIAN_MULTIPLIER))
+        } else {
+            gas.saturating_mul(operator_fee_scalar) / U256::from(OPERATOR_FEE_SCALAR_DECIMAL)
+        };
+
+        product.saturating_add(operator_fee_constant)
+    }
+
+    /// Calculate the operator fee for executing this transaction.
+    ///
+    /// Introduced in isthmus. Prior to isthmus, the operator fee is always zero.
+    pub fn operator_fee_refund(&self, gas: &Gas, spec_id: OpSpecId) -> U256 {
+        if !spec_id.is_enabled_in(OpSpecId::ISTHMUS) {
+            return U256::ZERO;
+        }
+
+        let operator_cost_gas_limit =
+            self.operator_fee_charge_inner(U256::from(gas.limit()), spec_id);
+        let operator_cost_gas_used = self.operator_fee_charge_inner(
+            U256::from(gas.limit() - (gas.remaining() + gas.refunded() as u64)),
+            spec_id,
+        );
+
+        operator_cost_gas_limit.saturating_sub(operator_cost_gas_used)
+    }
+
+    /// Calculate the data gas for posting the transaction on L1. Calldata costs 16 gas per byte
+    /// after compression.
+    ///
+    /// Prior to fjord, calldata costs 16 gas per non-zero byte and 4 gas per zero byte.
+    ///
+    /// Prior to regolith, an extra 68 non-zero bytes were included in the rollup data costs to
+    /// account for the empty signature.
+    pub fn data_gas(&self, input: &[u8], spec_id: OpSpecId) -> U256 {
+        if spec_id.is_enabled_in(OpSpecId::FJORD) {
+            let estimated_size = self.tx_estimated_size_fjord(input);
+
+            return estimated_size
+                .saturating_mul(U256::from(NON_ZERO_BYTE_COST))
+                .wrapping_div(U256::from(1_000_000));
+        };
+
+        // tokens in calldata where non-zero bytes are priced 4 times higher than zero bytes (Same
+        // as in Istanbul).
+        let mut tokens_in_transaction_data = get_tokens_in_calldata_istanbul(input);
+
+        // Prior to regolith, an extra 68 non zero bytes were included in the rollup data costs.
+        if !spec_id.is_enabled_in(OpSpecId::REGOLITH) {
+            tokens_in_transaction_data += 68 * NON_ZERO_BYTE_MULTIPLIER_ISTANBUL;
+        }
+
+        U256::from(tokens_in_transaction_data.saturating_mul(STANDARD_TOKEN_COST))
+    }
+
+    // Calculate the estimated compressed transaction size in bytes, scaled by 1e6.
+    // This value is computed based on the following formula:
+    // max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
+    fn tx_estimated_size_fjord(&self, input: &[u8]) -> U256 {
+        U256::from(estimate_tx_compressed_size(input))
+    }
+
+    /// Clears the cached L1 cost of the transaction.
+    pub const fn clear_tx_l1_cost(&mut self) {
+        self.tx_l1_cost = None;
+    }
+
+    /// Calculate additional transaction cost with `OpTxTr`.
+    ///
+    /// Internally calls [`L1BlockInfo::tx_cost`].
+    pub fn tx_cost_with_tx(&mut self, tx: impl OpTxTr, spec: OpSpecId) -> Option<U256> {
+        // account for additional cost of l1 fee and operator fee
+        let enveloped_tx = tx.enveloped_tx()?;
+        let gas_limit = U256::from(tx.gas_limit());
+        Some(self.tx_cost(enveloped_tx, gas_limit, spec))
+    }
+
+    /// Calculate additional transaction cost.
+    #[inline]
+    pub fn tx_cost(&mut self, enveloped_tx: &[u8], gas_limit: U256, spec: OpSpecId) -> U256 {
+        // compute L1 cost
+        let mut additional_cost = self.calculate_tx_l1_cost(enveloped_tx, spec);
+
+        // compute operator fee
+        if spec.is_enabled_in(OpSpecId::ISTHMUS) {
+            let operator_fee_charge = self.operator_fee_charge(enveloped_tx, gas_limit, spec);
+            additional_cost = additional_cost.saturating_add(operator_fee_charge);
+        }
+
+        additional_cost
+    }
+
+    /// Calculate the gas cost of a transaction based on L1 block data posted on L2, depending on
+    /// the [`OpSpecId`] passed.
+    pub fn calculate_tx_l1_cost(&mut self, input: &[u8], spec_id: OpSpecId) -> U256 {
+        if let Some(tx_l1_cost) = self.tx_l1_cost {
+            return tx_l1_cost;
+        }
+        // If the input is a deposit transaction or empty, the default value is zero.
+        let tx_l1_cost = if input.is_empty() || input.first() == Some(&0x7E) {
+            return U256::ZERO;
+        } else if spec_id.is_enabled_in(OpSpecId::FJORD) {
+            self.calculate_tx_l1_cost_fjord(input)
+        } else if spec_id.is_enabled_in(OpSpecId::ECOTONE) {
+            self.calculate_tx_l1_cost_ecotone(input, spec_id)
+        } else {
+            self.calculate_tx_l1_cost_bedrock(input, spec_id)
+        };
+
+        self.tx_l1_cost = Some(tx_l1_cost);
+        tx_l1_cost
+    }
+
+    /// Calculate the gas cost of a transaction based on L1 block data posted on L2, pre-Ecotone.
+    fn calculate_tx_l1_cost_bedrock(&self, input: &[u8], spec_id: OpSpecId) -> U256 {
+        let rollup_data_gas_cost = self.data_gas(input, spec_id);
+        rollup_data_gas_cost
+            .saturating_add(self.l1_fee_overhead.unwrap_or_default())
+            .saturating_mul(self.l1_base_fee)
+            .saturating_mul(self.l1_base_fee_scalar)
+            .wrapping_div(U256::from(1_000_000))
+    }
+
+    /// Calculate the gas cost of a transaction based on L1 block data posted on L2, post-Ecotone.
+    ///
+    /// [`OpSpecId::ECOTONE`] L1 cost function:
+    /// `(calldataGas/16)*(l1BaseFee*16*l1BaseFeeScalar + l1BlobBaseFee*l1BlobBaseFeeScalar)/1e6`
+    ///
+    /// We divide "calldataGas" by 16 to change from units of calldata gas to "estimated # of bytes
+    /// when compressed". Known as "compressedTxSize" in the spec.
+    ///
+    /// Function is actually computed as follows for better precision under integer arithmetic:
+    /// `calldataGas*(l1BaseFee*16*l1BaseFeeScalar + l1BlobBaseFee*l1BlobBaseFeeScalar)/16e6`
+    fn calculate_tx_l1_cost_ecotone(&self, input: &[u8], spec_id: OpSpecId) -> U256 {
+        // There is an edgecase where, for the very first Ecotone block (unless it is activated at
+        // Genesis), we must use the Bedrock cost function. To determine if this is the
+        // case, we can check if the Ecotone parameters are unset.
+        if self.empty_ecotone_scalars {
+            return self.calculate_tx_l1_cost_bedrock(input, spec_id);
+        }
+
+        let rollup_data_gas_cost = self.data_gas(input, spec_id);
+        let l1_fee_scaled = self.calculate_l1_fee_scaled_ecotone();
+
+        l1_fee_scaled
+            .saturating_mul(rollup_data_gas_cost)
+            .wrapping_div(U256::from(1_000_000 * NON_ZERO_BYTE_COST))
+    }
+
+    /// Calculate the gas cost of a transaction based on L1 block data posted on L2, post-Fjord.
+    ///
+    /// [`OpSpecId::FJORD`] L1 cost function:
+    /// `estimatedSize*(baseFeeScalar*l1BaseFee*16 + blobFeeScalar*l1BlobBaseFee)/1e12`
+    fn calculate_tx_l1_cost_fjord(&self, input: &[u8]) -> U256 {
+        let l1_fee_scaled = self.calculate_l1_fee_scaled_ecotone();
+        if l1_fee_scaled.is_zero() {
+            return U256::ZERO;
+        }
+
+        let estimated_size = self.tx_estimated_size_fjord(input);
+
+        estimated_size.saturating_mul(l1_fee_scaled).wrapping_div(U256::from(1_000_000_000_000u64))
+    }
+
+    // l1BaseFee*16*l1BaseFeeScalar + l1BlobBaseFee*l1BlobBaseFeeScalar
+    fn calculate_l1_fee_scaled_ecotone(&self) -> U256 {
+        let calldata_cost_per_byte = self
+            .l1_base_fee
+            .saturating_mul(U256::from(NON_ZERO_BYTE_COST))
+            .saturating_mul(self.l1_base_fee_scalar);
+        let blob_cost_per_byte = self
+            .l1_blob_base_fee
+            .unwrap_or_default()
+            .saturating_mul(self.l1_blob_base_fee_scalar.unwrap_or_default());
+
+        calldata_cost_per_byte.saturating_add(blob_cost_per_byte)
+    }
+}

--- a/crates/op/op-revm/src/lib.rs
+++ b/crates/op/op-revm/src/lib.rs
@@ -1,0 +1,29 @@
+//! Optimism-specific constants, types, and helpers.
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc as std;
+
+pub mod api;
+pub mod constants;
+pub mod evm;
+pub mod fast_lz;
+pub mod handler;
+pub mod l1block;
+pub mod precompiles;
+pub mod result;
+pub mod spec;
+pub mod transaction;
+
+pub use revm;
+
+pub use api::{
+    builder::OpBuilder,
+    default_ctx::{DefaultOp, OpContext},
+};
+pub use evm::OpEvm;
+pub use l1block::L1BlockInfo;
+pub use result::OpHaltReason;
+pub use spec::*;
+pub use transaction::{OpTransaction, error::OpTransactionError, estimate_tx_compressed_size};

--- a/crates/op/op-revm/src/precompiles.rs
+++ b/crates/op/op-revm/src/precompiles.rs
@@ -1,0 +1,327 @@
+//! Contains Optimism specific precompiles.
+#[cfg(not(feature = "std"))]
+use std::{boxed::Box, string::String};
+
+use crate::OpSpecId;
+use revm::{
+    context::Cfg,
+    context_interface::ContextTr,
+    handler::{EthPrecompiles, PrecompileProvider},
+    interpreter::{CallInputs, InterpreterResult},
+    precompile::{
+        self, EthPrecompileResult, Precompile, PrecompileHalt, PrecompileId, Precompiles, bn254,
+        eth_precompile_fn, secp256r1,
+    },
+    primitives::{Address, OnceLock, hardfork::SpecId},
+};
+
+/// Optimism precompile provider
+#[derive(Debug, Clone)]
+pub struct OpPrecompiles {
+    /// Inner precompile provider is same as Ethereums.
+    inner: EthPrecompiles,
+    /// Spec id of the precompile provider.
+    spec: OpSpecId,
+}
+
+impl OpPrecompiles {
+    /// Create a new precompile provider with the given `OpSpec`.
+    #[inline]
+    pub fn new_with_spec(spec: OpSpecId) -> Self {
+        let precompiles = match spec {
+            spec @ (OpSpecId::BEDROCK
+            | OpSpecId::REGOLITH
+            | OpSpecId::CANYON
+            | OpSpecId::ECOTONE) => Precompiles::new(spec.into_eth_spec().into()),
+            OpSpecId::FJORD => fjord(),
+            OpSpecId::GRANITE | OpSpecId::HOLOCENE => granite(),
+            OpSpecId::ISTHMUS => isthmus(),
+            OpSpecId::INTEROP | OpSpecId::KARST | OpSpecId::JOVIAN => jovian(),
+        };
+
+        Self { inner: EthPrecompiles { precompiles, spec: SpecId::default() }, spec }
+    }
+
+    /// Precompiles getter.
+    #[inline]
+    pub const fn precompiles(&self) -> &'static Precompiles {
+        self.inner.precompiles
+    }
+}
+
+/// Returns precompiles for Fjord spec.
+pub fn fjord() -> &'static Precompiles {
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+    INSTANCE.get_or_init(|| {
+        let mut precompiles = Precompiles::cancun().clone();
+        // RIP-7212: secp256r1 P256verify
+        precompiles.extend([secp256r1::P256VERIFY]);
+        precompiles
+    })
+}
+
+/// Returns precompiles for Granite spec.
+pub fn granite() -> &'static Precompiles {
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+    INSTANCE.get_or_init(|| {
+        let mut precompiles = fjord().clone();
+        // Restrict bn254Pairing input size
+        precompiles.extend([bn254_pair::GRANITE]);
+        precompiles
+    })
+}
+
+/// Returns precompiles for isthmus spec.
+pub fn isthmus() -> &'static Precompiles {
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+    INSTANCE.get_or_init(|| {
+        let mut precompiles = granite().clone();
+        // Prague bls12 precompiles
+        precompiles.extend(precompile::bls12_381::precompiles());
+        // Isthmus bls12 precompile modifications
+        precompiles.extend([
+            bls12_381::ISTHMUS_G1_MSM,
+            bls12_381::ISTHMUS_G2_MSM,
+            bls12_381::ISTHMUS_PAIRING,
+        ]);
+        precompiles
+    })
+}
+
+/// Returns precompiles for jovian spec.
+pub fn jovian() -> &'static Precompiles {
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+    INSTANCE.get_or_init(|| {
+        let mut precompiles = isthmus().clone();
+
+        let mut to_remove = Precompiles::default();
+        to_remove.extend([
+            bn254::pair::ISTANBUL,
+            bls12_381::ISTHMUS_G1_MSM,
+            bls12_381::ISTHMUS_G2_MSM,
+            bls12_381::ISTHMUS_PAIRING,
+        ]);
+
+        // Replace the 4 variable-input precompiles with Jovian versions (reduced limits)
+        precompiles.difference(&to_remove);
+
+        precompiles.extend([
+            bn254_pair::JOVIAN,
+            bls12_381::JOVIAN_G1_MSM,
+            bls12_381::JOVIAN_G2_MSM,
+            bls12_381::JOVIAN_PAIRING,
+        ]);
+
+        precompiles
+    })
+}
+
+impl<CTX> PrecompileProvider<CTX> for OpPrecompiles
+where
+    CTX: ContextTr<Cfg: Cfg<Spec = OpSpecId>>,
+{
+    type Output = InterpreterResult;
+
+    #[inline]
+    fn set_spec(&mut self, spec: <CTX::Cfg as Cfg>::Spec) -> bool {
+        if spec == self.spec {
+            return false;
+        }
+        *self = Self::new_with_spec(spec);
+        true
+    }
+
+    #[inline]
+    fn run(
+        &mut self,
+        context: &mut CTX,
+        inputs: &CallInputs,
+    ) -> Result<Option<Self::Output>, String> {
+        self.inner.run(context, inputs)
+    }
+
+    #[inline]
+    fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
+        self.inner.warm_addresses()
+    }
+
+    #[inline]
+    fn contains(&self, address: &Address) -> bool {
+        self.inner.contains(address)
+    }
+}
+
+impl Default for OpPrecompiles {
+    fn default() -> Self {
+        Self::new_with_spec(OpSpecId::JOVIAN)
+    }
+}
+
+/// Bn254 pair precompile.
+pub mod bn254_pair {
+    use super::*;
+
+    /// Max input size for the bn254 pair precompile.
+    pub const GRANITE_MAX_INPUT_SIZE: usize = 112687;
+
+    /// Run the bn254 pair precompile with Optimism input limit.
+    pub fn run_pair_granite(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
+        if input.len() > GRANITE_MAX_INPUT_SIZE {
+            return Err(PrecompileHalt::Bn254PairLength);
+        }
+        bn254::run_pair(
+            input,
+            bn254::pair::ISTANBUL_PAIR_PER_POINT,
+            bn254::pair::ISTANBUL_PAIR_BASE,
+            gas_limit,
+        )
+    }
+
+    eth_precompile_fn!(run_pair_granite_wrapper, run_pair_granite);
+
+    /// Bn254 pair precompile.
+    pub const GRANITE: Precompile =
+        Precompile::new(PrecompileId::Bn254Pairing, bn254::pair::ADDRESS, run_pair_granite_wrapper);
+
+    /// Max input size for the bn254 pair precompile.
+    pub const JOVIAN_MAX_INPUT_SIZE: usize = 81_984;
+
+    /// Run the bn254 pair precompile with Optimism input limit.
+    pub fn run_pair_jovian(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
+        if input.len() > JOVIAN_MAX_INPUT_SIZE {
+            return Err(PrecompileHalt::Bn254PairLength);
+        }
+        bn254::run_pair(
+            input,
+            bn254::pair::ISTANBUL_PAIR_PER_POINT,
+            bn254::pair::ISTANBUL_PAIR_BASE,
+            gas_limit,
+        )
+    }
+
+    eth_precompile_fn!(run_pair_jovian_wrapper, run_pair_jovian);
+
+    /// Bn254 pair precompile.
+    pub const JOVIAN: Precompile =
+        Precompile::new(PrecompileId::Bn254Pairing, bn254::pair::ADDRESS, run_pair_jovian_wrapper);
+}
+
+/// `Bls12_381` precompile.
+pub mod bls12_381 {
+    use super::*;
+    use revm::precompile::bls12_381_const::{G1_MSM_ADDRESS, G2_MSM_ADDRESS, PAIRING_ADDRESS};
+
+    /// Max input size for the g1 msm precompile.
+    pub const ISTHMUS_G1_MSM_MAX_INPUT_SIZE: usize = 513760;
+
+    /// The maximum input size for the BLS12-381 g1 msm operation after the Jovian Hardfork.
+    pub const JOVIAN_G1_MSM_MAX_INPUT_SIZE: usize = 288_960;
+
+    /// Max input size for the g2 msm precompile.
+    pub const ISTHMUS_G2_MSM_MAX_INPUT_SIZE: usize = 488448;
+
+    /// Max input size for the g2 msm precompile after the Jovian Hardfork.
+    pub const JOVIAN_G2_MSM_MAX_INPUT_SIZE: usize = 278_784;
+
+    /// Max input size for the pairing precompile.
+    pub const ISTHMUS_PAIRING_MAX_INPUT_SIZE: usize = 235008;
+
+    /// Max input size for the pairing precompile after the Jovian Hardfork.
+    pub const JOVIAN_PAIRING_MAX_INPUT_SIZE: usize = 156_672;
+
+    /// Run the g1 msm precompile with Optimism input limit.
+    pub fn run_g1_msm_isthmus(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
+        if input.len() > ISTHMUS_G1_MSM_MAX_INPUT_SIZE {
+            return Err(PrecompileHalt::Other(
+                "G1MSM input length too long for OP Stack input size limitation after the Isthmus Hardfork".into(),
+            ));
+        }
+        precompile::bls12_381::g1_msm::g1_msm(input, gas_limit)
+    }
+
+    eth_precompile_fn!(run_g1_msm_isthmus_wrapper, run_g1_msm_isthmus);
+
+    /// G1 msm precompile.
+    pub const ISTHMUS_G1_MSM: Precompile =
+        Precompile::new(PrecompileId::Bls12G1Msm, G1_MSM_ADDRESS, run_g1_msm_isthmus_wrapper);
+
+    /// Run the g1 msm precompile with Optimism input limit.
+    pub fn run_g1_msm_jovian(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
+        if input.len() > JOVIAN_G1_MSM_MAX_INPUT_SIZE {
+            return Err(PrecompileHalt::Other(
+                "G1MSM input length too long for OP Stack input size limitation after the Jovian Hardfork".into(),
+            ));
+        }
+        precompile::bls12_381::g1_msm::g1_msm(input, gas_limit)
+    }
+
+    eth_precompile_fn!(run_g1_msm_jovian_wrapper, run_g1_msm_jovian);
+
+    /// G1 msm precompile after the Jovian Hardfork.
+    pub const JOVIAN_G1_MSM: Precompile =
+        Precompile::new(PrecompileId::Bls12G1Msm, G1_MSM_ADDRESS, run_g1_msm_jovian_wrapper);
+
+    /// Run the g2 msm precompile with Optimism input limit.
+    pub fn run_g2_msm_isthmus(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
+        if input.len() > ISTHMUS_G2_MSM_MAX_INPUT_SIZE {
+            return Err(PrecompileHalt::Other(
+                "G2MSM input length too long for OP Stack input size limitation".into(),
+            ));
+        }
+        precompile::bls12_381::g2_msm::g2_msm(input, gas_limit)
+    }
+
+    eth_precompile_fn!(run_g2_msm_isthmus_wrapper, run_g2_msm_isthmus);
+
+    /// G2 msm precompile.
+    pub const ISTHMUS_G2_MSM: Precompile =
+        Precompile::new(PrecompileId::Bls12G2Msm, G2_MSM_ADDRESS, run_g2_msm_isthmus_wrapper);
+
+    /// Run the g2 msm precompile with Optimism input limit after the Jovian Hardfork.
+    pub fn run_g2_msm_jovian(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
+        if input.len() > JOVIAN_G2_MSM_MAX_INPUT_SIZE {
+            return Err(PrecompileHalt::Other(
+                "G2MSM input length too long for OP Stack input size limitation after the Jovian Hardfork".into(),
+            ));
+        }
+        precompile::bls12_381::g2_msm::g2_msm(input, gas_limit)
+    }
+
+    eth_precompile_fn!(run_g2_msm_jovian_wrapper, run_g2_msm_jovian);
+
+    /// G2 msm precompile after the Jovian Hardfork.
+    pub const JOVIAN_G2_MSM: Precompile =
+        Precompile::new(PrecompileId::Bls12G2Msm, G2_MSM_ADDRESS, run_g2_msm_jovian_wrapper);
+
+    /// Run the pairing precompile with Optimism input limit.
+    pub fn run_pair_isthmus(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
+        if input.len() > ISTHMUS_PAIRING_MAX_INPUT_SIZE {
+            return Err(PrecompileHalt::Other(
+                "Pairing input length too long for OP Stack input size limitation".into(),
+            ));
+        }
+        precompile::bls12_381::pairing::pairing(input, gas_limit)
+    }
+
+    eth_precompile_fn!(run_pair_isthmus_wrapper, run_pair_isthmus);
+
+    /// Pairing precompile.
+    pub const ISTHMUS_PAIRING: Precompile =
+        Precompile::new(PrecompileId::Bls12Pairing, PAIRING_ADDRESS, run_pair_isthmus_wrapper);
+
+    /// Run the pairing precompile with Optimism input limit after the Jovian Hardfork.
+    pub fn run_pair_jovian(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
+        if input.len() > JOVIAN_PAIRING_MAX_INPUT_SIZE {
+            return Err(PrecompileHalt::Other(
+                "Pairing input length too long for OP Stack input size limitation after the Jovian Hardfork".into(),
+            ));
+        }
+        precompile::bls12_381::pairing::pairing(input, gas_limit)
+    }
+
+    eth_precompile_fn!(run_pair_jovian_wrapper, run_pair_jovian);
+
+    /// Pairing precompile after the Jovian Hardfork.
+    pub const JOVIAN_PAIRING: Precompile =
+        Precompile::new(PrecompileId::Bls12Pairing, PAIRING_ADDRESS, run_pair_jovian_wrapper);
+}

--- a/crates/op/op-revm/src/result.rs
+++ b/crates/op/op-revm/src/result.rs
@@ -1,0 +1,29 @@
+//! Contains the `[OpHaltReason]` type.
+use revm::context_interface::result::HaltReason;
+
+/// Optimism halt reason.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum OpHaltReason {
+    /// Base halt reason.
+    Base(HaltReason),
+    /// Failed deposit halt reason.
+    FailedDeposit,
+}
+
+impl From<HaltReason> for OpHaltReason {
+    fn from(value: HaltReason) -> Self {
+        Self::Base(value)
+    }
+}
+
+impl TryFrom<OpHaltReason> for HaltReason {
+    type Error = OpHaltReason;
+
+    fn try_from(value: OpHaltReason) -> Result<Self, OpHaltReason> {
+        match value {
+            OpHaltReason::Base(reason) => Ok(reason),
+            OpHaltReason::FailedDeposit => Err(value),
+        }
+    }
+}

--- a/crates/op/op-revm/src/spec.rs
+++ b/crates/op/op-revm/src/spec.rs
@@ -1,0 +1,123 @@
+//! Contains the `[OpSpecId]` type and its implementation.
+use core::str::FromStr;
+use revm::primitives::hardfork::{SpecId, UnknownHardfork};
+
+/// Optimism spec id.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[allow(non_camel_case_types)]
+pub enum OpSpecId {
+    /// Bedrock spec id.
+    BEDROCK = 100,
+    /// Regolith spec id.
+    REGOLITH,
+    /// Canyon spec id.
+    CANYON,
+    /// Ecotone spec id.
+    ECOTONE,
+    /// Fjord spec id.
+    FJORD,
+    /// Granite spec id.
+    GRANITE,
+    /// Holocene spec id.
+    HOLOCENE,
+    /// Isthmus spec id.
+    ISTHMUS,
+    /// Jovian spec id.
+    #[default]
+    JOVIAN,
+    /// Karst spec id.
+    KARST,
+    /// Interop spec id.
+    INTEROP,
+}
+
+impl OpSpecId {
+    /// Converts the [`OpSpecId`] into a [`SpecId`].
+    pub const fn into_eth_spec(self) -> SpecId {
+        match self {
+            Self::BEDROCK | Self::REGOLITH => SpecId::MERGE,
+            Self::CANYON => SpecId::SHANGHAI,
+            Self::ECOTONE | Self::FJORD | Self::GRANITE | Self::HOLOCENE => SpecId::CANCUN,
+            Self::ISTHMUS | Self::JOVIAN | Self::INTEROP => SpecId::PRAGUE,
+            Self::KARST => SpecId::OSAKA,
+        }
+    }
+
+    /// Checks if the [`OpSpecId`] is enabled in the other [`OpSpecId`].
+    pub const fn is_enabled_in(self, other: Self) -> bool {
+        other as u8 <= self as u8
+    }
+}
+
+impl From<OpSpecId> for SpecId {
+    fn from(spec: OpSpecId) -> Self {
+        spec.into_eth_spec()
+    }
+}
+
+impl FromStr for OpSpecId {
+    type Err = UnknownHardfork;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            name::BEDROCK => Ok(Self::BEDROCK),
+            name::REGOLITH => Ok(Self::REGOLITH),
+            name::CANYON => Ok(Self::CANYON),
+            name::ECOTONE => Ok(Self::ECOTONE),
+            name::FJORD => Ok(Self::FJORD),
+            name::GRANITE => Ok(Self::GRANITE),
+            name::HOLOCENE => Ok(Self::HOLOCENE),
+            name::ISTHMUS => Ok(Self::ISTHMUS),
+            name::JOVIAN => Ok(Self::JOVIAN),
+            name::KARST => Ok(Self::KARST),
+            name::INTEROP => Ok(Self::INTEROP),
+            _ => Err(UnknownHardfork),
+        }
+    }
+}
+
+impl From<OpSpecId> for &'static str {
+    fn from(spec_id: OpSpecId) -> Self {
+        match spec_id {
+            OpSpecId::BEDROCK => name::BEDROCK,
+            OpSpecId::REGOLITH => name::REGOLITH,
+            OpSpecId::CANYON => name::CANYON,
+            OpSpecId::ECOTONE => name::ECOTONE,
+            OpSpecId::FJORD => name::FJORD,
+            OpSpecId::GRANITE => name::GRANITE,
+            OpSpecId::HOLOCENE => name::HOLOCENE,
+            OpSpecId::ISTHMUS => name::ISTHMUS,
+            OpSpecId::JOVIAN => name::JOVIAN,
+            OpSpecId::KARST => name::KARST,
+            OpSpecId::INTEROP => name::INTEROP,
+        }
+    }
+}
+
+/// String identifiers for Optimism hardforks
+pub mod name {
+    /// Bedrock spec name.
+    pub const BEDROCK: &str = "Bedrock";
+    /// Regolith spec name.
+    pub const REGOLITH: &str = "Regolith";
+    /// Canyon spec name.
+    pub const CANYON: &str = "Canyon";
+    /// Ecotone spec name.
+    pub const ECOTONE: &str = "Ecotone";
+    /// Fjord spec name.
+    pub const FJORD: &str = "Fjord";
+    /// Granite spec name.
+    pub const GRANITE: &str = "Granite";
+    /// Holocene spec name.
+    pub const HOLOCENE: &str = "Holocene";
+    /// Isthmus spec name.
+    pub const ISTHMUS: &str = "Isthmus";
+    /// Jovian spec name.
+    pub const JOVIAN: &str = "Jovian";
+    /// Karst spec name.
+    pub const KARST: &str = "Karst";
+    /// Interop spec name.
+    pub const INTEROP: &str = "Interop";
+}

--- a/crates/op/op-revm/src/transaction.rs
+++ b/crates/op/op-revm/src/transaction.rs
@@ -1,0 +1,29 @@
+//! Contains the `[OpTransaction]` type and its implementation.
+pub mod abstraction;
+pub mod deposit;
+pub mod error;
+
+pub use abstraction::{OpTransaction, OpTxTr};
+pub use error::OpTransactionError;
+
+use crate::fast_lz::flz_compress_len;
+
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#L79>
+const L1_COST_FASTLZ_COEF: u64 = 836_500;
+
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#L78>
+/// Inverted to be used with `saturating_sub`.
+const L1_COST_INTERCEPT: u64 = 42_585_600;
+
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#82>
+const MIN_TX_SIZE_SCALED: u64 = 100 * 1_000_000;
+
+/// Estimates the compressed size of a transaction.
+pub fn estimate_tx_compressed_size(input: &[u8]) -> u64 {
+    let fastlz_size = flz_compress_len(input) as u64;
+
+    fastlz_size
+        .saturating_mul(L1_COST_FASTLZ_COEF)
+        .saturating_sub(L1_COST_INTERCEPT)
+        .max(MIN_TX_SIZE_SCALED)
+}

--- a/crates/op/op-revm/src/transaction/abstraction.rs
+++ b/crates/op/op-revm/src/transaction/abstraction.rs
@@ -1,0 +1,194 @@
+//! Optimism transaction abstraction containing the `[OpTxTr]` trait and corresponding
+//! `[OpTransaction]` type.
+use super::deposit::{DEPOSIT_TRANSACTION_TYPE, DepositTransactionParts};
+use auto_impl::auto_impl;
+use revm::{
+    context::TxEnv,
+    context_interface::transaction::Transaction,
+    handler::SystemCallTx,
+    primitives::{Address, B256, Bytes, TxKind, U256},
+};
+
+/// Optimism Transaction trait.
+#[auto_impl(&, &mut, Box, Arc)]
+pub trait OpTxTr: Transaction {
+    /// Enveloped transaction bytes.
+    fn enveloped_tx(&self) -> Option<&Bytes>;
+
+    /// Source hash of the deposit transaction.
+    fn source_hash(&self) -> Option<B256>;
+
+    /// Mint of the deposit transaction
+    fn mint(&self) -> Option<u128>;
+
+    /// Whether the transaction is a system transaction
+    fn is_system_transaction(&self) -> bool;
+
+    /// Returns `true` if transaction is of type [`DEPOSIT_TRANSACTION_TYPE`].
+    fn is_deposit(&self) -> bool {
+        self.tx_type() == DEPOSIT_TRANSACTION_TYPE
+    }
+}
+
+/// Optimism transaction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct OpTransaction<T: Transaction> {
+    /// Base transaction fields.
+    pub base: T,
+    /// An enveloped EIP-2718 typed transaction
+    ///
+    /// This is used to compute the L1 tx cost using the L1 block info, as
+    /// opposed to requiring downstream apps to compute the cost
+    /// externally.
+    pub enveloped_tx: Option<Bytes>,
+    /// Deposit transaction parts.
+    pub deposit: DepositTransactionParts,
+}
+
+impl<T: Transaction> AsRef<T> for OpTransaction<T> {
+    fn as_ref(&self) -> &T {
+        &self.base
+    }
+}
+
+impl<T: Transaction> OpTransaction<T> {
+    /// Create a new Optimism transaction.
+    pub fn new(base: T) -> Self {
+        Self { base, enveloped_tx: None, deposit: DepositTransactionParts::default() }
+    }
+}
+
+impl Default for OpTransaction<TxEnv> {
+    fn default() -> Self {
+        Self {
+            base: TxEnv::default(),
+            enveloped_tx: Some(std::vec![0x00].into()),
+            deposit: DepositTransactionParts::default(),
+        }
+    }
+}
+
+impl<TX: Transaction + SystemCallTx> SystemCallTx for OpTransaction<TX> {
+    fn new_system_tx_with_caller(
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Self {
+        let mut tx =
+            Self::new(TX::new_system_tx_with_caller(caller, system_contract_address, data));
+
+        tx.enveloped_tx = Some(Bytes::default());
+
+        tx
+    }
+}
+
+impl<T: Transaction> Transaction for OpTransaction<T> {
+    type AccessListItem<'a>
+        = T::AccessListItem<'a>
+    where
+        T: 'a;
+    type Authorization<'a>
+        = T::Authorization<'a>
+    where
+        T: 'a;
+
+    fn tx_type(&self) -> u8 {
+        // If this is a deposit transaction (has source_hash set), return deposit type
+        if self.deposit.source_hash == B256::ZERO {
+            self.base.tx_type()
+        } else {
+            DEPOSIT_TRANSACTION_TYPE
+        }
+    }
+
+    fn caller(&self) -> Address {
+        self.base.caller()
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.base.gas_limit()
+    }
+
+    fn value(&self) -> U256 {
+        self.base.value()
+    }
+
+    fn input(&self) -> &Bytes {
+        self.base.input()
+    }
+
+    fn nonce(&self) -> u64 {
+        self.base.nonce()
+    }
+
+    fn kind(&self) -> TxKind {
+        self.base.kind()
+    }
+
+    fn chain_id(&self) -> Option<u64> {
+        self.base.chain_id()
+    }
+
+    fn access_list(&self) -> Option<impl Iterator<Item = Self::AccessListItem<'_>>> {
+        self.base.access_list()
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        self.base.max_priority_fee_per_gas()
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        self.base.max_fee_per_gas()
+    }
+
+    fn gas_price(&self) -> u128 {
+        self.base.gas_price()
+    }
+
+    fn blob_versioned_hashes(&self) -> &[B256] {
+        self.base.blob_versioned_hashes()
+    }
+
+    fn max_fee_per_blob_gas(&self) -> u128 {
+        self.base.max_fee_per_blob_gas()
+    }
+
+    fn effective_gas_price(&self, base_fee: u128) -> u128 {
+        // Deposit transactions use gas_price directly
+        if self.tx_type() == DEPOSIT_TRANSACTION_TYPE {
+            return self.gas_price();
+        }
+        self.base.effective_gas_price(base_fee)
+    }
+
+    fn authorization_list_len(&self) -> usize {
+        self.base.authorization_list_len()
+    }
+
+    fn authorization_list(&self) -> impl Iterator<Item = Self::Authorization<'_>> {
+        self.base.authorization_list()
+    }
+}
+
+impl<T: Transaction> OpTxTr for OpTransaction<T> {
+    fn enveloped_tx(&self) -> Option<&Bytes> {
+        self.enveloped_tx.as_ref()
+    }
+
+    fn source_hash(&self) -> Option<B256> {
+        if self.tx_type() != DEPOSIT_TRANSACTION_TYPE {
+            return None;
+        }
+        Some(self.deposit.source_hash)
+    }
+
+    fn mint(&self) -> Option<u128> {
+        self.deposit.mint
+    }
+
+    fn is_system_transaction(&self) -> bool {
+        self.deposit.is_system_transaction
+    }
+}

--- a/crates/op/op-revm/src/transaction/deposit.rs
+++ b/crates/op/op-revm/src/transaction/deposit.rs
@@ -1,0 +1,24 @@
+//! Contains Deposit transaction parts.
+use revm::primitives::B256;
+
+/// Deposit transaction type.
+pub const DEPOSIT_TRANSACTION_TYPE: u8 = 0x7E;
+
+/// Deposit transaction parts.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DepositTransactionParts {
+    /// Source hash of the deposit transaction.
+    pub source_hash: B256,
+    /// Minted value of the deposit transaction.
+    pub mint: Option<u128>,
+    /// Whether the transaction is a system transaction.
+    pub is_system_transaction: bool,
+}
+
+impl DepositTransactionParts {
+    /// Create a new deposit transaction parts.
+    pub const fn new(source_hash: B256, mint: Option<u128>, is_system_transaction: bool) -> Self {
+        Self { source_hash, mint, is_system_transaction }
+    }
+}

--- a/crates/op/op-revm/src/transaction/error.rs
+++ b/crates/op/op-revm/src/transaction/error.rs
@@ -1,0 +1,88 @@
+//! Contains the `[OpTransactionError]` type.
+use core::fmt::Display;
+use revm::context_interface::{
+    result::{EVMError, InvalidTransaction},
+    transaction::TransactionError,
+};
+
+/// Optimism transaction validation error.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum OpTransactionError {
+    /// Base transaction error.
+    Base(InvalidTransaction),
+    /// System transactions are not supported post-regolith hardfork.
+    ///
+    /// Before the Regolith hardfork, there was a special field in the `Deposit` transaction
+    /// type that differentiated between `system` and `user` deposit transactions. This field
+    /// was deprecated in the Regolith hardfork, and this error is thrown if a `Deposit` transaction
+    /// is found with this field set to `true` after the hardfork activation.
+    ///
+    /// In addition, this error is internal, and bubbles up into an
+    /// [`OpHaltReason::FailedDeposit`][crate::OpHaltReason::FailedDeposit] error in the `revm`
+    /// handler for the consumer to easily handle. This is due to a state transition rule on OP
+    /// Stack chains where, if for any reason a deposit transaction fails, the transaction
+    /// must still be included in the block, the sender nonce is bumped, the `mint` value persists,
+    /// and special gas accounting rules are applied. Normally on L1, [`EVMError::Transaction`]
+    /// errors are cause for non-inclusion, so a special [`OpHaltReason`][crate::OpHaltReason]
+    /// variant was introduced to handle this case for failed deposit transactions.
+    DepositSystemTxPostRegolith,
+    /// Deposit transaction halts bubble up to the global main return handler, wiping state and
+    /// only increasing the nonce + persisting the mint value.
+    ///
+    /// This is a catch-all error for any deposit transaction that results in an
+    /// [`OpHaltReason`][crate::OpHaltReason] error post-regolith hardfork. This allows for a
+    /// consumer to easily handle special cases where a deposit transaction fails during
+    /// validation, but must still be included in the block.
+    ///
+    /// In addition, this error is internal, and bubbles up into an
+    /// [`OpHaltReason::FailedDeposit`][crate::OpHaltReason::FailedDeposit] error in the `revm`
+    /// handler for the consumer to easily handle. This is due to a state transition rule on OP
+    /// Stack chains where, if for any reason a deposit transaction fails, the transaction
+    /// must still be included in the block, the sender nonce is bumped, the `mint` value persists,
+    /// and special gas accounting rules are applied. Normally on L1, [`EVMError::Transaction`]
+    /// errors are cause for non-inclusion, so a special [`OpHaltReason`][crate::OpHaltReason]
+    /// variant was introduced to handle this case for failed deposit transactions.
+    HaltedDepositPostRegolith,
+    /// Missing enveloped transaction bytes for non-deposit transaction.
+    ///
+    /// Non-deposit transactions on Optimism must have `enveloped_tx` field set
+    /// to properly calculate L1 costs.
+    MissingEnvelopedTx,
+}
+
+impl TransactionError for OpTransactionError {}
+
+impl Display for OpTransactionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Base(error) => error.fmt(f),
+            Self::DepositSystemTxPostRegolith => {
+                write!(f, "deposit system transactions post regolith hardfork are not supported")
+            }
+            Self::HaltedDepositPostRegolith => {
+                write!(
+                    f,
+                    "deposit transaction halted post-regolith; error will be bubbled up to main return handler"
+                )
+            }
+            Self::MissingEnvelopedTx => {
+                write!(f, "missing enveloped transaction bytes for non-deposit transaction")
+            }
+        }
+    }
+}
+
+impl core::error::Error for OpTransactionError {}
+
+impl From<InvalidTransaction> for OpTransactionError {
+    fn from(value: InvalidTransaction) -> Self {
+        Self::Base(value)
+    }
+}
+
+impl<DBError> From<OpTransactionError> for EVMError<DBError, OpTransactionError> {
+    fn from(value: OpTransactionError) -> Self {
+        Self::Transaction(value)
+    }
+}


### PR DESCRIPTION
Extract op-alloy-consensus, op-alloy-network, op-alloy-rpc-types, alloy-op-evm, alloy-op-hardforks, and op-revm from upstream into foundry-core.