### PR TITLE
chore: remove `similar-asserts` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,6 @@ rusqlite = { version = "0.39", features = ["bundled"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
-similar-asserts = "1"
 snapbox = "0.6.21"
 solar = { package = "solar-compiler", version = "=0.1.8", default-features = false }
 svm = { package = "svm-rs", version = "0.5", default-features = false }

--- a/crates/compilers/crates/artifacts/solc/Cargo.toml
+++ b/crates/compilers/crates/artifacts/solc/Cargo.toml
@@ -39,7 +39,6 @@ path-slash.workspace = true
 
 [dev-dependencies]
 serde_path_to_error = "0.1"
-similar-asserts.workspace = true
 foundry-compilers-core = { version = "0.19.14", path = "../../core", features = ["test-utils"] }
 
 [features]

--- a/crates/compilers/crates/artifacts/solc/src/lib.rs
+++ b/crates/compilers/crates/artifacts/solc/src/lib.rs
@@ -1837,7 +1837,7 @@ impl SourceFiles {
 mod tests {
     use super::*;
     use alloy_primitives::Address;
-    use similar_asserts::assert_eq;
+
     use std::fs;
 
     #[test]

--- a/crates/compilers/crates/artifacts/solc/src/remappings/find.rs
+++ b/crates/compilers/crates/artifacts/solc/src/remappings/find.rs
@@ -493,7 +493,6 @@ mod tests {
     use super::{super::tests::*, *};
     use foundry_compilers_core::utils::{mkdir_or_touch, tempdir, touch};
 
-
     /// Helper function for converting PathBufs to remapping strings.
     fn to_str(p: std::path::PathBuf) -> String {
         format!("{}/", p.display())

--- a/crates/compilers/crates/artifacts/solc/src/remappings/find.rs
+++ b/crates/compilers/crates/artifacts/solc/src/remappings/find.rs
@@ -492,7 +492,7 @@ fn last_nested_source_dir(root: &Path, dir: &Path) -> PathBuf {
 mod tests {
     use super::{super::tests::*, *};
     use foundry_compilers_core::utils::{mkdir_or_touch, tempdir, touch};
-    use similar_asserts::assert_eq;
+
 
     /// Helper function for converting PathBufs to remapping strings.
     fn to_str(p: std::path::PathBuf) -> String {

--- a/crates/compilers/crates/artifacts/solc/src/remappings/mod.rs
+++ b/crates/compilers/crates/artifacts/solc/src/remappings/mod.rs
@@ -358,7 +358,6 @@ fn needs_trailing_slash(name_or_path: &str) -> bool {
 mod tests {
     pub use super::*;
 
-
     #[test]
     fn relative_remapping() {
         let remapping = "oz=a/b/c/d";

--- a/crates/compilers/crates/artifacts/solc/src/remappings/mod.rs
+++ b/crates/compilers/crates/artifacts/solc/src/remappings/mod.rs
@@ -357,7 +357,7 @@ fn needs_trailing_slash(name_or_path: &str) -> bool {
 #[cfg(test)]
 mod tests {
     pub use super::*;
-    pub use similar_asserts::assert_eq;
+
 
     #[test]
     fn relative_remapping() {

--- a/crates/compilers/crates/compilers/Cargo.toml
+++ b/crates/compilers/crates/compilers/Cargo.toml
@@ -55,7 +55,6 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
     "env-filter",
     "fmt",
 ] }
-similar-asserts.workspace = true
 fd-lock = "4.0.4"
 tokio = { version = "1.47", features = ["rt-multi-thread", "macros"] }
 reqwest = { workspace = true }

--- a/crates/compilers/crates/compilers/tests/project.rs
+++ b/crates/compilers/crates/compilers/tests/project.rs
@@ -31,7 +31,7 @@ use foundry_compilers_core::{
     utils::{self, RuntimeOrHandle, canonicalize},
 };
 use semver::Version;
-use similar_asserts::assert_eq;
+
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     env,


### PR DESCRIPTION
Remove the `similar-asserts` dependency. It only provided colorized diffs on assertion failure and used the same `PartialEq` comparison as `std::assert_eq!`. All 4 usages were in `#[cfg(test)]` modules and have been replaced with the standard `assert_eq!`.