### PR TITLE
fix(ci): fix broken build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ alloy-sol-types = "1.5.7"
 alloy-chains = "0.2.34"
 
 # tempo
-tempo-primitives = { version = "1.6.0", default-features = false, features = [
+tempo-primitives = { version = "1.7.0", default-features = false, features = [
     "std",
     "serde",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,29 +105,29 @@ all = "warn"
 
 [workspace.dependencies]
 # alloy
-alloy-consensus = "2.0.4"
-alloy-dyn-abi = "1.5.7"
+alloy-consensus = "2.0.5"
+alloy-dyn-abi = "1.6.0"
 alloy-json-abi = { version = "1.3.1", features = ["serde_json"] }
-alloy-network = "2.0.4"
-alloy-primitives = { version = "1.5.7", features = [
+alloy-network = "2.0.5"
+alloy-primitives = { version = "1.6.0", features = [
     "getrandom",
     "rand",
     "map-fxhash",
     "map-foldhash",
 ] }
 alloy-rlp = "0.3.15"
-alloy-signer = "2.0.4"
-alloy-signer-aws = "2.0.4"
-alloy-signer-gcp = "2.0.4"
-alloy-signer-ledger = "2.0.4"
-alloy-signer-local = "2.0.4"
-alloy-signer-trezor = "2.0.4"
-alloy-signer-turnkey = "2.0.4"
-alloy-sol-types = "1.5.7"
+alloy-signer = "2.0.5"
+alloy-signer-aws = "2.0.5"
+alloy-signer-gcp = "2.0.5"
+alloy-signer-ledger = "2.0.5"
+alloy-signer-local = "2.0.5"
+alloy-signer-trezor = "2.0.5"
+alloy-signer-turnkey = "2.0.5"
+alloy-sol-types = "1.6.0"
 alloy-chains = "0.2.34"
 
 # tempo
-tempo-primitives = { version = "1.7.0", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "020bc28785f40fb1625e4e38b43db807b2bebee6", default-features = false, features = [
     "std",
     "serde",
 ] }
@@ -166,4 +166,3 @@ yansi = "1.0.1"
 
 # cross-group crate dependencies
 foundry-compilers = { version = "0.21.0", path = "crates/compilers/crates/compilers" }
-

--- a/deny.toml
+++ b/deny.toml
@@ -69,4 +69,4 @@ unknown-registry = "warn"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
 unknown-git = "deny"
-allow-git = []
+allow-git = ["https://github.com/tempoxyz/tempo"]


### PR DESCRIPTION
## Description

Fixes the broken nightly CI build by updating pinned dependency versions.

## Changes

- **alloy**: Bump `alloy-consensus`, `alloy-network`, and all `alloy-signer-*` crates from `2.0.4` → `2.0.5`.
- **alloy**: Bump `alloy-dyn-abi`, `alloy-primitives`, and `alloy-sol-types` from `1.5.7` → `1.6.0`.
- **tempo-primitives**: Switch from the `1.6.0` crates.io release to a git pin (`tempoxyz/tempo` @ `020bc28`) to pick up an unreleased fix needed for compatibility.
- **deny.toml**: Allowlist the `https://github.com/tempoxyz/tempo` git source so `cargo-deny` passes.

## Motivation

The previous version pins were no longer compatible with the latest nightly toolchain / transitive dependency graph, causing CI to fail. These bumps restore a green build.

## Notes

The `tempo-primitives` git pin is temporary and should be reverted to a crates.io release (`> 1.6.0`) once the upstream fix is published.