### PR TITLE
feat(block-explorers): add `set_no_proxy(bool)` builder method

### DIFF
--- a/crates/explorers/block-explorers/src/lib.rs
+++ b/crates/explorers/block-explorers/src/lib.rs
@@ -316,6 +316,18 @@ impl ClientBuilder {
         self
     }
 
+    /// Conditionally disables automatic system proxy detection.
+    ///
+    /// When `no_proxy` is `true`, behaves like [`Self::no_proxy`]. When
+    /// `false`, proxy detection is left enabled (the default).
+    ///
+    /// This is useful for threading a config flag through without a
+    /// conditional branch at the call site.
+    pub fn set_no_proxy(mut self, no_proxy: bool) -> Self {
+        self.no_proxy = no_proxy;
+        self
+    }
+
     /// Configures the Etherscan api url
     ///
     /// # Errors


### PR DESCRIPTION
## Motivation

The existing `ClientBuilder::no_proxy()` unconditionally sets `no_proxy = true`. Callers that want to conditionally disable proxy detection based on a config flag (e.g. `config.eth_rpc_no_proxy` from `--no-proxy`) need a branch:

```rust
let mut builder = Client::builder();
if config.eth_rpc_no_proxy {
    builder = builder.no_proxy();
}
```

## Change

Add `set_no_proxy(bool)` so callers can pass the flag through directly:

```rust
Client::builder()
    .set_no_proxy(config.eth_rpc_no_proxy)
    .build()
```

The existing `no_proxy()` is preserved for convenience.

Ref: [foundry-rs/foundry#13155](https://github.com/foundry-rs/foundry/pull/13155), [foundry-rs/foundry#14454](https://github.com/foundry-rs/foundry/pull/14454)