### PR TITLE
chore: bump Alloy to 2.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,10 +180,10 @@ walkdir.opt-level = 3
 
 [workspace.dependencies]
 # alloy
-alloy-consensus = "2.0.5"
+alloy-consensus = "2.2.0"
 alloy-dyn-abi = "1.6.0"
 alloy-json-abi = { version = "1.3.1", features = ["serde_json"] }
-alloy-network = "2.0.5"
+alloy-network = "2.2.0"
 alloy-primitives = { version = "1.6.0", features = [
     "getrandom",
     "rand",
@@ -191,13 +191,13 @@ alloy-primitives = { version = "1.6.0", features = [
     "map-foldhash",
 ] }
 alloy-rlp = "0.3.15"
-alloy-signer = "2.0.5"
-alloy-signer-aws = "2.0.5"
-alloy-signer-gcp = "2.0.5"
-alloy-signer-ledger = "2.0.5"
-alloy-signer-local = "2.0.5"
-alloy-signer-trezor = "2.0.5"
-alloy-signer-turnkey = "2.0.5"
+alloy-signer = "2.2.0"
+alloy-signer-aws = "2.2.0"
+alloy-signer-gcp = "2.2.0"
+alloy-signer-ledger = "2.2.0"
+alloy-signer-local = "2.2.0"
+alloy-signer-trezor = "2.2.0"
+alloy-signer-turnkey = "2.2.0"
 alloy-sol-types = "1.6.0"
 alloy-chains = "0.2.34"
 

--- a/crates/fork-db/Cargo.toml
+++ b/crates/fork-db/Cargo.toml
@@ -24,8 +24,8 @@ zstd = ["dep:zstd"]
 [dependencies]
 alloy-chains = { workspace = true, features = ["serde"] }
 alloy-primitives = { workspace = true, features = ["map"] }
-alloy-provider = { version = "2.0.4", default-features = false }
-alloy-rpc-types = { version = "2.0.4", features = ["eth"] }
+alloy-provider = { version = "2.2.0", default-features = false }
+alloy-rpc-types = { version = "2.2.0", features = ["eth"] }
 
 eyre.workspace = true
 futures = "0.3.32"
@@ -46,6 +46,6 @@ zstd = { version = "0.13.3", optional = true }
 
 [dev-dependencies]
 alloy-consensus.workspace = true
-alloy-rpc-client = "2.0.4"
+alloy-rpc-client = "2.2.0"
 tempfile.workspace = true
 tiny_http = "0.12.0"

--- a/crates/wallets/src/utils.rs
+++ b/crates/wallets/src/utils.rs
@@ -20,13 +20,13 @@ fn ensure_pk_not_env(pk: &str) -> Result<()> {
 pub fn create_private_key_signer(private_key_str: &str) -> Result<WalletSigner> {
     let Ok(private_key) = B256::from_hex(private_key_str) else {
         ensure_pk_not_env(private_key_str)?;
-        eyre::bail!("Failed to decode private key")
+        eyre::bail!("Failed to decode private key");
     };
     match PrivateKeySigner::from_bytes(&private_key) {
         Ok(pk) => Ok(WalletSigner::Local(pk)),
         Err(err) => {
             ensure_pk_not_env(private_key_str)?;
-            eyre::bail!("Failed to create wallet from private key: {err}")
+            eyre::bail!("Failed to create wallet from private key: {err}");
         }
     }
 }
@@ -129,13 +129,13 @@ pub fn create_keystore_signer(
     maybe_password_file: Option<&str>,
 ) -> Result<(Option<WalletSigner>, Option<PendingSigner>)> {
     if !path.exists() {
-        eyre::bail!("Keystore file `{path:?}` does not exist")
+        eyre::bail!("Keystore file `{path:?}` does not exist");
     }
 
     if path.is_dir() {
         eyre::bail!(
             "Keystore path `{path:?}` is a directory. Please specify the keystore file directly."
-        )
+        );
     }
 
     let password = match (maybe_password, maybe_password_file) {


### PR DESCRIPTION
Bumps the Alloy 2.x dependencies to 2.2.0 across the workspace and `foundry-fork-db`.

This keeps the consensus, network, provider, RPC, and signer crates on the same Alloy release.

Validation:
- `cargo +nightly fmt`
- `cargo +nightly clippy --all --all-features --all-targets -- -D warnings`
