### PR TITLE
deps: bump revm in fork-db

### DIFF
--- a/crates/fork-db/Cargo.toml
+++ b/crates/fork-db/Cargo.toml
@@ -32,7 +32,7 @@ futures = "0.3.32"
 
 parking_lot = "0.12.5"
 
-revm = { version = "40.0.3", features = ["std", "serde"] }
+revm = { version = "41.0.0", features = ["std", "serde"] }
 
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Bumps `foundry-fork-db` to `revm 41.0.0` so downstream Foundry can align with Tempo/reth revm 41 without pulling two `revm-database-interface` versions.

Validation:
- `cargo check -p foundry-fork-db`

Prompted by: @0xrusowsky