### PR TITLE
fix: don't abort on Ledger/Trezor USB init

### DIFF
--- a/crates/wallets/Cargo.toml
+++ b/crates/wallets/Cargo.toml
@@ -62,6 +62,10 @@ toml = { workspace = true, optional = true }
 tracing.workspace = true
 eth-keystore = "0.5.0"
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+hidapi-rusb = "1.3"
+rusb = "0.9"
+
 [dev-dependencies]
 reqwest = { workspace = true, features = ["json"] }
 tempfile.workspace = true

--- a/crates/wallets/src/error.rs
+++ b/crates/wallets/src/error.rs
@@ -40,8 +40,18 @@ pub enum WalletSignerError {
     IncorrectKeystorePassword,
     #[error(transparent)]
     Ledger(#[from] LedgerError),
+    #[error(
+        "failed to initialize the HID API for the Ledger device; \
+         this can happen in headless or containerized environments without USB/HID access"
+    )]
+    LedgerHidInit,
     #[error(transparent)]
     Trezor(#[from] TrezorError),
+    #[error(
+        "failed to initialize libusb for the Trezor device; \
+         this can happen in headless or containerized environments without USB access"
+    )]
+    TrezorUsbInit,
     #[error(transparent)]
     #[cfg(feature = "aws-kms")]
     Aws(#[from] Box<AwsSignerError>),

--- a/crates/wallets/src/signer.rs
+++ b/crates/wallets/src/signer.rs
@@ -49,13 +49,43 @@ pub enum WalletSigner {
     Turnkey(TurnkeySigner),
 }
 
+/// Probes HID availability without triggering `coins-ledger`'s panicking
+/// `HidApi::new().expect(..)`, which would abort the process under `panic = "abort"`
+/// (foundry-rs/foundry#14491). Cached because `hidapi-rusb` allows only one live `HidApi`; a later
+/// probe would see the lock held and fail.
+#[cfg(not(target_arch = "wasm32"))]
+fn hid_api_available() -> bool {
+    static HID_API_AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *HID_API_AVAILABLE.get_or_init(|| hidapi_rusb::HidApi::new().is_ok())
+}
+
+/// Probes libusb availability without triggering `rusb::GlobalContext`, which `panic!`s (inside a
+/// `Once`) when `libusb_init` fails and would abort the process under `panic = "abort"`. `trezor-
+/// client` uses that global context, so we probe a throwaway `rusb::Context` (which returns a
+/// `Result`) first. Cached so we probe at most once per process.
+#[cfg(not(target_arch = "wasm32"))]
+fn usb_available() -> bool {
+    static USB_AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *USB_AVAILABLE.get_or_init(|| rusb::Context::new().is_ok())
+}
+
 impl WalletSigner {
     pub async fn from_ledger_path(path: LedgerHDPath) -> Result<Self> {
+        #[cfg(not(target_arch = "wasm32"))]
+        if !hid_api_available() {
+            return Err(WalletSignerError::LedgerHidInit);
+        }
+
         let ledger = LedgerSigner::new(path, None).await?;
         Ok(Self::Ledger(ledger))
     }
 
     pub async fn from_trezor_path(path: TrezorHDPath) -> Result<Self> {
+        #[cfg(not(target_arch = "wasm32"))]
+        if !usb_available() {
+            return Err(WalletSignerError::TrezorUsbInit);
+        }
+
         let trezor = TrezorSigner::new(path, None).await?;
         Ok(Self::Trezor(trezor))
     }


### PR DESCRIPTION
`cast wallet list --all` crashed with a SIGABRT in headless/containerized environments because `coins-ledger` and `rusb` panic when HID/USB initialization fails, and Foundry ships with `panic = "abort"` so the panic aborts the whole process. This probes HID/USB availability first and returns a normal error, so hardware-wallet backends are skipped gracefully instead of crashing. Fixes foundry-rs/foundry#14491.