### PR TITLE
chore: release block-explorers 0.24.0

### DIFF
--- a/crates/block-explorers/CHANGELOG.md
+++ b/crates/block-explorers/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0](https://github.com/foundry-rs/foundry-core/releases/tag/block-explorers-v0.24.0) - 2026-05-13
+
+### Dependencies
+
+- Bump `foundry-compilers` to `0.21.0`
+
+### Miscellaneous Tasks
+
+- Flatten `block-explorers` to top-level crate ([#58](https://github.com/foundry-rs/foundry-core/issues/58))
+- Remove `foundry-blob-explorers` crate ([#57](https://github.com/foundry-rs/foundry-core/issues/57))
+
 ## [0.23.1](https://github.com/foundry-rs/foundry-core/releases/tag/0.23.1) - 2026-05-07
 
 ### Dependencies

--- a/crates/block-explorers/Cargo.toml
+++ b/crates/block-explorers/Cargo.toml
@@ -3,7 +3,7 @@ name = "foundry-block-explorers"
 description = "Bindings for Etherscan.io and other block explorer APIs"
 keywords = ["crypto", "ethers", "ethereum", "web3", "etherscan"]
 
-version = "0.23.1"
+version = "0.24.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Releases `foundry-block-explorers` `0.24.0` so downstream crates can consume `foundry-compilers 0.21.0`.

The currently published `foundry-block-explorers 0.23.1` requires `foundry-compilers ^0.20.0`, which prevents bumping `foundry-compilers` to `0.21.0` in [foundry](https://github.com/foundry-rs/foundry). This release re-publishes `block-explorers` against the new compilers major.

### Changes

- Bumps `crates/block-explorers` from `0.23.1` → `0.24.0`
- Workspace dep `foundry-compilers` is already at `0.21.0` on `main`, so the published crate will require `^0.21.0`
- Adds CHANGELOG entry

The follow-up bump in `foundry-rs/foundry` will be opened once this is published to crates.io.