### PR TITLE
fix(release): use full tag name in changelog URLs

### DIFF
--- a/crates/block-explorers/release.toml
+++ b/crates/block-explorers/release.toml
@@ -4,4 +4,4 @@ allow-branch = ["main"]
 sign-commit = true
 sign-tag = true
 rate-limit.existing-packages = 10
-pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{version}}"]
+pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{tag_name}}"]

--- a/crates/compilers/crates/artifacts/artifacts/release.toml
+++ b/crates/compilers/crates/artifacts/artifacts/release.toml
@@ -4,4 +4,4 @@ allow-branch = ["main"]
 sign-commit = true
 sign-tag = true
 rate-limit.existing-packages = 10
-pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{version}}"]
+pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{tag_name}}"]

--- a/crates/compilers/crates/artifacts/solc/release.toml
+++ b/crates/compilers/crates/artifacts/solc/release.toml
@@ -4,4 +4,4 @@ allow-branch = ["main"]
 sign-commit = true
 sign-tag = true
 rate-limit.existing-packages = 10
-pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{version}}"]
+pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{tag_name}}"]

--- a/crates/compilers/crates/artifacts/vyper/release.toml
+++ b/crates/compilers/crates/artifacts/vyper/release.toml
@@ -4,4 +4,4 @@ allow-branch = ["main"]
 sign-commit = true
 sign-tag = true
 rate-limit.existing-packages = 10
-pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{version}}"]
+pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{tag_name}}"]

--- a/crates/compilers/crates/compilers/release.toml
+++ b/crates/compilers/crates/compilers/release.toml
@@ -4,4 +4,4 @@ allow-branch = ["main"]
 sign-commit = true
 sign-tag = true
 rate-limit.existing-packages = 10
-pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{version}}"]
+pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{tag_name}}"]

--- a/crates/compilers/crates/core/release.toml
+++ b/crates/compilers/crates/core/release.toml
@@ -4,4 +4,4 @@ allow-branch = ["main"]
 sign-commit = true
 sign-tag = true
 rate-limit.existing-packages = 10
-pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{version}}"]
+pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{tag_name}}"]

--- a/crates/fork-db/release.toml
+++ b/crates/fork-db/release.toml
@@ -4,4 +4,4 @@ allow-branch = ["main"]
 sign-commit = true
 sign-tag = true
 rate-limit.existing-packages = 10
-pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{version}}"]
+pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{tag_name}}"]

--- a/crates/wallets/release.toml
+++ b/crates/wallets/release.toml
@@ -4,4 +4,4 @@ allow-branch = ["main"]
 sign-commit = true
 sign-tag = true
 rate-limit.existing-packages = 10
-pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{version}}"]
+pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{tag_name}}"]


### PR DESCRIPTION
## Problem

Generated changelog entries link to non-existent GitHub release tags. For
example, the `compilers-v0.21.0` entry currently renders as:

```md
## [0.21.0](https://github.com/foundry-rs/foundry-core/releases/tag/0.21.0) - 2026-05-13
```

The actual tag is `compilers-v0.21.0`, so the link 404s. Same issue exists in the prior `0.20.0` compilers entry, the latest block-explorers entries, and the latest fork-db entries.

## Cause

The pre-release-hook in every `release.toml` invokes:

```toml
pre-release-hook = ["bash", "-c", "$WORKSPACE_ROOT/.github/scripts/changelog.sh --tag {{version}}"]
```

`{{version}}` is the bare semver (`0.21.0`), so git-cliff sees `version = "0.21.0"`. Each `cliff.toml` then renders:

```tera
## [{{ version | trim_start_matches(pat="compilers-v") }}](https://github.com/foundry-rs/foundry-core/releases/tag/{{ version }})
```

The `trim_start_matches` filter is a no-op (no prefix to trim), and the URL ends up as the bare version.

## Fix

Switch `{{version}}` → `{{tag_name}}` in the pre-release-hook of all eight `release.toml` files. cargo-release expands `{{tag_name}}` to the prefixed tag (e.g. `compilers-v0.21.0`), so:

- The URL becomes `releases/tag/compilers-v0.21.0` ✅
- The existing `trim_start_matches` filter strips the prefix from the displayed link text → still `[0.21.0]` ✅

No changes needed to `cliff.toml` files or the `changelog.sh` script.

## Scope

Affects future releases only. Existing broken changelog URLs are left as-is to avoid touching historical entries.