### PR TITLE
perf(compilers): skip out-of-scope artifact reads

### DIFF
--- a/crates/compilers/crates/compilers/src/cache.rs
+++ b/crates/compilers/crates/compilers/src/cache.rs
@@ -330,11 +330,20 @@ impl<S: CompilerSettings> CompilerCache<S> {
     pub fn read_artifacts<Artifact: DeserializeOwned + Send + Sync>(
         &self,
     ) -> Result<Artifacts<Artifact>> {
+        self.read_artifacts_filtered(|_| true)
+    }
+
+    fn read_artifacts_filtered<Artifact, F>(&self, filter: F) -> Result<Artifacts<Artifact>>
+    where
+        Artifact: DeserializeOwned + Send + Sync,
+        F: Fn(&Path) -> bool + Send + Sync,
+    {
         use rayon::prelude::*;
 
         let artifacts = self
             .files
             .par_iter()
+            .filter(|(file, _)| filter(file))
             .map(|(file, entry)| entry.read_artifact_files().map(|files| (file.clone(), files)))
             .collect::<Result<ArtifactsMap<_>>>()?;
         Ok(Artifacts(artifacts))
@@ -1119,7 +1128,17 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
             let mut cached_artifacts = if project.paths.artifacts.exists() {
                 trace!("reading artifacts from cache...");
                 // if we failed to read the whole set of artifacts we use an empty set
-                let artifacts = cache.read_artifacts::<T::Artifact>().unwrap_or_default();
+                // Only artifacts in the current source graph can be returned by this compilation.
+                // Avoid deserializing cached artifacts from unrelated partial compilations.
+                let in_scope = cache
+                    .files
+                    .keys()
+                    .filter(|file| edges.get_parsed_source(file).is_some())
+                    .cloned()
+                    .collect::<HashSet<_>>();
+                let artifacts = cache
+                    .read_artifacts_filtered::<T::Artifact, _>(|file| in_scope.contains(file))
+                    .unwrap_or_default();
                 trace!("read {} artifacts from cache", artifacts.artifact_files().count());
                 artifacts
             } else {

--- a/crates/compilers/crates/compilers/tests/project.rs
+++ b/crates/compilers/crates/compilers/tests/project.rs
@@ -553,6 +553,25 @@ fn can_compile_dapp_sample_with_cache() {
     assert!(compiled.find_first("Dapp").is_none());
 }
 
+#[test]
+fn partial_compile_ignores_out_of_scope_artifacts() {
+    let project = TempProject::<MultiCompiler>::dapptools().unwrap();
+    let a = project.add_basic_source("A", "^0.8.10").unwrap();
+    let b = project.add_basic_source("B", "^0.8.10").unwrap();
+
+    project.compile().unwrap().assert_success();
+
+    let cache = CompilerCache::<MultiCompilerSettings>::read_joined(project.paths()).unwrap();
+    let b_artifact = cache.entry(&b).unwrap().find_artifact_path("B").unwrap();
+    fs::write(b_artifact, "invalid artifact").unwrap();
+
+    let compiled = project.project().compile_file(&a).unwrap();
+    compiled.assert_success();
+    assert!(compiled.is_unchanged());
+    assert!(compiled.find(&a, "A").is_some());
+    assert!(compiled.find(&b, "B").is_none());
+}
+
 fn copy_dir_all(src: &Path, dst: &Path) -> io::Result<()> {
     std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {


### PR DESCRIPTION
## Summary

- only deserialize cached artifacts whose source belongs to the current compilation graph
- keep full-cache callers unchanged while reducing I/O and JSON work for partial builds
- cover partial compilation with a corrupt out-of-scope artifact, proving unrelated artifacts are not opened
- checked formatting, the focused regression, existing Solidity/Vyper cache tests, and `foundry-compilers` with all features

## Benchmarks

Aave V4 (`271M out`, warm cache), Apple M5 Pro. Measured with `hyperfine --warmup 5 --runs 20`.

| Command | Before | After | Speedup | Artifacts read |
| --- | ---: | ---: | ---: | ---: |
| `forge build src/libraries/math/WadRayMath.sol` | `504.7 ms ± 3.9 ms` | `396.2 ms ± 2.5 ms` | `1.27x` | `664 -> 3` |
| `forge build tests/deployments/batches/AaveV4AuthorityBatch.t.sol` | `540.6 ms ± 6.8 ms` | `443.5 ms ± 1.3 ms` | `1.22x` | `664 -> 235` |

The same scoped reads also reduce a cached filtered test run from `1.147 s ± 0.010 s` to `1.059 s ± 0.004 s` (`1.08x`).
