### PR TITLE
feat(output-selection): add `OutputSelection::empty()` and `insert` builder method

### DIFF
--- a/crates/compilers/crates/artifacts/solc/src/output_selection.rs
+++ b/crates/compilers/crates/artifacts/solc/src/output_selection.rs
@@ -70,6 +70,35 @@ impl OutputSelection {
         .into()
     }
 
+    /// Returns a completely empty output selection: `{}`.
+    /// 
+    /// Used for fine-grained control over which outputs are requested.
+    /// Combine with [`Self::insert`] to build the selection of outputs incrementally.
+    /// 
+    /// # Example
+    /// ```no_run
+    /// use foundry_compilers_artifacts_solc::output_selection::OutputSelection;
+    /// 
+    /// // Request only `abi` and `storageLayout`, for every contract in Counter.sol.
+    /// let selection = OutputSelection::empty()
+    ///     .insert("Counter.sol", "*", ["abi".to_string(), "storageLayout".to_string()]);
+    /// ```
+    pub fn empty() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    /// Inserts the set of requested outputs for a given `file` and `contract`
+    /// selector, returning `self` for chaining.
+    pub fn insert(mut self, file: impl Into<String>, contract: impl Into<String>, outputs: impl IntoIterator<Item = String>) -> Self {
+        self.0
+            .entry(file.into())
+            .or_default()
+            .entry(contract.into())
+            .or_default()
+            .extend(outputs);
+        self
+    }
+
     /// Default output selection.
     pub fn default_output_selection() -> Self {
         BTreeMap::from([("*".to_string(), Self::default_file_output_selection())]).into()
@@ -590,6 +619,32 @@ mod tests {
             serde_json::from_str(&json).unwrap();
 
         assert_eq!(json, serde_json::to_string(&deserde_selection).unwrap());
+    }
+
+    #[test]
+    fn outputselection_builder_works() {
+        let output = OutputSelection::empty()
+            .insert("*", "*", [
+                "abi".to_string(),
+                "evm.assembly".to_string(),
+            ])
+            .insert("Counter.sol", "*", [
+                "evm.bytecode.object".to_string(),
+            ])
+            .insert("Counter.sol", "Counter", [
+                "storageLayout".to_string(),
+            ]);
+        let s = serde_json::to_string(&output).unwrap();
+        assert_eq!(s, r#"{"*":{"*":["abi","evm.assembly"]},"Counter.sol":{"*":["evm.bytecode.object"],"Counter":["storageLayout"]}}"#);
+    }
+
+    #[test]
+    fn outputselection_builder_merges_same_key() {
+        let output = OutputSelection::empty()
+            .insert("*", "*", ["abi".to_string()])
+            .insert("*", "*", ["evm.bytecode.object".to_string()]);
+        let s = serde_json::to_string(&output).unwrap();
+        assert_eq!(s, r#"{"*":{"*":["abi","evm.bytecode.object"]}}"#);
     }
 
     #[test]

--- a/crates/compilers/crates/artifacts/solc/src/output_selection.rs
+++ b/crates/compilers/crates/artifacts/solc/src/output_selection.rs
@@ -73,7 +73,7 @@ impl OutputSelection {
     /// Returns a completely empty output selection: `{}`.
     /// 
     /// Used for fine-grained control over which outputs are requested.
-    /// Combine with [`Self::insert`] to build the selection of outputs incrementally.
+    /// Combine with [`Self::with_output`] to build the selection of outputs incrementally.
     /// 
     /// # Example
     /// ```no_run
@@ -81,15 +81,14 @@ impl OutputSelection {
     /// 
     /// // Request only `abi` and `storageLayout`, for every contract in Counter.sol.
     /// let selection = OutputSelection::empty()
-    ///     .insert("Counter.sol", "*", ["abi".to_string(), "storageLayout".to_string()]);
+    ///     .with_output("Counter.sol", "*", ["abi".to_string(), "storageLayout".to_string()]);
     /// ```
     pub const fn empty() -> Self {
         Self(BTreeMap::new())
     }
 
-    /// Inserts the set of requested outputs for a given `file` and `contract`
-    /// selector, returning `self` for chaining.
-    pub fn insert(mut self, file: impl Into<String>, contract: impl Into<String>, outputs: impl IntoIterator<Item = String>) -> Self {
+    /// Adds the given outputs for a `(file, contract)` selector, returning `self` for chaining.
+    pub fn with_output(mut self, file: impl Into<String>, contract: impl Into<String>, outputs: impl IntoIterator<Item = String>) -> Self {
         self.0
             .entry(file.into())
             .or_default()
@@ -624,14 +623,14 @@ mod tests {
     #[test]
     fn outputselection_builder_works() {
         let output = OutputSelection::empty()
-            .insert("*", "*", [
+            .with_output("*", "*", [
                 "abi".to_string(),
                 "evm.assembly".to_string(),
             ])
-            .insert("Counter.sol", "*", [
+            .with_output("Counter.sol", "*", [
                 "evm.bytecode.object".to_string(),
             ])
-            .insert("Counter.sol", "Counter", [
+            .with_output("Counter.sol", "Counter", [
                 "storageLayout".to_string(),
             ]);
         let s = serde_json::to_string(&output).unwrap();
@@ -641,8 +640,8 @@ mod tests {
     #[test]
     fn outputselection_builder_merges_same_key() {
         let output = OutputSelection::empty()
-            .insert("*", "*", ["abi".to_string()])
-            .insert("*", "*", ["evm.bytecode.object".to_string()]);
+            .with_output("*", "*", ["abi".to_string()])
+            .with_output("*", "*", ["evm.bytecode.object".to_string()]);
         let s = serde_json::to_string(&output).unwrap();
         assert_eq!(s, r#"{"*":{"*":["abi","evm.bytecode.object"]}}"#);
     }

--- a/crates/compilers/crates/artifacts/solc/src/output_selection.rs
+++ b/crates/compilers/crates/artifacts/solc/src/output_selection.rs
@@ -83,7 +83,7 @@ impl OutputSelection {
     /// let selection = OutputSelection::empty()
     ///     .insert("Counter.sol", "*", ["abi".to_string(), "storageLayout".to_string()]);
     /// ```
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self(BTreeMap::new())
     }
 

--- a/crates/compilers/crates/artifacts/solc/src/output_selection.rs
+++ b/crates/compilers/crates/artifacts/solc/src/output_selection.rs
@@ -71,30 +71,33 @@ impl OutputSelection {
     }
 
     /// Returns a completely empty output selection: `{}`.
-    /// 
+    ///
     /// Used for fine-grained control over which outputs are requested.
     /// Combine with [`Self::with_output`] to build the selection of outputs incrementally.
-    /// 
+    ///
     /// # Example
     /// ```no_run
     /// use foundry_compilers_artifacts_solc::output_selection::OutputSelection;
-    /// 
+    ///
     /// // Request only `abi` and `storageLayout`, for every contract in Counter.sol.
-    /// let selection = OutputSelection::empty()
-    ///     .with_output("Counter.sol", "*", ["abi".to_string(), "storageLayout".to_string()]);
+    /// let selection = OutputSelection::empty().with_output(
+    ///     "Counter.sol",
+    ///     "*",
+    ///     ["abi".to_string(), "storageLayout".to_string()],
+    /// );
     /// ```
     pub const fn empty() -> Self {
         Self(BTreeMap::new())
     }
 
     /// Adds the given outputs for a `(file, contract)` selector, returning `self` for chaining.
-    pub fn with_output(mut self, file: impl Into<String>, contract: impl Into<String>, outputs: impl IntoIterator<Item = String>) -> Self {
-        self.0
-            .entry(file.into())
-            .or_default()
-            .entry(contract.into())
-            .or_default()
-            .extend(outputs);
+    pub fn with_output(
+        mut self,
+        file: impl Into<String>,
+        contract: impl Into<String>,
+        outputs: impl IntoIterator<Item = String>,
+    ) -> Self {
+        self.0.entry(file.into()).or_default().entry(contract.into()).or_default().extend(outputs);
         self
     }
 
@@ -623,18 +626,14 @@ mod tests {
     #[test]
     fn outputselection_builder_works() {
         let output = OutputSelection::empty()
-            .with_output("*", "*", [
-                "abi".to_string(),
-                "evm.assembly".to_string(),
-            ])
-            .with_output("Counter.sol", "*", [
-                "evm.bytecode.object".to_string(),
-            ])
-            .with_output("Counter.sol", "Counter", [
-                "storageLayout".to_string(),
-            ]);
+            .with_output("*", "*", ["abi".to_string(), "evm.assembly".to_string()])
+            .with_output("Counter.sol", "*", ["evm.bytecode.object".to_string()])
+            .with_output("Counter.sol", "Counter", ["storageLayout".to_string()]);
         let s = serde_json::to_string(&output).unwrap();
-        assert_eq!(s, r#"{"*":{"*":["abi","evm.assembly"]},"Counter.sol":{"*":["evm.bytecode.object"],"Counter":["storageLayout"]}}"#);
+        assert_eq!(
+            s,
+            r#"{"*":{"*":["abi","evm.assembly"]},"Counter.sol":{"*":["evm.bytecode.object"],"Counter":["storageLayout"]}}"#
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`OutputSelection` currently only offers constructors that start from a broad default (`default_output_selection`, `complete_output_selection`, `common_output_selection`, `ast_output_selection`). There is no way to start from a truly empty selection  and build it incrementally. This would be useful when you want fine-grained control over what is requested, and this PR provides a simple builder pattern API to do just that.

`common_output_selection` is close but always uses `"*"` as the file key, so it can't express per-file selections.

## Changes

- Add `OutputSelection::empty()`, returning `Self(BTreeMap::new())`.
- Add `OutputSelection::insert(file, contract, outputs)`, a  builder method that inserts or extends the requested outputs for a given `(file, contract)` pair. Repeated calls for the same key append to the existing outputs rather than replacing them (not deduped).
- Doc comments with runnable examples for both.
- Unit tests covering:
  - building a selection across multiple files/contracts and asserting the
    exact serialized JSON,
  - merging outputs when `insert` is called twice for the same
    `(file, contract)` key.

Claude was consulted for feature validity and code correctness verification.