### PR TITLE
fix: scope release notes to same crate group tag

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -89,7 +89,12 @@ if $EXECUTE; then
     echo "==> Next: create GitHub release for ${TAG}"
     confirm
 
-    gh release create "$TAG" --generate-notes
+    PREV_TAG=$(git tag -l "${GROUP}-v*" --sort=-v:refname | grep -v "^${TAG}$" | head -1)
+    if [[ -n "$PREV_TAG" ]]; then
+        gh release create "$TAG" --generate-notes --notes-start-tag "$PREV_TAG"
+    else
+        gh release create "$TAG" --generate-notes
+    fi
 else
     echo "Dry-run complete. Re-run with --execute to publish."
 fi


### PR DESCRIPTION
Use `--notes-start-tag` with the previous tag from the same crate group so release notes only compare within the group (e.g. `explorers-v0.22.0..explorers-v0.23.0`) instead of against the most recent tag overall.