### PR TITLE
chore(wallets): update Tempo Accounts key metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ alloy-sol-types = "1.6.0"
 alloy-chains = "0.2.34"
 
 # tempo
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "d01d0e267a4cbfbc7a1cd6b05834ec1235303bb4", default-features = false }
+tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1", default-features = false }
 
 # misc
 async-trait = "0.1.89"


### PR DESCRIPTION
Pins the open Tempo Accounts integration to the commit that exposes the selected access key signature type. This keeps Foundry, `mpp-rs`, and Tempo on one nominal type universe while `mpp-rs` composes Accounts-backed sessions.

Validation:
- `cargo check -p foundry-wallets`
- `cargo fmt --all -- --check`