### PR TITLE
feat: add Amsterdam EVM version

### DIFF
--- a/crates/compilers/crates/artifacts/solc/src/lib.rs
+++ b/crates/compilers/crates/artifacts/solc/src/lib.rs
@@ -814,6 +814,7 @@ pub enum EvmVersion {
     #[default]
     Prague,
     Osaka,
+    Amsterdam,
 }
 
 impl EvmVersion {
@@ -852,7 +853,8 @@ impl EvmVersion {
             // If the Solc version is the latest, it supports all EVM versions.
             // For all other cases, cap at the at-the-time highest possible fork.
             if *version >= OSAKA_SOLC {
-                self
+                // Amsterdam has no dedicated solc target yet; cap at Osaka.
+                self.min(Self::Osaka)
             } else if self >= Self::Prague && *version >= PRAGUE_SOLC {
                 Self::Prague
             } else if self >= Self::Cancun && *version >= CANCUN_SOLC {
@@ -896,6 +898,7 @@ impl EvmVersion {
             Self::Cancun => "cancun",
             Self::Prague => "prague",
             Self::Osaka => "osaka",
+            Self::Amsterdam => "amsterdam",
         }
     }
 
@@ -966,6 +969,7 @@ impl FromStr for EvmVersion {
             "cancun" => Ok(Self::Cancun),
             "prague" => Ok(Self::Prague),
             "osaka" => Ok(Self::Osaka),
+            "amsterdam" => Ok(Self::Amsterdam),
             s => Err(format!("Unknown evm version: {s}")),
         }
     }
@@ -2016,6 +2020,8 @@ mod tests {
             ("0.8.26", EvmVersion::Prague, Some(EvmVersion::Cancun)),
             ("0.8.27", EvmVersion::Prague, Some(EvmVersion::Prague)),
             ("0.8.29", EvmVersion::Osaka, Some(EvmVersion::Osaka)),
+            // Amsterdam caps at Osaka (no dedicated solc target yet)
+            ("0.8.29", EvmVersion::Amsterdam, Some(EvmVersion::Osaka)),
         ] {
             let version = Version::from_str(solc_version).unwrap();
             assert_eq!(


### PR DESCRIPTION
## Summary

Add `EvmVersion::Amsterdam` variant after `Osaka`.

### Changes
- Add `Amsterdam` variant to `EvmVersion` enum
- Add `AMSTERDAM_SOLC` constant (provisional `0.8.32` — update when solc ships native support)
- Update `normalize_version_solc` to cap Amsterdam at Osaka for older solc versions
- Add `as_str` and `FromStr` support for `"amsterdam"`
- Add normalization test coverage

### Notes
- Solc does not yet have a dedicated `amsterdam` EVM target (it uses `@future` experimental). The `AMSTERDAM_SOLC` constant is provisional.
- Companion PR: [foundry-rs/foundry#14683](https://github.com/foundry-rs/foundry/pull/14683) adds the `EthereumHardfork::Amsterdam => SpecId::AMSTERDAM` mapping