### PR TITLE
feat(wallets): expose pending keystore addresses

### DIFF
--- a/crates/wallets/Cargo.toml
+++ b/crates/wallets/Cargo.toml
@@ -26,7 +26,7 @@ alloy-dyn-abi.workspace = true
 
 # browser wallet
 axum = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
+serde_json.workspace = true
 tokio = { workspace = true, features = ["macros"], optional = true }
 uuid = { workspace = true, optional = true }
 webbrowser = { version = "1.0.6", optional = true }
@@ -64,10 +64,11 @@ eth-keystore = "0.5.0"
 
 [dev-dependencies]
 reqwest = { workspace = true, features = ["json"] }
+tempfile.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 
 [features]
-browser = ["dep:axum", "dep:serde_json", "dep:tokio", "dep:uuid", "dep:webbrowser", "dep:tower", "dep:tower-http"]
+browser = ["dep:axum", "dep:tokio", "dep:uuid", "dep:webbrowser", "dep:tower", "dep:tower-http"]
 tempo = ["dep:tempo-primitives", "dep:rusqlite", "dep:alloy-rlp", "dep:toml"]
 aws-kms = ["dep:alloy-signer-aws", "dep:aws-config", "dep:aws-smithy-time-compat"]
 gcp-kms = ["dep:alloy-signer-gcp"]

--- a/crates/wallets/src/signer.rs
+++ b/crates/wallets/src/signer.rs
@@ -318,14 +318,14 @@ impl TxSigner<Signature> for WalletSigner {
 /// Signers that require user action to be obtained.
 #[derive(Debug, Clone)]
 pub enum PendingSigner {
-    Keystore(PathBuf),
+    Keystore(PathBuf, Option<Address>),
     Interactive,
 }
 
 impl PendingSigner {
     pub fn unlock(self) -> Result<WalletSigner> {
         match self {
-            Self::Keystore(path) => {
+            Self::Keystore(path, _) => {
                 let password = rpassword::prompt_password("Enter keystore password:")?;
                 match PrivateKeySigner::decrypt_keystore(path, password) {
                     Ok(signer) => Ok(WalletSigner::Local(signer)),

--- a/crates/wallets/src/utils.rs
+++ b/crates/wallets/src/utils.rs
@@ -101,7 +101,7 @@ pub fn maybe_get_keystore_path(
 }
 
 /// Extracts the address from a keystore JSON file without decrypting it.
-pub fn extract_keystore_address(path: &Path) -> Result<Address> {
+fn extract_keystore_address(path: &Path) -> Result<Address> {
     let content = fs::read_to_string(path)
         .wrap_err_with(|| format!("Failed to read keystore file at {path:?}"))?;
     let json: serde_json::Value = serde_json::from_str(&content)

--- a/crates/wallets/src/utils.rs
+++ b/crates/wallets/src/utils.rs
@@ -1,5 +1,5 @@
 use crate::{PendingSigner, WalletSigner, error::PrivateKeyError};
-use alloy_primitives::{B256, hex::FromHex};
+use alloy_primitives::{Address, B256, hex::FromHex};
 use alloy_signer_ledger::HDPath as LedgerHDPath;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_signer_trezor::HDPath as TrezorHDPath;
@@ -100,6 +100,22 @@ pub fn maybe_get_keystore_path(
         .or_else(|| maybe_name.map(|name| default_keystore_dir.join(name))))
 }
 
+/// Extracts the address from a keystore JSON file without decrypting it.
+pub fn extract_keystore_address(path: &Path) -> Result<Address> {
+    let content = fs::read_to_string(path)
+        .wrap_err_with(|| format!("Failed to read keystore file at {path:?}"))?;
+    let json: serde_json::Value = serde_json::from_str(&content)
+        .wrap_err_with(|| format!("Failed to parse keystore JSON at {path:?}"))?;
+    let address = json
+        .get("address")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| eyre::eyre!("Keystore JSON does not contain an `address` field"))?;
+
+    address
+        .parse()
+        .wrap_err_with(|| format!("Failed to parse address `{address}` from keystore JSON"))
+}
+
 /// Creates keystore signer from given parameters.
 ///
 /// If correct password or password file is provided, the keystore is decrypted and a [WalletSigner]
@@ -147,7 +163,8 @@ pub fn create_keystore_signer(
             .wrap_err_with(|| format!("Failed to decrypt keystore {path:?}"))?;
         Ok((Some(WalletSigner::Local(wallet)), None))
     } else {
-        Ok((None, Some(PendingSigner::Keystore(path.clone()))))
+        let address = extract_keystore_address(path).ok();
+        Ok((None, Some(PendingSigner::Keystore(path.clone(), address))))
     }
 }
 
@@ -162,5 +179,19 @@ mod tests {
         assert!(create_private_key_signer(&pk_str).is_ok());
         // skip 0x
         assert!(create_private_key_signer(&pk_str[2..]).is_ok());
+    }
+
+    #[test]
+    fn extracts_keystore_address() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("keystore.json");
+        let address = Address::random();
+        fs::write(
+            &path,
+            format!(r#"{{"address":"{}","version":3}}"#, alloy_primitives::hex::encode(address)),
+        )
+        .unwrap();
+
+        assert_eq!(extract_keystore_address(&path).unwrap(), address);
     }
 }

--- a/crates/wallets/src/wallet_multi/mod.rs
+++ b/crates/wallets/src/wallet_multi/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 #[cfg(feature = "browser")]
 use alloy_network::Network;
-use alloy_primitives::map::AddressHashMap;
+use alloy_primitives::{Address, map::AddressHashMap};
 use alloy_signer::Signer;
 use clap::Parser;
 use derive_builder::Builder;
@@ -50,6 +50,17 @@ impl MultiWallet {
 
     pub fn add_signer(&mut self, signer: WalletSigner) {
         self.signers.insert(signer.address(), signer);
+    }
+
+    /// Returns addresses for unlocked signers and pending keystores whose address can be read
+    /// without unlocking.
+    pub fn available_addresses(&self) -> Vec<Address> {
+        let mut addresses: Vec<_> = self.signers.keys().copied().collect();
+        addresses.extend(self.pending_signers.iter().filter_map(|pending| match pending {
+            PendingSigner::Keystore(_, Some(address)) => Some(*address),
+            _ => None,
+        }));
+        addresses
     }
 }
 
@@ -621,5 +632,19 @@ mod tests {
                 test_case.2
             )
         }
+    }
+
+    #[test]
+    fn available_addresses_includes_pending_keystores() {
+        let address = Address::random();
+        let wallet = MultiWallet::new(
+            vec![
+                PendingSigner::Keystore(PathBuf::from("keystore"), Some(address)),
+                PendingSigner::Interactive,
+            ],
+            vec![],
+        );
+
+        assert_eq!(wallet.available_addresses(), vec![address]);
     }
 }


### PR DESCRIPTION
## Summary

- store the parsed address for pending keystore signers
- expose `MultiWallet::available_addresses()` so callers can inspect keystore addresses without unlocking
- keep tests focused on address extraction and pending keystore address exposure

## Tests

- `cargo test -p foundry-wallets`

Prompted by: @DaniPopes