### PR TITLE
fix: make release dry-run side-effect free

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -60,7 +60,7 @@ esac
 # 1. Dry-run cargo release (always, as a sanity check)
 echo "==> Next: cargo release dry-run"
 confirm
-cargo release "$VERSION" "${PACKAGES[@]}" --no-push
+cargo release "$VERSION" "${PACKAGES[@]}" --no-push --no-tag
 
 # 2. Semver-checks
 echo "==> Next: semver-checks"


### PR DESCRIPTION
Adds `--no-tag` to the dry-run `cargo release` command so it doesn't check for or create tags. This prevents false errors when a tag already exists from a previous release.