### PR TITLE
fix(compilers): exclude unrelated re-export imports

### DIFF
--- a/crates/compilers/crates/compilers/src/flatten.rs
+++ b/crates/compilers/crates/compilers/src/flatten.rs
@@ -1,6 +1,6 @@
 use crate::{
     ArtifactOutput, CompilerSettings, Graph, Project, ProjectPathsConfig, SourceParser, Updates,
-    apply_updates,
+    VersionedSourceFiles, apply_updates,
     compilers::{Compiler, ParsedSource},
     filter::MaybeSolData,
     resolver::parse::SolData,
@@ -207,6 +207,15 @@ impl Flattener {
 
         let output = output.compiler_output;
 
+        // AST IDs are only unique within a single compiler invocation. Select the build that
+        // contains the target so IDs from different builds are never mixed.
+        let target_build_id = output
+            .sources
+            .0
+            .get(target)
+            .and_then(|files| files.iter().find(|file| file.source_file.ast.is_some()))
+            .map(|file| file.build_id.clone());
+
         let sources = Source::read_all([target.to_path_buf()])?;
         let graph = Graph::<C::Parser>::resolve_sources(&project.paths, sources)?;
 
@@ -222,12 +231,19 @@ impl Flattener {
             sources
         };
 
-        let sources = Source::read_all(&ordered_sources)?;
+        let mut sources = Source::read_all(&ordered_sources)?;
+        let coherent_target_build = target_build_id.as_ref().is_some_and(|build_id| {
+            has_complete_ast_build(&output.sources, &ordered_sources, build_id)
+        });
 
         // Convert all ASTs from artifacts to strongly typed ASTs
         let mut asts: Vec<(PathBuf, SourceUnit)> = Vec::new();
         for (path, ast) in output.sources.0.iter().filter_map(|(path, files)| {
-            if let Some(ast) = files.first().and_then(|source| source.source_file.ast.as_ref())
+            let source = target_build_id
+                .as_ref()
+                .and_then(|build_id| files.iter().find(|source| source.build_id == *build_id))
+                .or_else(|| files.first());
+            if let Some(ast) = source.and_then(|source| source.source_file.ast.as_ref())
                 && sources.contains_key(path)
             {
                 return Some((path, ast));
@@ -235,6 +251,18 @@ impl Flattener {
             None
         }) {
             asts.push((PathBuf::from(path), serde_json::from_str(&serde_json::to_string(ast)?)?));
+        }
+
+        // Prune intermediary-only sources only when every physical dependency has an AST from one
+        // coherent build. Otherwise retain the complete dependency closure.
+        let mut ordered_sources = ordered_sources;
+        if coherent_target_build
+            && asts.len() == ordered_sources.len()
+            && let Some(retained) = collect_semantic_sources(target, &asts)
+        {
+            ordered_sources.retain(|path| retained.contains(path));
+            sources.retain(|path, _| retained.contains(path));
+            asts.retain(|(path, _)| retained.contains(path));
         }
 
         Ok(Self {
@@ -784,6 +812,108 @@ impl Flattener {
     }
 }
 
+/// Returns whether every source has an AST produced by the selected compiler build.
+fn has_complete_ast_build(
+    sources: &VersionedSourceFiles,
+    paths: &[PathBuf],
+    build_id: &str,
+) -> bool {
+    paths.iter().all(|path| {
+        sources.0.get(path).is_some_and(|files| {
+            files
+                .iter()
+                .any(|source| source.build_id == build_id && source.source_file.ast.is_some())
+        })
+    })
+}
+
+/// Collects source units selected by imports, resolving named imports to their declaration owners.
+/// Returns `None` if the AST data is incomplete or inconsistent.
+fn collect_semantic_sources(
+    target: &Path,
+    asts: &[(PathBuf, SourceUnit)],
+) -> Option<HashSet<PathBuf>> {
+    let mut asts_by_path = HashMap::new();
+    let mut source_units = HashMap::new();
+    let mut declaration_owners = HashMap::new();
+
+    for (path, ast) in asts {
+        asts_by_path.insert(path.clone(), ast);
+        if source_units.insert(ast.id, path.clone()).is_some() {
+            return None;
+        }
+        for node in &ast.nodes {
+            if let Some(id) = top_level_declaration_id(node)
+                && declaration_owners.insert(id, path.clone()).is_some()
+            {
+                return None;
+            }
+        }
+    }
+
+    let mut retained = HashSet::new();
+    let mut pending = vec![target.to_path_buf()];
+
+    while let Some(path) = pending.pop() {
+        if !retained.insert(path.clone()) {
+            continue;
+        }
+        let ast = asts_by_path.get(&path)?;
+
+        for import in ast.nodes.iter().filter_map(|node| match node {
+            SourceUnitPart::ImportDirective(import) => Some(import),
+            _ => None,
+        }) {
+            if import.symbol_aliases.is_empty() {
+                pending.push(source_units.get(&import.source_unit)?.clone());
+                continue;
+            }
+
+            for alias in &import.symbol_aliases {
+                let mut ids = alias
+                    .foreign
+                    .overloaded_declarations
+                    .iter()
+                    .map(|id| usize::try_from(*id).ok())
+                    .collect::<Option<HashSet<_>>>()?;
+                if let Some(id) = alias.foreign.referenced_declaration
+                    && let Ok(id) = usize::try_from(id)
+                {
+                    ids.insert(id);
+                }
+                if ids.is_empty() {
+                    let imported_path = source_units.get(&import.source_unit)?;
+                    let imported_ast = asts_by_path.get(imported_path)?;
+                    ids.extend(imported_ast.exported_symbols.get(&alias.foreign.name)?);
+                }
+                if ids.is_empty() {
+                    return None;
+                }
+                for id in ids {
+                    pending.push(declaration_owners.get(&id)?.clone());
+                }
+            }
+        }
+    }
+
+    Some(retained)
+}
+
+/// Returns the ID of an importable top-level declaration.
+fn top_level_declaration_id(node: &SourceUnitPart) -> Option<usize> {
+    match node {
+        SourceUnitPart::VariableDeclaration(node) => Some(node.id),
+        SourceUnitPart::EnumDefinition(node) => Some(node.id),
+        SourceUnitPart::ErrorDefinition(node) => Some(node.id),
+        SourceUnitPart::EventDefinition(node) => Some(node.id),
+        SourceUnitPart::FunctionDefinition(node) => Some(node.id),
+        SourceUnitPart::StructDefinition(node) => Some(node.id),
+        SourceUnitPart::UserDefinedValueTypeDefinition(node) => Some(node.id),
+        SourceUnitPart::ContractDefinition(node) => Some(node.id),
+        _ => None,
+    }
+}
+
 /// Performs DFS to collect all dependencies of a target
 fn collect_deps<P: SourceParser<ParsedSource: MaybeSolData>>(
     path: &Path,
@@ -880,4 +1010,47 @@ pub fn combine_version_pragmas(pragmas: &[impl AsRef<str>]) -> Option<String> {
         return None;
     }
     Some(format!("pragma solidity {};", versions.iter().format(" ")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::VersionedSourceFile;
+    use foundry_compilers_artifacts::SourceFile;
+    use semver::Version;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    fn versioned_source(build_id: &str) -> VersionedSourceFile {
+        VersionedSourceFile {
+            source_file: SourceFile {
+                id: 0,
+                ast: Some(
+                    serde_json::from_value(json!({
+                        "absolutePath": "source.sol",
+                        "exportedSymbols": {},
+                        "id": 0,
+                        "nodeType": "SourceUnit",
+                        "nodes": [],
+                        "src": "0:0:0"
+                    }))
+                    .unwrap(),
+                ),
+            },
+            version: Version::new(0, 8, 30),
+            build_id: build_id.to_string(),
+            profile: "default".to_string(),
+        }
+    }
+
+    #[test]
+    fn complete_ast_build_rejects_mixed_builds() {
+        let paths = vec![PathBuf::from("A.sol"), PathBuf::from("B.sol")];
+        let sources = VersionedSourceFiles(BTreeMap::from([
+            (paths[0].clone(), vec![versioned_source("target")]),
+            (paths[1].clone(), vec![versioned_source("other")]),
+        ]));
+
+        assert!(!has_complete_ast_build(&sources, &paths, "target"));
+    }
 }

--- a/crates/compilers/crates/compilers/src/flatten.rs
+++ b/crates/compilers/crates/compilers/src/flatten.rs
@@ -1,6 +1,6 @@
 use crate::{
     ArtifactOutput, CompilerSettings, Graph, Project, ProjectPathsConfig, SourceParser, Updates,
-    VersionedSourceFiles, apply_updates,
+    VersionedSourceFile, VersionedSourceFiles, apply_updates,
     compilers::{Compiler, ParsedSource},
     filter::MaybeSolData,
     resolver::parse::SolData,
@@ -207,15 +207,6 @@ impl Flattener {
 
         let output = output.compiler_output;
 
-        // AST IDs are only unique within a single compiler invocation. Select the build that
-        // contains the target so IDs from different builds are never mixed.
-        let target_build_id = output
-            .sources
-            .0
-            .get(target)
-            .and_then(|files| files.iter().find(|file| file.source_file.ast.is_some()))
-            .map(|file| file.build_id.clone());
-
         let sources = Source::read_all([target.to_path_buf()])?;
         let graph = Graph::<C::Parser>::resolve_sources(&project.paths, sources)?;
 
@@ -232,17 +223,21 @@ impl Flattener {
         };
 
         let mut sources = Source::read_all(&ordered_sources)?;
-        let coherent_target_build = target_build_id.as_ref().is_some_and(|build_id| {
-            has_complete_ast_build(&output.sources, &ordered_sources, build_id)
-        });
+
+        // AST IDs are only unique within a single compiler invocation. Select a target build only
+        // if it produced an AST for every source, then use that build exclusively.
+        let Some(target_build_id) =
+            complete_ast_build_id(&output.sources, &ordered_sources, target)
+        else {
+            return Err(FlattenerError::Compilation(SolcError::msg(
+                "no compiler build produced ASTs for every source",
+            )));
+        };
 
         // Convert all ASTs from artifacts to strongly typed ASTs
         let mut asts: Vec<(PathBuf, SourceUnit)> = Vec::new();
         for (path, ast) in output.sources.0.iter().filter_map(|(path, files)| {
-            let source = target_build_id
-                .as_ref()
-                .and_then(|build_id| files.iter().find(|source| source.build_id == *build_id))
-                .or_else(|| files.first());
+            let source = source_with_ast(files, &target_build_id);
             if let Some(ast) = source.and_then(|source| source.source_file.ast.as_ref())
                 && sources.contains_key(path)
             {
@@ -253,13 +248,10 @@ impl Flattener {
             asts.push((PathBuf::from(path), serde_json::from_str(&serde_json::to_string(ast)?)?));
         }
 
-        // Prune intermediary-only sources only when every physical dependency has an AST from one
-        // coherent build. Otherwise retain the complete dependency closure.
+        // Prune intermediary-only sources. If semantic resolution fails, retain the complete
+        // dependency closure.
         let mut ordered_sources = ordered_sources;
-        if coherent_target_build
-            && asts.len() == ordered_sources.len()
-            && let Some(retained) = collect_semantic_sources(target, &asts)
-        {
+        if let Some(retained) = collect_semantic_sources(target, &asts) {
             ordered_sources.retain(|path| retained.contains(path));
             sources.retain(|path, _| retained.contains(path));
             asts.retain(|(path, _)| retained.contains(path));
@@ -812,19 +804,28 @@ impl Flattener {
     }
 }
 
-/// Returns whether every source has an AST produced by the selected compiler build.
-fn has_complete_ast_build(
+/// Returns the ID of a target build that produced an AST for every source.
+fn complete_ast_build_id(
     sources: &VersionedSourceFiles,
     paths: &[PathBuf],
-    build_id: &str,
-) -> bool {
-    paths.iter().all(|path| {
-        sources.0.get(path).is_some_and(|files| {
-            files
-                .iter()
-                .any(|source| source.build_id == build_id && source.source_file.ast.is_some())
-        })
+    target: &Path,
+) -> Option<String> {
+    sources.0.get(target)?.iter().find_map(|target_source| {
+        let build_id = &target_source.build_id;
+        (target_source.source_file.ast.is_some()
+            && paths.iter().all(|path| {
+                sources.0.get(path).is_some_and(|files| source_with_ast(files, build_id).is_some())
+            }))
+        .then(|| build_id.clone())
     })
+}
+
+/// Returns the source produced by the selected build only if it contains an AST.
+fn source_with_ast<'a>(
+    files: &'a [VersionedSourceFile],
+    build_id: &str,
+) -> Option<&'a VersionedSourceFile> {
+    files.iter().find(|source| source.build_id == build_id && source.source_file.ast.is_some())
 }
 
 /// Collects source units selected by imports, resolving named imports to their declaration owners.
@@ -1015,17 +1016,16 @@ pub fn combine_version_pragmas(pragmas: &[impl AsRef<str>]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::VersionedSourceFile;
     use foundry_compilers_artifacts::SourceFile;
     use semver::Version;
     use serde_json::json;
     use std::collections::BTreeMap;
 
-    fn versioned_source(build_id: &str) -> VersionedSourceFile {
+    fn versioned_source(build_id: &str, has_ast: bool) -> VersionedSourceFile {
         VersionedSourceFile {
             source_file: SourceFile {
                 id: 0,
-                ast: Some(
+                ast: has_ast.then(|| {
                     serde_json::from_value(json!({
                         "absolutePath": "source.sol",
                         "exportedSymbols": {},
@@ -1034,8 +1034,8 @@ mod tests {
                         "nodes": [],
                         "src": "0:0:0"
                     }))
-                    .unwrap(),
-                ),
+                    .unwrap()
+                }),
             },
             version: Version::new(0, 8, 30),
             build_id: build_id.to_string(),
@@ -1044,13 +1044,29 @@ mod tests {
     }
 
     #[test]
-    fn complete_ast_build_rejects_mixed_builds() {
+    fn complete_ast_build_ignores_incomplete_target_build() {
         let paths = vec![PathBuf::from("A.sol"), PathBuf::from("B.sol")];
-        let sources = VersionedSourceFiles(BTreeMap::from([
-            (paths[0].clone(), vec![versioned_source("target")]),
-            (paths[1].clone(), vec![versioned_source("other")]),
+        let mut sources = VersionedSourceFiles(BTreeMap::from([
+            (
+                paths[0].clone(),
+                vec![versioned_source("incomplete", false), versioned_source("complete", true)],
+            ),
+            (
+                paths[1].clone(),
+                vec![
+                    versioned_source("incomplete", true),
+                    versioned_source("complete", false),
+                    versioned_source("complete", true),
+                ],
+            ),
         ]));
 
-        assert!(!has_complete_ast_build(&sources, &paths, "target"));
+        assert_eq!(
+            complete_ast_build_id(&sources, &paths, &paths[0]),
+            Some("complete".to_string())
+        );
+
+        sources.0.get_mut(&paths[1]).unwrap().retain(|source| source.build_id == "incomplete");
+        assert_eq!(complete_ast_build_id(&sources, &paths, &paths[0]), None);
     }
 }

--- a/crates/compilers/crates/compilers/tests/project.rs
+++ b/crates/compilers/crates/compilers/tests/project.rs
@@ -599,6 +599,188 @@ fn test_flatteners(project: &TempProject, target: &Path, additional_checks: fn(&
     additional_checks(&result);
 }
 
+// <https://github.com/foundry-rs/foundry/issues/7239>
+#[test]
+fn can_flatten_named_import_through_intermediary() {
+    let project = TempProject::<MultiCompiler>::dapptools().unwrap();
+
+    project
+        .add_source(
+            "Test",
+            r#"pragma solidity ^0.8.10;
+contract Test {}
+contract Sibling {}
+"#,
+        )
+        .unwrap();
+    project
+        .add_source(
+            "Test2",
+            r#"pragma solidity ^0.8.10;
+contract Test2 {}
+"#,
+        )
+        .unwrap();
+    project
+        .add_source(
+            "Intermediary",
+            r#"pragma solidity ^0.8.10;
+import {Test} from "./Test.sol";
+import {Test2} from "./Test2.sol";
+"#,
+        )
+        .unwrap();
+    let target = project
+        .add_source(
+            "A",
+            r#"pragma solidity ^0.8.10;
+import {Test as Base} from "./Intermediary.sol";
+contract A is Base {}
+"#,
+        )
+        .unwrap();
+
+    let target = canonicalize(target).unwrap();
+    let result = Flattener::new(project.project().clone(), &target).unwrap().flatten();
+    assert_eq!(
+        result,
+        r#"pragma solidity ^0.8.10;
+
+// src/Test.sol
+
+contract Test {}
+contract Sibling {}
+
+// src/A.sol
+
+contract A is Test {}
+"#
+    );
+
+    let flattened = project.add_source("Flattened", result).unwrap();
+    project.project().compile_file(flattened).unwrap().assert_success();
+}
+
+#[test]
+fn can_flatten_plain_import_through_intermediary() {
+    let project = TempProject::<MultiCompiler>::dapptools().unwrap();
+
+    project.add_source("Test", "contract Test {}\n").unwrap();
+    project.add_source("Test2", "contract Test2 {}\n").unwrap();
+    project
+        .add_source(
+            "Intermediary",
+            r#"import {Test} from "./Test.sol";
+import {Test2} from "./Test2.sol";
+"#,
+        )
+        .unwrap();
+    let target = project
+        .add_source(
+            "A",
+            r#"import "./Intermediary.sol";
+contract A is Test {}
+"#,
+        )
+        .unwrap();
+
+    let result = Flattener::new(project.project().clone(), &canonicalize(target).unwrap())
+        .unwrap()
+        .flatten();
+    assert!(result.contains("contract Test {}"));
+    assert!(result.contains("contract Test2 {}"));
+    assert!(result.contains("// src/Intermediary.sol"));
+
+    let flattened = project.add_source("Flattened", result).unwrap();
+    project.project().compile_file(flattened).unwrap().assert_success();
+}
+
+#[test]
+fn can_flatten_overloads_through_intermediary() {
+    let project = TempProject::<MultiCompiler>::dapptools().unwrap();
+
+    project
+        .add_source(
+            "Uint",
+            "function convert(uint256 value) pure returns (uint256) { return value; }",
+        )
+        .unwrap();
+    project
+        .add_source(
+            "Address",
+            "function convert(address value) pure returns (address) { return value; }",
+        )
+        .unwrap();
+    project.add_source("Unused", "contract Unused {}\n").unwrap();
+    project
+        .add_source(
+            "Intermediary",
+            r#"import "./Uint.sol";
+import "./Address.sol";
+import "./Unused.sol";
+"#,
+        )
+        .unwrap();
+    let target = project
+        .add_source(
+            "A",
+            r#"import {convert} from "./Intermediary.sol";
+contract A {
+    function values(uint256 number, address account) external pure {
+        convert(number);
+        convert(account);
+    }
+}
+"#,
+        )
+        .unwrap();
+
+    let result = Flattener::new(project.project().clone(), &canonicalize(target).unwrap())
+        .unwrap()
+        .flatten();
+    assert!(result.contains("function convert_1(uint256 value)"));
+    assert!(result.contains("function convert_0(address value)"));
+    assert!(!result.contains("contract Unused"), "{result}");
+    assert!(!result.contains("// src/Intermediary.sol"));
+
+    let flattened = project.add_source("Flattened", result).unwrap();
+    project.project().compile_file(flattened).unwrap().assert_success();
+}
+
+#[test]
+fn can_flatten_namespace_import_through_intermediary() {
+    let project = TempProject::<MultiCompiler>::dapptools().unwrap();
+
+    project.add_source("Test", "contract Test {}\n").unwrap();
+    project.add_source("Test2", "contract Test2 {}\n").unwrap();
+    project
+        .add_source(
+            "Intermediary",
+            r#"import {Test} from "./Test.sol";
+import {Test2} from "./Test2.sol";
+"#,
+        )
+        .unwrap();
+    let target = project
+        .add_source(
+            "A",
+            r#"import * as Types from "./Intermediary.sol";
+contract A is Types.Test {}
+"#,
+        )
+        .unwrap();
+
+    let result = Flattener::new(project.project().clone(), &canonicalize(target).unwrap())
+        .unwrap()
+        .flatten();
+    assert!(result.contains("contract Test {}"));
+    assert!(result.contains("contract Test2 {}"));
+    assert!(result.contains("// src/Intermediary.sol"));
+
+    let flattened = project.add_source("Flattened", result).unwrap();
+    project.project().compile_file(flattened).unwrap().assert_success();
+}
+
 #[test]
 fn can_flatten_file_with_external_lib() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/hardhat-sample");


### PR DESCRIPTION
Resolve named imports to their declaration-owning source units when flattening, preventing unrelated dependencies from intermediary re-export files from being included. Plain and namespace imports remain conservative, and incomplete AST data falls back to the full dependency closure.

Towards foundry-rs/foundry#7239.