### PR TITLE
chore(fork-db): bump revm to 40.0.3

### DIFF
--- a/crates/fork-db/Cargo.toml
+++ b/crates/fork-db/Cargo.toml
@@ -32,7 +32,7 @@ futures = "0.3.32"
 
 parking_lot = "0.12.5"
 
-revm = { version = "38.0.0", features = ["std", "serde"] }
+revm = { version = "40.0.3", features = ["std", "serde"] }
 
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Bumps `foundry-fork-db` to the revm 40.0.3 family so downstream Foundry builds do not pull both revm 38 and revm 40 database traits.

This is needed by the Foundry revm bump in foundry-rs/foundry#14925.

Validation:
- Verified through foundry-rs/foundry#14925 with `cargo build --bin forge --profile release --no-default-features`

Prompted by: @klkvr
