### PR TITLE
docs: add missing feature flags to READMEs

### DIFF
--- a/crates/compilers/crates/compilers/README.md
+++ b/crates/compilers/crates/compilers/README.md
@@ -11,3 +11,5 @@ Originally part of [`ethers-rs`](https://github.com/gakonst/ethers-rs) as `ether
 - `svm-solc`: Enables [svm](https://github.com/alloy-rs/svm-rs) to auto-detect and manage `solc` builds.
 - `project-util`: Utilities for creating and testing project workspaces.
 - `rustls`: Uses `rustls` for TLS (enabled by default).
+- `openssl`: Uses `openssl` for TLS.
+- `test-utils`: Testing utilities.

--- a/crates/explorers/blob-explorers/README.md
+++ b/crates/explorers/blob-explorers/README.md
@@ -7,3 +7,4 @@ See also [Blobscan on GitHub](https://github.com/Blobscan/blobscan).
 ## Features
 
 - `rustls`: Uses `rustls` for TLS (default).
+- `openssl`: Uses `openssl` for TLS.

--- a/crates/explorers/block-explorers/README.md
+++ b/crates/explorers/block-explorers/README.md
@@ -7,3 +7,4 @@ Bindings for [Etherscan](https://etherscan.io) and other block explorer APIs, us
 - `foundry-compilers`: Enables contract verification support via [`foundry-compilers`](https://github.com/foundry-rs/foundry-core/tree/main/crates/compilers).
 - `compilers-full`: Enables all compiler backends when `foundry-compilers` is active.
 - `rustls`: Uses `rustls` for TLS (default).
+- `openssl`: Uses `openssl` for TLS.

--- a/crates/fork-db/README.md
+++ b/crates/fork-db/README.md
@@ -5,3 +5,7 @@ Fork database used by [Foundry](https://github.com/foundry-rs/foundry).
 > **Note:** This crate was previously maintained at [foundry-rs/foundry-fork-db](https://github.com/foundry-rs/foundry-fork-db).
 
 Provides a shared, caching database layer backed by a remote RPC provider, allowing EVM execution against forked chain state. Built on top of [revm](https://github.com/bluealloy/revm).
+
+## Features
+
+- `zstd`: Enables [zstd](https://github.com/gysber/zstd-rs) compression support.

--- a/crates/wallets/README.md
+++ b/crates/wallets/README.md
@@ -12,6 +12,8 @@ Supports multiple signer backends:
 
 ## Features
 
+- `browser`: Browser wallet support via a local HTTP callback server.
+- `tempo`: Tempo access key signing support.
 - `aws-kms`: [AWS KMS](https://aws.amazon.com/kms/) signer support via [`alloy-signer-aws`](https://docs.rs/alloy-signer-aws).
 - `gcp-kms`: [GCP KMS](https://cloud.google.com/kms) signer support via [`alloy-signer-gcp`](https://docs.rs/alloy-signer-gcp).
 - `turnkey`: [Turnkey](https://www.turnkey.com) signer support via [`alloy-signer-turnkey`](https://docs.rs/alloy-signer-turnkey).


### PR DESCRIPTION
Add undocumented feature flags to crate READMEs:

- **compilers**: `openssl`, `test-utils`
- **blob-explorers**: `openssl`
- **block-explorers**: `openssl`
- **fork-db**: `zstd` (new Features section)
- **wallets**: `browser`, `tempo`

Found by scanning all `[features]` sections in `Cargo.toml` files and cross-referencing with their respective READMEs.