### PR TITLE
chore: inline compilers inter-crate deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,9 +167,6 @@ uuid = { version = "1.19.0", features = ["v4", "serde"] }
 walkdir = "2.5"
 yansi = "1.0"
 
-# crates
-foundry-compilers = { path = "crates/compilers/crates/compilers" }
-foundry-compilers-artifacts = { path = "crates/compilers/crates/artifacts/artifacts" }
-foundry-compilers-artifacts-solc = { path = "crates/compilers/crates/artifacts/solc" }
-foundry-compilers-artifacts-vyper = { path = "crates/compilers/crates/artifacts/vyper" }
-foundry-compilers-core = { path = "crates/compilers/crates/core" }
+# cross-group crate dependencies
+foundry-compilers = { version = "0.19.14", path = "crates/compilers/crates/compilers" }
+

--- a/crates/compilers/crates/artifacts/artifacts/Cargo.toml
+++ b/crates/compilers/crates/artifacts/artifacts/Cargo.toml
@@ -14,8 +14,8 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-foundry-compilers-artifacts-solc.workspace = true
-foundry-compilers-artifacts-vyper.workspace = true
+foundry-compilers-artifacts-solc = { version = "0.19.14", path = "../solc" }
+foundry-compilers-artifacts-vyper = { version = "0.19.14", path = "../vyper" }
 
 [features]
 async = ["foundry-compilers-artifacts-solc/async"]

--- a/crates/compilers/crates/artifacts/solc/Cargo.toml
+++ b/crates/compilers/crates/artifacts/solc/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-foundry-compilers-core.workspace = true
+foundry-compilers-core = { version = "0.19.14", path = "../../core" }
 
 alloy-json-abi.workspace = true
 alloy-primitives.workspace = true
@@ -40,7 +40,7 @@ path-slash.workspace = true
 [dev-dependencies]
 serde_path_to_error = "0.1"
 similar-asserts.workspace = true
-foundry-compilers-core = { workspace = true, features = ["test-utils"] }
+foundry-compilers-core = { version = "0.19.14", path = "../../core", features = ["test-utils"] }
 
 [features]
 async = ["dep:tokio", "dep:futures-util"]

--- a/crates/compilers/crates/artifacts/vyper/Cargo.toml
+++ b/crates/compilers/crates/artifacts/vyper/Cargo.toml
@@ -14,8 +14,8 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-foundry-compilers-artifacts-solc.workspace = true
-foundry-compilers-core.workspace = true
+foundry-compilers-artifacts-solc = { version = "0.19.14", path = "../solc" }
+foundry-compilers-core = { version = "0.19.14", path = "../../core" }
 
 serde.workspace = true
 alloy-primitives.workspace = true
@@ -23,5 +23,5 @@ alloy-json-abi.workspace = true
 semver.workspace = true
 
 [dev-dependencies]
-foundry-compilers-core = { workspace = true, features = ["test-utils"] }
+foundry-compilers-core = { version = "0.19.14", path = "../../core", features = ["test-utils"] }
 serde_json.workspace = true

--- a/crates/compilers/crates/compilers/Cargo.toml
+++ b/crates/compilers/crates/compilers/Cargo.toml
@@ -14,12 +14,12 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-foundry-compilers-artifacts = { workspace = true, features = [
+foundry-compilers-artifacts = { version = "0.19.14", path = "../artifacts/artifacts", features = [
     "checksum",
     "walkdir",
     "rayon",
 ] }
-foundry-compilers-core = { workspace = true, features = ["hasher", "regex"] }
+foundry-compilers-core = { version = "0.19.14", path = "../core", features = ["hasher", "regex"] }
 serde.workspace = true
 semver.workspace = true
 alloy-primitives.workspace = true
@@ -61,7 +61,7 @@ tokio = { version = "1.47", features = ["rt-multi-thread", "macros"] }
 reqwest = { workspace = true }
 tempfile = "3.20"
 snapbox.workspace = true
-foundry-compilers-core = { workspace = true, features = ["test-utils"] }
+foundry-compilers-core = { version = "0.19.14", path = "../core", features = ["test-utils"] }
 
 [features]
 default = ["rustls"]


### PR DESCRIPTION
Move internal compilers inter-crate dependencies from workspace `Cargo.toml` to inline `version + path` in each sub-crate's `Cargo.toml`.

This decouples the compilers group's versioning from the workspace root, since each crate group versions independently. Only the cross-group dependency (`foundry-compilers` used by `block-explorers`) remains as a workspace dep.