### PR TITLE
fix(ci): pin time for aws smithy compatibility

### DIFF
--- a/crates/wallets/Cargo.toml
+++ b/crates/wallets/Cargo.toml
@@ -36,6 +36,8 @@ tower-http = { workspace = true, features = ["cors", "set-header"], optional = t
 # aws-kms
 alloy-signer-aws = { workspace = true, features = ["eip712"], optional = true }
 aws-config = { version = "1.8.14", default-features = true, optional = true }
+# aws-smithy-types 1.5.0 conflicts with time 0.3.48 on Rust 1.96+.
+aws-smithy-time-compat = { package = "time", version = "=0.3.47", optional = true }
 
 # gcp-kms
 alloy-signer-gcp = { workspace = true, features = ["eip712"], optional = true }
@@ -67,6 +69,6 @@ tokio = { workspace = true, features = ["macros"] }
 [features]
 browser = ["dep:axum", "dep:serde_json", "dep:tokio", "dep:uuid", "dep:webbrowser", "dep:tower", "dep:tower-http"]
 tempo = ["dep:tempo-primitives", "dep:rusqlite", "dep:alloy-rlp", "dep:toml"]
-aws-kms = ["dep:alloy-signer-aws", "dep:aws-config"]
+aws-kms = ["dep:alloy-signer-aws", "dep:aws-config", "dep:aws-smithy-time-compat"]
 gcp-kms = ["dep:alloy-signer-gcp"]
 turnkey = ["dep:alloy-signer-turnkey"]

--- a/crates/wallets/src/lib.rs
+++ b/crates/wallets/src/lib.rs
@@ -35,3 +35,5 @@ pub use wallet_raw::RawWalletOpts;
 
 #[cfg(feature = "aws-kms")]
 use aws_config as _;
+#[cfg(feature = "aws-kms")]
+use aws_smithy_time_compat as _;


### PR DESCRIPTION
## Summary

Pin the `time` crate to `0.3.47` only when the `foundry-wallets` `aws-kms` feature is enabled.

`aws-smithy-types 1.5.0` currently conflicts with `time 0.3.48` on Rust 1.96+/nightly because both crates provide overlapping `From<HourBase>` implementations.

## Notes

A direct AWS SDK bump is not currently viable: newer AWS SDK crates pull in `aws-smithy-async` versions requiring newer `tokio`, while `alloy-signer-turnkey` still depends on `turnkey_client 0.6.2`, which pins `tokio = 1.47.1`.

The `aws_smithy_time_compat` crate-root import exists only to satisfy the workspace `unused_crate_dependencies` lint.