### PR TITLE
fix(compilers): restore removed `openssl` feature

### DIFF
--- a/crates/compilers/crates/compilers/Cargo.toml
+++ b/crates/compilers/crates/compilers/Cargo.toml
@@ -94,6 +94,7 @@ project-util = [
 ]
 
 rustls = ["svm?/rustls"]
+openssl = ["svm?/openssl"]
 
 [[test]]
 name = "project"


### PR DESCRIPTION
The `openssl` feature was removed from `foundry-compilers`, causing a `cargo-semver-checks` failure (`feature_missing`). Downstream crates enabling `foundry-compilers/openssl` would fail to compile.

Re-adds `openssl = ["svm?/openssl"]` to maintain backwards compatibility.