### PR TITLE
ci: add nightly tests workflow

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+[test-groups]
+
+[profile.default]
+retries = { backoff = "exponential", count = 2, delay = "5s", jitter = true }
+slow-timeout = { period = "30s", terminate-after = 3 }
+default-filter = "not test(/external_/)"

--- a/.github/NIGHTLY_TEST_FAILURE_TEMPLATE.md
+++ b/.github/NIGHTLY_TEST_FAILURE_TEMPLATE.md
@@ -1,0 +1,10 @@
+---
+title: "bug: nightly tests workflow failed"
+labels: P-normal, T-bug
+---
+
+The nightly tests workflow has failed. This indicates external API rate limiting, RPC reliability issues, or other intermittent failures that may affect users.
+
+Check the [nightly tests workflow page]({{ env.WORKFLOW_URL }}) for details.
+
+This issue was raised by the workflow at `.github/workflows/test-nightly.yml`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,15 +101,7 @@ jobs:
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: test
-        shell: bash
-        run: |
-          args="--workspace ${{ matrix.flags }} --retries 2"
-          if [ -z "$ETHERSCAN_API_KEY" ]; then
-            args="$args --exclude foundry-block-explorers"
-          fi
-          cargo nextest run $args
-        env:
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+        run: cargo nextest run --workspace ${{ matrix.flags }}
 
   doctest:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,12 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: test
         shell: bash
-        run: cargo nextest run --workspace ${{ matrix.flags }} --retries 2
+        run: |
+          args="--workspace ${{ matrix.flags }} --retries 2"
+          if [ -z "$ETHERSCAN_API_KEY" ]; then
+            args="$args --exclude foundry-block-explorers"
+          fi
+          cargo nextest run $args
         env:
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
 

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Test
         env:
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-        run: cargo nextest run --workspace --all-features --no-fail-fast
+        run: cargo nextest run --workspace --all-features --no-fail-fast --ignore-default-filter
 
   issue:
     name: Open an issue

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -1,0 +1,62 @@
+name: nightly
+
+permissions: {}
+
+on:
+  schedule:
+    - cron: "0 2 * * *" # Run daily at 2 AM UTC
+  workflow_dispatch: # Needed so we can run it manually
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+  RUSTC_WRAPPER: "sccache"
+
+jobs:
+  test:
+    name: nightly tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@cf39a74df4a72510be4e5b63348d61067f11e64a # v2.75.0
+        with:
+          tool: nextest
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Test
+        env:
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+        run: cargo nextest run --workspace --all-features --no-fail-fast
+
+  issue:
+    name: Open an issue
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: failure()
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_URL: |
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: .github/NIGHTLY_TEST_FAILURE_TEMPLATE.md

--- a/crates/explorers/block-explorers/tests/it/account.rs
+++ b/crates/explorers/block-explorers/tests/it/account.rs
@@ -11,7 +11,7 @@ use serial_test::serial;
 
 #[tokio::test]
 #[serial]
