### PR TITLE
chore: pin dependencies to patch versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,65 +105,67 @@ all = "warn"
 
 [workspace.dependencies]
 # alloy
-alloy-consensus = { version = "2.0.0", default-features = false }
-alloy-dyn-abi = "1.5.2"
-alloy-json-abi = { version = "1.3", features = ["serde_json"] }
-alloy-network = { version = "2.0.0", default-features = false }
-alloy-primitives = { version = "1.5.2", features = [
+alloy-consensus = "2.0.4"
+alloy-dyn-abi = "1.5.7"
+alloy-json-abi = { version = "1.3.1", features = ["serde_json"] }
+alloy-network = "2.0.4"
+alloy-primitives = { version = "1.5.7", features = [
     "getrandom",
     "rand",
     "map-fxhash",
     "map-foldhash",
 ] }
-alloy-rlp = "0.3"
-alloy-signer = { version = "2.0.0", default-features = false }
-alloy-signer-aws = { version = "2.0.0", default-features = false }
-alloy-signer-gcp = { version = "2.0.0", default-features = false }
-alloy-signer-ledger = { version = "2.0.0", default-features = false }
-alloy-signer-local = { version = "2.0.0", default-features = false }
-alloy-signer-trezor = { version = "2.0.0", default-features = false }
-alloy-signer-turnkey = { version = "2.0.0", default-features = false }
-alloy-sol-types = "1.5.2"
-alloy-chains = "0.2"
-alloy-eips = { version = "2.0.0", default-features = false }
-alloy-rpc-types-eth = { version = "2.0.0", default-features = false }
-alloy-serde = { version = "2.0.0", default-features = false }
+alloy-rlp = "0.3.15"
+alloy-signer = "2.0.4"
+alloy-signer-aws = "2.0.4"
+alloy-signer-gcp = "2.0.4"
+alloy-signer-ledger = "2.0.4"
+alloy-signer-local = "2.0.4"
+alloy-signer-trezor = "2.0.4"
+alloy-signer-turnkey = "2.0.4"
+alloy-sol-types = "1.5.7"
+alloy-chains = "0.2.34"
+alloy-eips = { version = "2.0.4", default-features = false }
+alloy-rpc-types-eth = { version = "2.0.4", default-features = false }
+alloy-serde = "2.0.4"
 
 # tempo
-tempo-primitives = { version = "1.6", default-features = false, features = [
+tempo-primitives = { version = "1.6.0", default-features = false, features = [
     "std",
     "serde",
 ] }
 
 # misc
-async-trait = "0.1"
-axum = "0.8"
-dirs = "6"
-dunce = "1.0"
-eyre = "0.6"
-futures-util = "0.3"
-memchr = "2.7"
-path-slash = "0.2"
-rayon = "1.11"
-regex = "1.11"
-reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
-rusqlite = { version = "0.39", features = ["bundled"] }
-semver = { version = "1.0", features = ["serde"] }
-serde = { version = "1.0", features = ["derive", "rc"] }
-serde_json = { version = "1.0", features = ["arbitrary_precision"] }
+async-trait = "0.1.89"
+axum = "0.8.9"
+dirs = "6.0.0"
+dunce = "1.0.5"
+eyre = "0.6.12"
+fs_extra = "1.3.0"
+futures-util = "0.3.32"
+memchr = "2.7.6"
+path-slash = "0.2.1"
+rayon = "1.11.0"
+regex = "1.11.3"
+reqwest = { version = "0.13.3", default-features = false, features = ["rustls"] }
+rusqlite = { version = "0.39.0", features = ["bundled"] }
+semver = { version = "1.0.28", features = ["serde"] }
+serde = { version = "1.0.228", features = ["derive", "rc"] }
+serde_json = { version = "1.0.149", features = ["arbitrary_precision"] }
 snapbox = "1.2.1"
 solar = { package = "solar-compiler", version = "=0.1.8", default-features = false }
-svm = { package = "svm-rs", version = "0.5", default-features = false }
-tempfile = "3.20"
-thiserror = "2"
-tokio = { version = "1", features = ["rt-multi-thread"] }
-toml = "0.9"
-tower = "0.5"
-tower-http = "0.6"
-tracing = "0.1"
-uuid = { version = "1.19.0", features = ["v4", "serde"] }
-walkdir = "2.5"
-yansi = "1.0"
+svm = { package = "svm-rs", version = "0.5.25", default-features = false }
+tempfile = "3.20.0"
+thiserror = "2.0.18"
+tokio = { version = "1.47.1", features = ["rt-multi-thread"] }
+toml = "0.9.12"
+tower = "0.5.3"
+tower-http = "0.6.8"
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", default-features = false, features = ["env-filter", "fmt"] }
+uuid = { version = "1.23.1", features = ["v4", "serde"] }
+walkdir = "2.5.0"
+yansi = "1.0.1"
 
 # cross-group crate dependencies
 foundry-compilers = { version = "0.20.0", path = "crates/compilers/crates/compilers" }

--- a/crates/compilers/crates/artifacts/solc/Cargo.toml
+++ b/crates/compilers/crates/artifacts/solc/Cargo.toml
@@ -38,7 +38,7 @@ rayon = { workspace = true, optional = true }
 path-slash.workspace = true
 
 [dev-dependencies]
-serde_path_to_error = "0.1"
+serde_path_to_error = "0.1.20"
 foundry-compilers-core = { version = "0.20.0", path = "../../core", features = ["test-utils"] }
 
 [features]

--- a/crates/compilers/crates/compilers/Cargo.toml
+++ b/crates/compilers/crates/compilers/Cargo.toml
@@ -34,31 +34,28 @@ solar.workspace = true
 futures-util = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 
-auto_impl = "1"
-winnow = "0.7"
-dyn-clone = "1"
-derive_more = { version = "2", features = ["debug"] }
+auto_impl = "1.3.0"
+winnow = "0.7.15"
+dyn-clone = "1.0.20"
+derive_more = { version = "2.1.1", features = ["debug"] }
 itertools = ">=0.13, <=0.14"
 
 # project-util
-tempfile = { version = "3.20", optional = true }
-fs_extra = { version = "1.3", optional = true }
-rand = { version = "0.9", optional = true }
+tempfile = { workspace = true, optional = true }
+fs_extra = { workspace = true, optional = true }
+rand = { version = "0.9.4", optional = true }
 
 # svm
 svm = { workspace = true, optional = true }
-svm-builds = { package = "svm-rs-builds", version = "0.5", default-features = false, optional = true }
-sha2 = { version = "0.11", default-features = false, optional = true }
+svm-builds = { package = "svm-rs-builds", version = "0.5.25", optional = true }
+sha2 = { version = "0.11.0", default-features = false, optional = true }
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3", default-features = false, features = [
-    "env-filter",
-    "fmt",
-] }
+tracing-subscriber.workspace = true
 fd-lock = "4.0.4"
-tokio = { version = "1.47", features = ["rt-multi-thread", "macros"] }
-reqwest = { workspace = true }
-tempfile = "3.20"
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+reqwest.workspace = true
+tempfile.workspace = true
 snapbox.workspace = true
 foundry-compilers-core = { version = "0.20.0", path = "../core", features = ["test-utils"] }
 

--- a/crates/compilers/crates/core/Cargo.toml
+++ b/crates/compilers/crates/core/Cargo.toml
@@ -22,9 +22,7 @@ serde.workspace = true
 thiserror.workspace = true
 
 # hasher
-xxhash-rust = { version = "0.8", optional = true, default-features = false, features = [
-    "xxh3",
-] }
+xxhash-rust = { version = "0.8.15", optional = true, features = ["xxh3"] }
 
 # regex
 regex = { workspace = true, optional = true }
@@ -39,7 +37,7 @@ tokio = { workspace = true, optional = true }
 
 # project-util
 tempfile = { workspace = true, optional = true }
-fs_extra = { version = "1.3", optional = true }
+fs_extra = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 path-slash.workspace = true

--- a/crates/explorers/blob-explorers/Cargo.toml
+++ b/crates/explorers/blob-explorers/Cargo.toml
@@ -24,7 +24,7 @@ alloy-eips.workspace = true
 
 reqwest = { workspace = true, features = ["json", "query"] }
 serde = { workspace = true, features = ["derive"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.44", features = ["serde"] }
 
 [features]
 default = ["rustls"]

--- a/crates/explorers/block-explorers/Cargo.toml
+++ b/crates/explorers/block-explorers/Cargo.toml
@@ -42,7 +42,7 @@ foundry-compilers = { workspace = true, optional = true }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 serial_test = "3.2.0"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
+tracing-subscriber.workspace = true
 
 [features]
 default = ["rustls"]

--- a/crates/explorers/block-explorers/src/account.rs
+++ b/crates/explorers/block-explorers/src/account.rs
@@ -99,9 +99,7 @@ mod json_string {
         if json.is_empty() {
             Ok(Option::None)
         } else {
-            serde_json::from_str(&format!("\"{json}\""))
-                .map(Option::Some)
-                .map_err(D::Error::custom)
+            serde_json::from_str(&format!("\"{json}\"")).map(Option::Some).map_err(D::Error::custom)
         }
     }
 }

--- a/crates/explorers/block-explorers/src/account.rs
+++ b/crates/explorers/block-explorers/src/account.rs
@@ -99,7 +99,7 @@ mod json_string {
         if json.is_empty() {
             Ok(Option::None)
         } else {
-            serde_json::from_str(&format!("\"{}\"", &json))
+            serde_json::from_str(&format!("\"{json}\""))
                 .map(Option::Some)
                 .map_err(D::Error::custom)
         }

--- a/crates/fork-db/Cargo.toml
+++ b/crates/fork-db/Cargo.toml
@@ -22,30 +22,30 @@ default = []
 zstd = ["dep:zstd"]
 
 [dependencies]
-alloy-chains = { version = "0.2", default-features = false, features = ["serde"] }
+alloy-chains = { workspace = true, features = ["serde"] }
 alloy-primitives = { workspace = true, features = ["map"] }
-alloy-provider = { version = "2.0.0", default-features = false }
-alloy-rpc-types = { version = "2.0.0", features = ["eth"] }
+alloy-provider = { version = "2.0.4", default-features = false }
+alloy-rpc-types = { version = "2.0.4", features = ["eth"] }
 
 eyre.workspace = true
-futures = "0.3"
+futures = "0.3.32"
 
-parking_lot = "0.12"
+parking_lot = "0.12.5"
 
 revm = { version = "38.0.0", features = ["std", "serde"] }
 
-serde = { workspace = true }
+serde.workspace = true
 serde_json.workspace = true
 
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing.workspace = true
 
-url = "2"
-zstd = { version = "0.13", optional = true }
+url = "2.5.8"
+zstd = { version = "0.13.3", optional = true }
 
 [dev-dependencies]
-alloy-consensus = { workspace = true }
-alloy-rpc-client = "2.0.0"
+alloy-consensus.workspace = true
+alloy-rpc-client = "2.0.4"
 tempfile.workspace = true
-tiny_http = "0.12"
+tiny_http = "0.12.0"

--- a/crates/wallets/Cargo.toml
+++ b/crates/wallets/Cargo.toml
@@ -35,7 +35,7 @@ tower-http = { workspace = true, features = ["cors", "set-header"], optional = t
 
 # aws-kms
 alloy-signer-aws = { workspace = true, features = ["eip712"], optional = true }
-aws-config = { version = "1", default-features = true, optional = true }
+aws-config = { version = "1.8.14", default-features = true, optional = true }
 
 # gcp-kms
 alloy-signer-gcp = { workspace = true, features = ["eip712"], optional = true }
@@ -49,11 +49,11 @@ rusqlite = { workspace = true, optional = true }
 alloy-rlp = { workspace = true, optional = true }
 
 async-trait.workspace = true
-clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
-derive_builder = "0.20"
+clap = { version = "4.6.1", features = ["derive", "env", "unicode", "wrap_help"] }
+derive_builder = "0.20.2"
 dirs.workspace = true
 eyre.workspace = true
-rpassword = "7"
+rpassword = "7.5.2"
 serde.workspace = true
 thiserror.workspace = true
 toml = { workspace = true, optional = true }


### PR DESCRIPTION
Pins all workspace and crate-level dependencies to specific patch versions while preserving the original minor versions (no minor or major bumps).

## Changes

### Pinning
- Workspace and crate Cargo.toml files updated to pin every dependency to its current resolved patch version within the previously-allowed minor.

### Dedup / workspace promotion
- Promoted shared deps to the workspace: `fs_extra`, `tracing-subscriber`.
- Switched several crate-level deps to `workspace = true` (or the `foo.workspace = true` shorthand) where the spec matches the workspace one:
  - fork-db: `alloy-chains`, `serde`, `alloy-consensus` (dev)
  - block-explorers: `tracing-subscriber` (dev)
  - compilers: `tempfile`, `fs_extra`, `tokio` (dev), `tracing-subscriber` (dev), `reqwest` (dev), `tempfile` (dev)

### Cleanup
- Removed redundant `default-features = false` where the dep has no `default` feature (no-op): `alloy-network`, `alloy-signer{,-aws,-gcp,-ledger,-local,-trezor,-turnkey}`, `xxhash-rust`, `svm-rs-builds`.
- Removed `default-features = false` where the only default is `std` (we always assume std): `alloy-consensus`, `alloy-serde`.

## Notes
This PR is purely about pinning versions and consolidating Cargo.toml structure — no functional or behavioral changes intended.