### PR TITLE
feat(compilers): support solc experimental setting

### DIFF
--- a/crates/compilers/crates/artifacts/solc/src/lib.rs
+++ b/crates/compilers/crates/artifacts/solc/src/lib.rs
@@ -260,6 +260,11 @@ pub struct Settings {
     /// false by default.
     #[serde(rename = "viaIR", default, skip_serializing_if = "Option::is_none")]
     pub via_ir: Option<bool>,
+    /// Enables experimental Solidity compiler features.
+    ///
+    /// Since 0.8.35.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub experimental: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub debug: Option<DebuggingSettings>,
     /// Addresses of the libraries. If not all libraries are given here,
@@ -354,6 +359,11 @@ impl Settings {
                 model_checker.show_proved_safe = None;
                 model_checker.show_unsupported = None;
             }
+        }
+
+        if *version < Version::new(0, 8, 35) {
+            // introduced in 0.8.35 <https://github.com/ethereum/solidity/releases/tag/v0.8.35>
+            self.experimental = None;
         }
 
         if let Some(evm_version) = self.evm_version {
@@ -455,6 +465,19 @@ impl Settings {
         self.set_via_ir(true)
     }
 
+    /// Sets the `experimental` value.
+    #[must_use]
+    pub const fn set_experimental(mut self, experimental: bool) -> Self {
+        self.experimental = Some(experimental);
+        self
+    }
+
+    /// Enables experimental Solidity compiler features.
+    #[must_use]
+    pub const fn with_experimental(self) -> Self {
+        self.set_experimental(true)
+    }
+
     /// Enable `viaIR` and use the minimum optimization settings.
     ///
     /// This is useful in the following scenarios:
@@ -552,6 +575,7 @@ impl Default for Settings {
             output_selection: OutputSelection::default_output_selection(),
             evm_version: Some(EvmVersion::default()),
             via_ir: None,
+            experimental: None,
             debug: None,
             libraries: Default::default(),
             remappings: Default::default(),
@@ -2061,6 +2085,33 @@ mod tests {
 
         let i = input.sanitized(&Version::new(0, 8, 0));
         assert!(i.settings.metadata.unwrap().cbor_metadata.is_none());
+    }
+
+    #[test]
+    fn can_serialize_experimental() {
+        let settings = Settings::default().with_experimental();
+        let value = serde_json::to_value(&settings).unwrap();
+        assert_eq!(value["experimental"], true);
+
+        let settings: Settings = serde_json::from_value(serde_json::json!({
+            "experimental": true
+        }))
+        .unwrap();
+        assert_eq!(settings.experimental, Some(true));
+    }
+
+    #[test]
+    fn can_sanitize_experimental() {
+        let settings = Settings::default().with_experimental();
+
+        let input =
+            SolcInput { language: SolcLanguage::Solidity, sources: Default::default(), settings };
+
+        let i = input.clone().sanitized(&Version::new(0, 8, 35));
+        assert_eq!(i.settings.experimental, Some(true));
+
+        let i = input.sanitized(&Version::new(0, 8, 34));
+        assert!(i.settings.experimental.is_none());
     }
 
     #[test]

--- a/crates/compilers/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/mod.rs
@@ -304,6 +304,7 @@ impl CompilerSettings for SolcSettings {
                     output_selection,
                     evm_version,
                     via_ir,
+                    experimental,
                     debug,
                     libraries,
                 },
@@ -317,6 +318,7 @@ impl CompilerSettings for SolcSettings {
             && *metadata == other.settings.metadata
             && *evm_version == other.settings.evm_version
             && *via_ir == other.settings.via_ir
+            && *experimental == other.settings.experimental
             && *debug == other.settings.debug
             && *libraries == other.settings.libraries
             && output_selection.is_subset_of(&other.settings.output_selection)


### PR DESCRIPTION
## Summary

- Adds the Solidity Standard JSON `settings.experimental` field to solc artifacts.
- Sanitizes the setting away for solc versions before 0.8.35.
- Includes `experimental` in solc compiler-settings cache compatibility checks.

## Companion PR

Foundry-side wiring is in foundry-rs/foundry#15177. That draft temporarily patches `foundry-compilers` to this PR commit for validation and should switch back to the published crate once this lands.

## Context

Solidity 0.8.35 introduced experimental mode as `--experimental` and `settings.experimental`. This gives Foundry a typed compiler API to set that Standard JSON field instead of only passing a process-level extra arg.

Reference: https://www.soliditylang.org/blog/2026/04/29/solidity-0.8.35-release-announcement/

## Validation

- `cargo +1.95.0 test -p foundry-compilers-artifacts-solc experimental`
- `cargo +1.95.0 check -p foundry-compilers`
