### PR TITLE
feat(block-explorers): add `no_proxy` to `ClientBuilder`

### DIFF
--- a/crates/explorers/block-explorers/src/lib.rs
+++ b/crates/explorers/block-explorers/src/lib.rs
@@ -592,8 +592,7 @@ mod tests {
 
     #[test]
     fn builder_no_proxy_builds() {
-        let client =
-            Client::builder().chain(Chain::mainnet()).unwrap().no_proxy().build().unwrap();
+        let client = Client::builder().chain(Chain::mainnet()).unwrap().no_proxy().build().unwrap();
         assert_eq!(client.etherscan_url.as_str(), "https://etherscan.io/");
     }
 

--- a/crates/explorers/block-explorers/src/lib.rs
+++ b/crates/explorers/block-explorers/src/lib.rs
@@ -256,6 +256,8 @@ pub struct ClientBuilder {
     etherscan_url: Option<Url>,
     /// Path to where ABI files should be cached
     cache: Option<Cache>,
+    /// Whether to disable system proxy detection in the default HTTP client
+    no_proxy: bool,
 }
 
 // === impl ClientBuilder ===
@@ -300,6 +302,19 @@ impl ClientBuilder {
         self
     }
 
+    /// Disables automatic system proxy detection in the default HTTP client.
+    ///
+    /// Mirrors [`reqwest::ClientBuilder::no_proxy`]. Useful in sandboxed
+    /// environments where `reqwest`'s system proxy lookup can panic (for
+    /// example on macOS when `SCDynamicStore` returns NULL).
+    ///
+    /// Has no effect when a custom client is supplied via
+    /// [`with_client`](Self::with_client).
+    pub fn no_proxy(mut self) -> Self {
+        self.no_proxy = true;
+        self
+    }
+
     /// Configures the Etherscan api url
     ///
     /// # Errors
@@ -330,10 +345,17 @@ impl ClientBuilder {
     ///   - `etherscan_api_url`
     ///   - `etherscan_url`
     pub fn build(self) -> Result<Client> {
-        let ClientBuilder { client, api_key, etherscan_api_url, etherscan_url, cache } = self;
+        let ClientBuilder { client, api_key, etherscan_api_url, etherscan_url, cache, no_proxy } =
+            self;
+
+        let client = match client {
+            Some(c) => c,
+            None if no_proxy => reqwest::Client::builder().no_proxy().build()?,
+            None => reqwest::Client::default(),
+        };
 
         let client = Client {
-            client: client.unwrap_or_default(),
+            client,
             api_key,
             etherscan_api_url: etherscan_api_url
                 .clone()
@@ -566,6 +588,13 @@ mod tests {
     fn local_networks_not_supported() {
         let err = Client::new_from_env(Chain::dev()).unwrap_err();
         assert!(matches!(err, EtherscanError::LocalNetworksNotSupported));
+    }
+
+    #[test]
+    fn builder_no_proxy_builds() {
+        let client =
+            Client::builder().chain(Chain::mainnet()).unwrap().no_proxy().build().unwrap();
+        assert_eq!(client.etherscan_url.as_str(), "https://etherscan.io/");
     }
 
     #[test]

--- a/crates/explorers/block-explorers/src/lib.rs
+++ b/crates/explorers/block-explorers/src/lib.rs
@@ -256,7 +256,8 @@ pub struct ClientBuilder {
     etherscan_url: Option<Url>,
     /// Path to where ABI files should be cached
     cache: Option<Cache>,
-    /// Whether to disable system proxy detection in the default HTTP client
+    /// Whether to disable system proxy detection in the default HTTP client.
+    /// Ignored when a custom client is set via [`with_client`](Self::with_client).
     no_proxy: bool,
 }
 


### PR DESCRIPTION
## Summary

Mirrors [`reqwest::ClientBuilder::no_proxy`] on `foundry_block_explorers::ClientBuilder`, letting callers disable system proxy detection without having to construct their own `reqwest::Client`.

## Motivation

In sandboxed environments (e.g., Cursor IDE, macOS App Sandbox, restricted shells) `reqwest`'s system proxy lookup via `SCDynamicStore` can crash with:

```
The application panicked (crashed).
Message:  Attempted to create a NULL object.
Location: .../system-configuration-0.6.1/src/dynamic_store.rs:154
```

[foundry-rs/foundry#13155](https://github.com/foundry-rs/foundry/pull/13155) already added a `--no-proxy` flag for the RPC transport. [foundry-rs/foundry#14454](https://github.com/foundry-rs/foundry/pull/14454) does the same for the Etherscan path, but currently has to construct a `reqwest::Client` manually and pipe it in via `with_client(..)`, which forces `foundry-config` to pull in `reqwest` directly.

This PR moves the primitive to the right layer so the foundry-side fix can become a single `.no_proxy()` call.

## Changes

- Add `no_proxy: bool` field to `ClientBuilder`.
- Add `ClientBuilder::no_proxy()` method mirroring `reqwest::ClientBuilder::no_proxy`.
- When a custom client is supplied via `with_client`, `no_proxy` is ignored (user-provided client wins).
- Unit test for `.no_proxy().build()`.

## Follow-up

foundry-rs/foundry#14454 will be updated to call `.no_proxy()` and drop its direct `reqwest` dependency once this ships.