### PR TITLE
fix(compilers): reuse Solar ASTs for interface hashes

### DIFF
--- a/crates/compilers/crates/compilers/src/cache.rs
+++ b/crates/compilers/crates/compilers/src/cache.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 mod iface;
-use iface::interface_repr_hash;
+use iface::{interface_repr_hash, interface_repr_hash_compiler};
 
 /// ethers-rs format version
 ///
@@ -722,13 +722,35 @@ impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
 
     /// Gets or calculates the interface representation hash for the given source file.
     fn interface_repr_hash(&mut self, source: &Source, file: &Path) -> &str {
-        self.interface_repr_hashes.entry(file.to_path_buf()).or_insert_with(|| {
-            // TODO: use `interface_representation_ast` directly with `edges.parser()`.
-            if let Some(r) = interface_repr_hash(&source.content, file) {
-                return r;
+        let Self { edges, content_hashes, interface_repr_hashes, .. } = self;
+        Self::interface_repr_hash_with_parser(
+            source,
+            file,
+            edges.parser(),
+            content_hashes,
+            interface_repr_hashes,
+        )
+    }
+
+    fn interface_repr_hash_with_parser<'a, P: SourceParser>(
+        source: &Source,
+        file: &Path,
+        parser: &P,
+        content_hashes: &mut HashMap<PathBuf, String>,
+        interface_repr_hashes: &'a mut HashMap<PathBuf, String>,
+    ) -> &'a str {
+        interface_repr_hashes.entry(file.to_path_buf()).or_insert_with(|| {
+            if let Some(compiler) = parser.solar_compiler()
+                && let Some(hash) = interface_repr_hash_compiler(compiler, file)
+            {
+                return hash;
             }
-            // Equivalent to: self.content_hash(source, file).into()
-            self.content_hashes
+
+            if let Some(hash) = interface_repr_hash(&source.content, file) {
+                return hash;
+            }
+
+            content_hashes
                 .entry(file.to_path_buf())
                 .or_insert_with(|| source.content_hash())
                 .clone()
@@ -869,7 +891,7 @@ impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
             let (sources, edges) = graph.into_sources();
 
             // Calculate content hashes for later comparison.
-            self.fill_hashes(&sources);
+            self.fill_hashes(&sources, edges.parser());
 
             // Pre-add all sources that are guaranteed to be dirty
             for file in sources.keys() {
@@ -999,13 +1021,19 @@ impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
     }
 
     /// Adds the file's hashes to the set if not set yet
-    fn fill_hashes(&mut self, sources: &Sources) {
+    fn fill_hashes(&mut self, sources: &Sources, parser: &C::Parser) {
         for (file, source) in sources {
             let _ = self.content_hash(source, file);
 
             // Fill interface representation hashes for source files
             if self.cache.preprocessed && self.project.paths.is_source_file(file) {
-                let _ = self.interface_repr_hash(source, file);
+                let _ = Self::interface_repr_hash_with_parser(
+                    source,
+                    file,
+                    parser,
+                    &mut self.content_hashes,
+                    &mut self.interface_repr_hashes,
+                );
             }
         }
     }

--- a/crates/compilers/crates/compilers/src/cache/iface.rs
+++ b/crates/compilers/crates/compilers/src/cache/iface.rs
@@ -10,8 +10,29 @@ pub(crate) fn interface_repr_hash(content: &str, path: &Path) -> Option<String> 
     Some(foundry_compilers_artifacts::Source::content_hash_of(&src))
 }
 
+pub(crate) fn interface_repr_hash_compiler(
+    compiler: &solar::sema::Compiler,
+    path: &Path,
+) -> Option<String> {
+    compiler.enter(|compiler| {
+        let sf = compiler.sess().source_map().get_file(path)?;
+        let (_, source) = compiler.gcx().sources.get_file(&sf)?;
+        let ast = source.ast.as_ref()?;
+        Some(interface_repr_hash_ast(source.file.src.as_str(), compiler.gcx().sess, ast))
+    })
+}
+
 pub(crate) fn interface_repr(content: &str, path: &Path) -> Result<String, EmittedDiagnostics> {
     parse_one_source(content, path, |sess, ast| interface_representation_ast(content, sess, ast))
+}
+
+pub(crate) fn interface_repr_hash_ast(
+    content: &str,
+    sess: &solar::sema::interface::Session,
+    ast: &solar::parse::ast::SourceUnit<'_>,
+) -> String {
+    let src = interface_representation_ast(content, sess, ast);
+    foundry_compilers_artifacts::Source::content_hash_of(&src)
 }
 
 /// Helper function to remove parts of the contract which do not alter its interface:

--- a/crates/compilers/crates/compilers/src/compilers/mod.rs
+++ b/crates/compilers/crates/compilers/src/compilers/mod.rs
@@ -174,6 +174,11 @@ pub trait SourceParser: Clone + Debug + Send + Sync {
     ) -> Result<()> {
         Ok(())
     }
+
+    /// Returns the Solar compiler that owns already parsed Solidity sources, if available.
+    fn solar_compiler(&self) -> Option<&solar::sema::Compiler> {
+        None
+    }
 }
 
 /// Parser of the source files which is used to identify imports and version requirements of the

--- a/crates/compilers/crates/compilers/src/compilers/multi.rs
+++ b/crates/compilers/crates/compilers/src/compilers/multi.rs
@@ -473,6 +473,10 @@ impl SourceParser for MultiCompilerParser {
 
         Ok(())
     }
+
+    fn solar_compiler(&self) -> Option<&solar::sema::Compiler> {
+        self.solc.solar_compiler()
+    }
 }
 
 impl ParsedSource for MultiCompilerParsedSource {

--- a/crates/compilers/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/mod.rs
@@ -464,6 +464,10 @@ impl SourceParser for SolParser {
 
         Ok(())
     }
+
+    fn solar_compiler(&self) -> Option<&solar::sema::Compiler> {
+        Some(&self.compiler)
+    }
 }
 
 impl ParsedSource for SolData {


### PR DESCRIPTION
This reuses the Solar compiler state retained by the source parser when computing preprocessed-cache interface representation hashes, so source files parsed during graph resolution do not get reparsed one by one. Parsers without Solar state keep returning `None`, and the existing `parse_one_source` path remains as the fallback when an AST is unavailable.
