### PR TITLE
fix(compilers): request flatten ASTs for all profiles

### DIFF
--- a/crates/compilers/crates/compilers/src/flatten.rs
+++ b/crates/compilers/crates/compilers/src/flatten.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ArtifactOutput, CompilerSettings, Graph, Project, ProjectPathsConfig, SourceParser, Updates,
-    VersionedSourceFile, VersionedSourceFiles, apply_updates,
+    ArtifactOutput, Graph, Project, ProjectPathsConfig, SourceParser, Updates, VersionedSourceFile,
+    VersionedSourceFiles, apply_updates,
     compilers::{Compiler, ParsedSource},
     filter::MaybeSolData,
     resolver::parse::SolData,
@@ -192,10 +192,10 @@ impl Flattener {
     where
         C::Parser: SourceParser<ParsedSource: MaybeSolData>,
     {
-        // Configure project to compile the target file and only request AST for target file.
+        // Configure every settings profile to request only AST output when compiling the target.
         project.cached = false;
         project.no_artifacts = true;
-        project.settings.update_output_selection(|selection| {
+        project.update_output_selection(|selection| {
             *selection = OutputSelection::ast_output_selection();
         });
 

--- a/crates/compilers/crates/compilers/tests/project.rs
+++ b/crates/compilers/crates/compilers/tests/project.rs
@@ -662,6 +662,56 @@ contract A is Test {}
 }
 
 #[test]
+fn can_flatten_with_additional_settings_profile() {
+    let mut project = TempProject::<MultiCompiler>::dapptools().unwrap();
+
+    project.add_source("Base", "contract Base {}\n").unwrap();
+    let target = project
+        .add_source(
+            "A",
+            r#"import {Base} from "./Base.sol";
+contract A is Base {}
+"#,
+        )
+        .unwrap();
+
+    let mut optimized_settings = project.project().settings.clone();
+    optimized_settings.solc.optimizer.enabled = Some(true);
+    optimized_settings.solc.optimizer.runs = Some(10_000);
+    optimized_settings.solc.output_selection = OutputSelection::default_output_selection();
+    project.project_mut().additional_settings.insert("optimized".to_string(), optimized_settings);
+    project.project_mut().restrictions.insert(
+        target.clone(),
+        RestrictionsWithVersion {
+            restrictions: MultiCompilerRestrictions {
+                solc: SolcRestrictions {
+                    optimizer_runs: Restriction { min: Some(10_000), ..Default::default() },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            version: None,
+        },
+    );
+
+    let target = canonicalize(target).unwrap();
+    let result = Flattener::new(project.project().clone(), &target).unwrap().flatten();
+    assert_eq!(
+        result,
+        r#"// src/Base.sol
+contract Base {}
+
+// src/A.sol
+
+contract A is Base {}
+"#
+    );
+
+    let flattened = project.add_source("Flattened", result).unwrap();
+    project.project().compile_file(flattened).unwrap().assert_success();
+}
+
+#[test]
 fn can_flatten_plain_import_through_intermediary() {
     let project = TempProject::<MultiCompiler>::dapptools().unwrap();
 


### PR DESCRIPTION
Updates `Flattener::new` to request AST output from every settings profile instead of only the default profile.

Previously, flattening could fail with `no compiler build produced ASTs for every source` when restrictions selected an additional profile that did not request AST output.

The regression test forces the target onto an additional `optimized` profile and verifies that flattening succeeds and the generated output recompiles.

Follow-up to https://github.com/foundry-rs/foundry-core/pull/125#discussion_r3631681432.