### PR TITLE
chore: group dependabot updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      actions-weekly:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "cargo"
     directory: "/"
@@ -14,3 +19,8 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5
+    groups:
+      cargo-weekly:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Group minor and patch version updates per ecosystem into single PRs to reduce PR noise. Major version bumps and security updates still get individual PRs.

**Before:** up to 10 PRs/week (5 per ecosystem)
**After:** up to 4 PRs/week (1 grouped + 1 major per ecosystem, worst case)