-async fn get_ether_balance_single_success() {
+async fn external_get_ether_balance_single_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let balance = client
             .get_ether_balance_single(
@@ -26,7 +26,7 @@ async fn get_ether_balance_single_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_ether_balance_multi_success() {
+async fn external_get_ether_balance_multi_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let balances = client
             .get_ether_balance_multi(
@@ -43,7 +43,7 @@ async fn get_ether_balance_multi_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_transactions_success() {
+async fn external_get_transactions_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let txs = client
             .get_transactions(&"0x4F26FfBe5F04ED43630fdC30A87638d53D0b0876".parse().unwrap(), None)
@@ -55,7 +55,7 @@ async fn get_transactions_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_internal_transactions_success() {
+async fn external_get_internal_transactions_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let txs = client
             .get_internal_transactions(
@@ -72,7 +72,7 @@ async fn get_internal_transactions_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_internal_transactions_by_tx_hash_success() {
+async fn external_get_internal_transactions_by_tx_hash_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let txs = client
             .get_internal_transactions(
@@ -91,7 +91,7 @@ async fn get_internal_transactions_by_tx_hash_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_erc20_transfer_events_success() {
+async fn external_get_erc20_transfer_events_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let txs = client
             .get_erc20_token_transfer_events(
@@ -112,7 +112,7 @@ async fn get_erc20_transfer_events_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_erc721_transfer_events_success() {
+async fn external_get_erc721_transfer_events_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let txs = client
             .get_erc721_token_transfer_events(
@@ -130,7 +130,7 @@ async fn get_erc721_transfer_events_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_erc1155_transfer_events_success() {
+async fn external_get_erc1155_transfer_events_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let txs = client
             .get_erc1155_token_transfer_events(
@@ -148,7 +148,7 @@ async fn get_erc1155_transfer_events_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_mined_blocks_success() {
+async fn external_get_mined_blocks_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         client
             .get_mined_blocks(
@@ -164,7 +164,7 @@ async fn get_mined_blocks_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_avalanche_transactions() {
+async fn external_get_avalanche_transactions() {
     run_with_client(Chain::from_named(NamedChain::Avalanche), |client| async move {
         let txs = client
             .get_transactions(&"0x1549ea9b546ba9ffb306d78a1e1f304760cc4abf".parse().unwrap(), None)
@@ -176,7 +176,7 @@ async fn get_avalanche_transactions() {
 
 #[tokio::test]
 #[serial]
-async fn get_etherscan_polygon_key_v2() {
+async fn external_get_etherscan_polygon_key_v2() {
     // This requires the etherscan api key to be set – expected for this test suite.
     let etherscan_test_api_key = env::var("ETHERSCAN_API_KEY").unwrap();
     // SAFETY: This test runs serially and no other threads access this env var.
@@ -193,7 +193,7 @@ async fn get_etherscan_polygon_key_v2() {
 
 #[tokio::test]
 #[serial]
-async fn get_sonic_transactions() {
+async fn external_get_sonic_transactions() {
     run_with_client(Chain::from_named(NamedChain::Sonic), |client| async move {
         let txs = client
             .get_transactions(&"0x1549ea9b546ba9ffb306d78a1e1f304760cc4abf".parse().unwrap(), None)

--- a/crates/explorers/block-explorers/tests/it/blocks.rs
+++ b/crates/explorers/block-explorers/tests/it/blocks.rs
@@ -5,7 +5,7 @@ use serial_test::serial;
 
 #[tokio::test]
 #[serial]
-async fn check_get_block_by_timestamp_before() {
+async fn external_check_get_block_by_timestamp_before() {
     run_with_client(Chain::mainnet(), |client| async move {
         let block_no = client.get_block_by_timestamp(1577836800, "before").await;
         assert!(block_no.is_ok());
@@ -18,7 +18,7 @@ async fn check_get_block_by_timestamp_before() {
 
 #[tokio::test]
 #[serial]
-async fn check_get_block_by_timestamp_after() {
+async fn external_check_get_block_by_timestamp_after() {
     run_with_client(Chain::mainnet(), |client| async move {
         let block_no = client.get_block_by_timestamp(1577836800, "after").await;
 

--- a/crates/explorers/block-explorers/tests/it/contract.rs
+++ b/crates/explorers/block-explorers/tests/it/contract.rs
@@ -10,7 +10,7 @@ const DEPOSIT_CONTRACT_ABI: &str = include!("../../test-data/deposit_contract.ex
 #[ignore]
 #[tokio::test]
 #[serial]
-async fn can_fetch_ftm_contract_abi() {
+async fn external_can_fetch_ftm_contract_abi() {
     run_with_client(Chain::from_named(NamedChain::Fantom), |client| async move {
         let _abi = client
             .contract_abi("0x80AA7cb0006d5DDD91cce684229Ac6e398864606".parse().unwrap())
@@ -22,7 +22,7 @@ async fn can_fetch_ftm_contract_abi() {
 
 #[tokio::test]
 #[serial]
-async fn can_fetch_contract_abi() {
+async fn external_can_fetch_contract_abi() {
     run_with_client(Chain::mainnet(), |client| async move {
         let abi = client
             .contract_abi("0x00000000219ab540356cBB839Cbe05303d7705Fa".parse().unwrap())
@@ -35,7 +35,7 @@ async fn can_fetch_contract_abi() {
 
 #[tokio::test]
 #[serial]
-async fn can_fetch_and_cache_contract_abi() {
+async fn external_can_fetch_and_cache_contract_abi() {
     async fn fetch_abi(client: &Client, addr: &str) {
         let abi = client.contract_abi(addr.parse().unwrap()).await.unwrap();
         assert_eq!(abi, serde_json::from_str(DEPOSIT_CONTRACT_ABI).unwrap());
@@ -55,7 +55,7 @@ async fn can_fetch_and_cache_contract_abi() {
 
 #[tokio::test]
 #[serial]
-async fn can_fetch_and_cache_contract_source_code() {
+async fn external_can_fetch_and_cache_contract_source_code() {
     async fn fetch_source_code(client: &Client, addr: &str) {
         let meta = client.contract_source_code(addr.parse().unwrap()).await.unwrap();
         assert_eq!(meta.items.len(), 1);
@@ -80,7 +80,7 @@ async fn can_fetch_and_cache_contract_source_code() {
 
 #[tokio::test]
 #[serial]
-async fn can_fetch_deposit_contract_source_code_from_blockscout() {
+async fn external_can_fetch_deposit_contract_source_code_from_blockscout() {
     let client = Client::builder()
         .with_url("https://eth.blockscout.com")
         .unwrap()
@@ -103,7 +103,7 @@ async fn can_fetch_deposit_contract_source_code_from_blockscout() {
 
 #[tokio::test]
 #[serial]
-async fn can_fetch_other_contract_source_code_from_blockscout() {
+async fn external_can_fetch_other_contract_source_code_from_blockscout() {
     let client = Client::builder()
         .with_url("https://eth.blockscout.com")
         .unwrap()
@@ -125,7 +125,7 @@ async fn can_fetch_other_contract_source_code_from_blockscout() {
 
 #[tokio::test]
 #[serial]
-async fn can_fetch_contract_source_code() {
+async fn external_can_fetch_contract_source_code() {
     run_with_client(Chain::mainnet(), |client| async move {
         let meta = client
             .contract_source_code("0x00000000219ab540356cBB839Cbe05303d7705Fa".parse().unwrap())
@@ -143,7 +143,7 @@ async fn can_fetch_contract_source_code() {
 
 #[tokio::test]
 #[serial]
-async fn can_get_error_on_unverified_contract() {
+async fn external_can_get_error_on_unverified_contract() {
     init_tracing();
     run_with_client(Chain::mainnet(), |client| async move {
         let addr = "0xb5c31a0e22cae98ac08233e512bd627885aa24e5".parse().unwrap();
@@ -156,7 +156,7 @@ async fn can_get_error_on_unverified_contract() {
 /// Query a contract that has a single string source entry instead of underlying JSON metadata.
 #[tokio::test]
 #[serial]
-async fn can_fetch_contract_source_tree_for_singleton_contract() {
+async fn external_can_fetch_contract_source_tree_for_singleton_contract() {
     run_with_client(Chain::mainnet(), |client| async move {
         let meta = client
             .contract_source_code("0x00000000219ab540356cBB839Cbe05303d7705Fa".parse().unwrap())
@@ -175,7 +175,7 @@ async fn can_fetch_contract_source_tree_for_singleton_contract() {
 /// Query a contract that has many source entries as JSON metadata and ensure they are reflected.
 #[tokio::test]
 #[serial]
-async fn can_fetch_contract_source_tree_for_multi_entry_contract() {
+async fn external_can_fetch_contract_source_tree_for_multi_entry_contract() {
     run_with_client(Chain::mainnet(), |client| async move {
         let meta = client
             .contract_source_code("0x8d04a8c79cEB0889Bdd12acdF3Fa9D207eD3Ff63".parse().unwrap())
@@ -192,7 +192,7 @@ async fn can_fetch_contract_source_tree_for_multi_entry_contract() {
 /// Query a contract that has a plain source code mapping instead of tagged structures.
 #[tokio::test]
 #[serial]
-async fn can_fetch_contract_source_tree_for_plain_source_code_mapping() {
+async fn external_can_fetch_contract_source_tree_for_plain_source_code_mapping() {
     run_with_client(Chain::mainnet(), |client| async move {
         let meta = client
             .contract_source_code("0x68b26dcf21180d2a8de5a303f8cc5b14c8d99c4c".parse().unwrap())
@@ -208,7 +208,7 @@ async fn can_fetch_contract_source_tree_for_plain_source_code_mapping() {
 
 #[tokio::test]
 #[serial]
-async fn can_fetch_contract_creation_data() {
+async fn external_can_fetch_contract_creation_data() {
     run_with_client(Chain::mainnet(), |client| async move {
         client
             .contract_creation_data("0xdac17f958d2ee523a2206206994597c13d831ec7".parse().unwrap())
@@ -220,7 +220,7 @@ async fn can_fetch_contract_creation_data() {
 
 #[tokio::test]
 #[serial]
-async fn error_when_creation_data_for_eoa() {
+async fn external_error_when_creation_data_for_eoa() {
     init_tracing();
     run_with_client(Chain::mainnet(), |client| async move {
         let addr = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".parse().unwrap();

--- a/crates/explorers/block-explorers/tests/it/gas.rs
+++ b/crates/explorers/block-explorers/tests/it/gas.rs
@@ -5,7 +5,7 @@ use serial_test::serial;
 
 #[tokio::test]
 #[serial]
-async fn gas_estimate_success() {
+async fn external_gas_estimate_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let result = client.gas_estimate(U256::from(2000000000u32)).await;
 
@@ -17,7 +17,7 @@ async fn gas_estimate_success() {
 #[tokio::test]
 #[ignore]
 #[serial]
-async fn gas_oracle_success() {
+async fn external_gas_oracle_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let result = client.gas_oracle().await;
 

--- a/crates/explorers/block-explorers/tests/it/main.rs
+++ b/crates/explorers/block-explorers/tests/it/main.rs
@@ -126,7 +126,7 @@ fn init_tracing() {
 }
 
 #[tokio::test]
-async fn check_wrong_etherscan_api_key() {
+async fn external_check_wrong_etherscan_api_key() {
     let client = Client::new(Chain::mainnet(), "ABCDEFG").unwrap();
     let resp = client
         .contract_source_code("0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413".parse().unwrap())

--- a/crates/explorers/block-explorers/tests/it/transaction.rs
+++ b/crates/explorers/block-explorers/tests/it/transaction.rs
@@ -5,7 +5,7 @@ use serial_test::serial;
 
 #[tokio::test]
 #[serial]
-async fn check_contract_execution_status_success() {
+async fn external_check_contract_execution_status_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let status = client
             .check_contract_execution_status(
@@ -20,7 +20,7 @@ async fn check_contract_execution_status_success() {
 
 #[tokio::test]
 #[serial]
-async fn check_contract_execution_status_error() {
+async fn external_check_contract_execution_status_error() {
     run_with_client(Chain::mainnet(), |client| async move {
         let err = client
             .check_contract_execution_status(
@@ -37,7 +37,7 @@ async fn check_contract_execution_status_error() {
 
 #[tokio::test]
 #[serial]
-async fn check_transaction_receipt_status_success() {
+async fn external_check_transaction_receipt_status_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let success = client
             .check_transaction_receipt_status(
@@ -52,7 +52,7 @@ async fn check_transaction_receipt_status_success() {
 
 #[tokio::test]
 #[serial]
-async fn check_transaction_receipt_status_failed() {
+async fn external_check_transaction_receipt_status_failed() {
     run_with_client(Chain::mainnet(), |client| async move {
         let err = client
             .check_transaction_receipt_status(

--- a/crates/explorers/block-explorers/tests/it/verify.rs
+++ b/crates/explorers/block-explorers/tests/it/verify.rs
@@ -11,7 +11,7 @@ use tracing::trace;
 
 #[tokio::test]
 #[serial]
-async fn test_can_flatten_and_verify_contract_single_file_mainnet() {
+async fn external_can_flatten_and_verify_contract_single_file_mainnet() {
     let root = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/test-data/rewards"));
     let paths = ProjectPathsConfig::builder()
         .sources(root)
@@ -55,7 +55,7 @@ async fn test_can_flatten_and_verify_contract_single_file_mainnet() {
 
 #[tokio::test]
 #[serial]
-async fn can_verify_contract_json_multi_file_mainnet() {
+async fn external_can_verify_contract_json_multi_file_mainnet() {
     let root = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/test-data/rewards"));
 
     let paths = ProjectPathsConfig::builder()
@@ -120,7 +120,7 @@ async fn can_verify_contract_json_multi_file_mainnet() {
 
 #[tokio::test]
 #[serial]
-async fn can_verify_contract_json_multi_file_v2_base() {
+async fn external_can_verify_contract_json_multi_file_v2_base() {
     let root = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/test-data/rewards"));
 
     let compiler_version = "v0.8.17+commit.8df45f5f";
@@ -165,7 +165,7 @@ async fn can_verify_contract_json_multi_file_v2_base() {
 
 #[tokio::test]
 #[serial]
-async fn can_verify_contract_json_multi_file_v2_fails_base() {
+async fn external_can_verify_contract_json_multi_file_v2_fails_base() {
     let compiler_version = "v0.8.17+commit.8df45f5f";
 
     let root = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/test-data/rewards"));
@@ -233,7 +233,7 @@ async fn can_verify_contract_json_multi_file_v2_fails_base() {
 
 #[tokio::test]
 #[serial]
-async fn can_verify_contract_sol_flatten_v2_fails_base() {
+async fn external_can_verify_contract_sol_flatten_v2_fails_base() {
     let compiler_version = "v0.8.17+commit.8df45f5f";
 
     let root = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/test-data/rewards"));

--- a/crates/explorers/block-explorers/tests/it/version.rs
+++ b/crates/explorers/block-explorers/tests/it/version.rs
@@ -2,7 +2,7 @@ use foundry_block_explorers::{errors::EtherscanError, utils::lookup_compiler_ver
 use semver::{BuildMetadata, Prerelease, Version};
 
 #[tokio::test]
-async fn can_lookup_compiler_version_build_metadata() {
+async fn external_can_lookup_compiler_version_build_metadata() {
     let v = Version::new(0, 8, 13);
     let version = lookup_compiler_version(&v).await.unwrap();
     assert_eq!(v.major, version.major);
@@ -13,7 +13,7 @@ async fn can_lookup_compiler_version_build_metadata() {
 }
 
 #[tokio::test]
-async fn errors_on_invalid_solc() {
+async fn external_errors_on_invalid_solc() {
     let v = Version::new(100, 0, 0);
     let err = lookup_compiler_version(&v).await.unwrap_err();
     assert!(matches!(err, EtherscanError::MissingSolcVersion(_)));


### PR DESCRIPTION
- Exclude `foundry-block-explorers` from CI when `ETHERSCAN_API_KEY` is unavailable
- Add nightly workflow to run full test suite with secrets
- Auto-open issue on nightly failure