### PR TITLE
fix(CI): bump MSRV and ignore RUSTSEC advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,11 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        rust: ["stable", "1.93"]
+        rust: ["stable", "1.95"]
         flags: ["", "--all-features"]
         exclude:
           # Skip because some features have higher MSRV.
-          - rust: "1.93" # MSRV
+          - rust: "1.95" # MSRV
             flags: "--all-features"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.95"
 authors = ["Foundry Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://getfoundry.sh"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Core libraries extracted from [Foundry](https://github.com/foundry-rs/foundry), 
 
 ## Supported Rust Versions (MSRV)
 
-The current MSRV (minimum supported rust version) is **1.93**.
+The current MSRV (minimum supported rust version) is **1.95**.
 
 Note that the MSRV is not increased automatically, and only as part of a minor release.
 

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,9 @@ yanked = "warn"
 ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained
     "RUSTSEC-2024-0436",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
+    # TODO: Remove after next alloy-rs/core release that no longer depends on proc-macro-error2.
+    "RUSTSEC-2026-0173",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
MSRV bump + proc-macro-error2 tmp RUSTSEC ignore