### PR TITLE
chore(wallets): update Tempo sponsor validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ alloy-sol-types = "1.6.0"
 alloy-chains = "0.2.34"
 
 # tempo
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "9081cc65940c419ab60ebd1fd8170483ee49cfe1", default-features = false }
+tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "cf4e08013c0d6c537364f053462807ec42d4056a", default-features = false }
 
 # misc
 async-trait = "0.1.89"


### PR DESCRIPTION
Updates the `tempo-alloy` pin to the latest commit from the coordinated Accounts wallet PR.

The new commit fixes sign-only sponsor validation when the user supplied a fee-token preference. Fee-payer service encoding intentionally omits that preference so the sponsor can select the token it pays with; the prior validator rejected the otherwise valid signed response as a different payload.

This pin is required to keep Foundry’s Tempo types single-versioned while consuming that fix.

Validation:
- `cargo check -p foundry-wallets`
- `cargo clippy -p foundry-wallets --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`