### PR TITLE
fix(compilers): preserve source unit names

### DIFF
--- a/crates/compilers/crates/artifacts/solc/src/lib.rs
+++ b/crates/compilers/crates/artifacts/solc/src/lib.rs
@@ -45,15 +45,77 @@ use foundry_compilers_core::{
 pub use serde_helpers::{deserialize_bytes, deserialize_opt_bytes};
 pub use sources::*;
 
+/// An exact source unit name from Solidity's standard JSON interface.
+///
+/// Unlike a file system path, a source unit name preserves repeated separators and other lexical
+/// differences. Path-style accessors are provided for consumers that use source unit names as
+/// paths after compiler output has been correlated with compiler input.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SourceUnitName(String);
+
+impl SourceUnitName {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn as_path(&self) -> &Path {
+        Path::new(&self.0)
+    }
+
+    pub fn display(&self) -> std::path::Display<'_> {
+        self.as_path().display()
+    }
+
+    pub fn to_string_lossy(&self) -> std::borrow::Cow<'_, str> {
+        std::borrow::Cow::Borrowed(&self.0)
+    }
+}
+
+impl std::ops::Deref for SourceUnitName {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl std::borrow::Borrow<str> for SourceUnitName {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for SourceUnitName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<String> for SourceUnitName {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<SourceUnitName> for PathBuf {
+    fn from(value: SourceUnitName) -> Self {
+        value.0.into()
+    }
+}
+
 /// Solidity files are made up of multiple `source units`, a solidity contract is such a `source
 /// unit`, therefore a solidity file can contain multiple contracts: (1-N*) relationship.
 ///
 /// This types represents this mapping as `file name -> (contract name -> T)`, where the generic is
-/// intended to represent contract specific information, like [`Contract`] itself, See [`Contracts`]
+/// intended to represent contract specific information, like [`Contract`] itself.
 pub type FileToContractsMap<T> = BTreeMap<PathBuf, BTreeMap<String, T>>;
 
-/// file -> (contract name -> Contract)
-pub type Contracts = FileToContractsMap<Contract>;
+/// Source unit name -> (contract name -> Contract).
+///
+/// Source unit names in compiler output are identifiers, not file system paths, and must retain
+/// their exact spelling.
+pub type Contracts = BTreeMap<SourceUnitName, BTreeMap<String, Contract>>;
 
 pub const SOLIDITY: &str = "Solidity";
 pub const YUL: &str = "Yul";
@@ -1526,7 +1588,7 @@ pub struct CompilerOutput {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<Error>,
     #[serde(default)]
-    pub sources: BTreeMap<PathBuf, SourceFile>,
+    pub sources: BTreeMap<SourceUnitName, SourceFile>,
     #[serde(default)]
     pub contracts: Contracts,
 }
@@ -1563,7 +1625,7 @@ impl CompilerOutput {
     /// bytecode, runtime bytecode, and abi
     pub fn get(&self, path: &Path, contract: &str) -> Option<CompactContractRef<'_>> {
         self.contracts
-            .get(path)
+            .get(path.to_str()?)
             .and_then(|contracts| contracts.get(contract))
             .map(CompactContractRef::from)
     }
@@ -1585,8 +1647,8 @@ impl CompilerOutput {
         // e.g. `src/utils/upgradeProxy.sol` is emitted as `src/utils/UpgradeProxy.sol`
         let files: HashSet<_> =
             files.into_iter().map(|s| s.to_string_lossy().to_lowercase()).collect();
-        self.contracts.retain(|f, _| files.contains(&f.to_string_lossy().to_lowercase()));
-        self.sources.retain(|f, _| files.contains(&f.to_string_lossy().to_lowercase()));
+        self.contracts.retain(|f, _| files.contains(&f.to_lowercase()));
+        self.sources.retain(|f, _| files.contains(&f.to_lowercase()));
     }
 
     pub fn merge(&mut self, other: Self) {
@@ -1873,17 +1935,17 @@ impl SourceFile {
 
 /// A wrapper type for a list of source files: `path -> SourceFile`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SourceFiles(pub BTreeMap<PathBuf, SourceFile>);
+pub struct SourceFiles(pub BTreeMap<SourceUnitName, SourceFile>);
 
 impl SourceFiles {
     /// Returns an iterator over the source files' IDs and path.
     pub fn into_ids(self) -> impl Iterator<Item = (u32, PathBuf)> {
-        self.0.into_iter().map(|(k, v)| (v.id, k))
+        self.0.into_iter().map(|(k, v)| (v.id, k.into()))
     }
 
     /// Returns an iterator over the source files' paths and IDs.
     pub fn into_paths(self) -> impl Iterator<Item = (PathBuf, u32)> {
-        self.0.into_iter().map(|(k, v)| (k, v.id))
+        self.0.into_iter().map(|(k, v)| (k.into(), v.id))
     }
 }
 
@@ -1953,6 +2015,33 @@ mod tests {
                 panic!("Failed to read compiler output of {} {}", path.display(), err)
             });
         }
+    }
+
+    #[test]
+    fn compiler_output_preserves_source_unit_names() {
+        let output = r#"{
+            "sources": {
+                "src/file.sol": {"id": 1},
+                "src//file.sol": {"id": 2}
+            },
+            "contracts": {
+                "src/file.sol": {"Exact": {}},
+                "src//file.sol": {"Alias": {}}
+            }
+        }"#;
+
+        let output: CompilerOutput = serde_json::from_str(output).unwrap();
+        assert_eq!(output.sources.len(), 2);
+        assert_eq!(output.sources["src/file.sol"].id, 1);
+        assert_eq!(output.sources["src//file.sol"].id, 2);
+        assert!(output.contracts["src/file.sol"].contains_key("Exact"));
+        assert!(output.contracts["src//file.sol"].contains_key("Alias"));
+
+        let output = serde_json::to_value(output).unwrap();
+        assert!(output["sources"].get("src/file.sol").is_some());
+        assert!(output["sources"].get("src//file.sol").is_some());
+        assert!(output["contracts"].get("src/file.sol").is_some());
+        assert!(output["contracts"].get("src//file.sol").is_some());
     }
 
     #[test]

--- a/crates/compilers/crates/compilers/src/buildinfo.rs
+++ b/crates/compilers/crates/compilers/src/buildinfo.rs
@@ -93,10 +93,21 @@ impl<L: Language> RawBuildInfo<L> {
         full_build_info: bool,
     ) -> Result<Self> {
         let version = input.version().clone();
-        let build_context = BuildContext::new(input, output)?;
+        let build_context = if let Some(payload) = &output.build_info {
+            BuildContext {
+                source_id_to_path: payload.source_id_to_path.clone(),
+                language: input.language(),
+            }
+        } else {
+            BuildContext::new(input, output)?
+        };
 
         let solc_short = format!("{}.{}.{}", version.major, version.minor, version.patch);
-        let input = serde_json::to_value(input)?;
+        let input = if let Some(payload) = &output.build_info {
+            payload.input.clone()
+        } else {
+            serde_json::to_value(input)?
+        };
         let id = utils::unique_hash_many([
             ETHERS_FORMAT_VERSION,
             &version.to_string(),
@@ -110,7 +121,12 @@ impl<L: Language> RawBuildInfo<L> {
             build_info.insert("solcVersion".to_string(), serde_json::to_value(&solc_short)?);
             build_info.insert("solcLongVersion".to_string(), serde_json::to_value(&version)?);
             build_info.insert("input".to_string(), input);
-            build_info.insert("output".to_string(), serde_json::to_value(output)?);
+            let output = if let Some(payload) = &output.build_info {
+                payload.output.clone()
+            } else {
+                serde_json::to_value(output)?
+            };
+            build_info.insert("output".to_string(), output);
         }
 
         Ok(Self { id, build_info, build_context })

--- a/crates/compilers/crates/compilers/src/compilers/mod.rs
+++ b/crates/compilers/crates/compilers/src/compilers/mod.rs
@@ -289,6 +289,9 @@ impl<E, C> CompilerOutput<E, C> {
     }
 
     pub fn merge(&mut self, other: Self) {
+        // A build-info payload describes one compiler invocation and cannot represent merged
+        // outputs. Clear it before changing the projected sources and contracts.
+        self.build_info = None;
         self.errors.extend(other.errors);
         self.contracts.extend(other.contracts);
         self.sources.extend(other.sources);
@@ -324,6 +327,36 @@ impl<E, C> Default for CompilerOutput<E, C> {
             sources: BTreeMap::new(),
             metadata: BTreeMap::new(),
             build_info: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BuildInfoPayload, CompilerOutput};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn merging_outputs_clears_build_info_payload() {
+        let payload = || {
+            Some(Box::new(BuildInfoPayload {
+                input: serde_json::Value::Null,
+                output: serde_json::Value::Null,
+                source_id_to_path: BTreeMap::new(),
+            }))
+        };
+
+        for (left, right) in [(true, false), (false, true), (true, true)] {
+            let mut output = CompilerOutput::<(), ()> {
+                build_info: left.then(payload).flatten(),
+                ..Default::default()
+            };
+            let other =
+                CompilerOutput { build_info: right.then(payload).flatten(), ..Default::default() };
+
+            output.merge(other);
+
+            assert!(output.build_info.is_none());
         }
     }
 }

--- a/crates/compilers/crates/compilers/src/compilers/mod.rs
+++ b/crates/compilers/crates/compilers/src/compilers/mod.rs
@@ -253,6 +253,22 @@ pub struct CompilerOutput<E, C> {
     pub sources: BTreeMap<PathBuf, SourceFile>,
     #[serde(default, skip_serializing_if = "::std::collections::BTreeMap::is_empty")]
     pub metadata: BTreeMap<String, serde_json::Value>,
+    /// Immutable compiler-run provenance used when the generic path-based projection would
+    /// collapse distinct source unit names. This intentionally survives transformations of the
+    /// projected output so build-info remains lossless.
+    #[doc(hidden)]
+    #[serde(skip)]
+    pub build_info: Option<Box<BuildInfoPayload>>,
+}
+
+/// A lossless build-info representation for compiler output that cannot be represented by the
+/// generic path-based output maps.
+#[derive(Debug)]
+#[doc(hidden)]
+pub struct BuildInfoPayload {
+    pub(crate) input: serde_json::Value,
+    pub(crate) output: serde_json::Value,
+    pub(crate) source_id_to_path: BTreeMap<u32, PathBuf>,
 }
 
 impl<E, C> CompilerOutput<E, C> {
@@ -295,6 +311,7 @@ impl<E, C> CompilerOutput<E, C> {
             contracts: self.contracts,
             sources: self.sources,
             metadata: self.metadata,
+            build_info: self.build_info,
         }
     }
 }
@@ -306,6 +323,7 @@ impl<E, C> Default for CompilerOutput<E, C> {
             contracts: BTreeMap::new(),
             sources: BTreeMap::new(),
             metadata: BTreeMap::new(),
+            build_info: None,
         }
     }
 }

--- a/crates/compilers/crates/compilers/src/compilers/solc/compiler.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/compiler.rs
@@ -527,6 +527,65 @@ impl Solc {
         cmd
     }
 
+    /// Reads a source unit using the same base and include paths passed to Solc's filesystem
+    /// loader.
+    pub(super) fn read_source_unit(&self, source_unit: &str) -> Result<String> {
+        if self.extra_args.iter().any(|arg| {
+            arg == "--base-path"
+                || arg.starts_with("--base-path=")
+                || arg == "--include-path"
+                || arg.starts_with("--include-path=")
+        }) {
+            return Err(SolcError::msg(
+                "cannot recover source-unit content when extra Solc arguments override base or include paths",
+            ));
+        }
+
+        let source_unit = source_unit.strip_prefix("file://").unwrap_or(source_unit);
+        let cwd = std::env::current_dir().map_err(|err| SolcError::io(err, "."))?;
+        let child_cwd =
+            self.base_path.as_deref().map(|path| absolute_path(&cwd, path)).unwrap_or(cwd);
+        let mut roots = Vec::new();
+        if let Some(base_path) = &self.base_path
+            && SUPPORTS_BASE_PATH.matches(&self.version)
+        {
+            roots.push(absolute_path(&child_cwd, base_path));
+        }
+        if let Some(base_path) = &self.base_path
+            && SUPPORTS_BASE_PATH.matches(&self.version)
+            && SUPPORTS_INCLUDE_PATH.matches(&self.version)
+        {
+            roots.extend(
+                self.include_paths
+                    .iter()
+                    .filter(|path| path.as_path() != base_path.as_path())
+                    .map(|path| absolute_path(&child_cwd, path)),
+            );
+        }
+        let mut candidates = if roots.is_empty() {
+            vec![absolute_path(&child_cwd, Path::new(source_unit))]
+        } else {
+            roots.into_iter().map(|root| append_source_unit(&root, source_unit)).collect()
+        };
+        candidates.retain(|path| path.is_file());
+
+        let path = match candidates.as_slice() {
+            [] => {
+                return Err(SolcError::msg(format!(
+                    "source unit `{source_unit}` was emitted by Solc but could not be found in the base or include paths"
+                )));
+            }
+            [path] => path,
+            _ => {
+                return Err(SolcError::msg(format!(
+                    "source unit `{source_unit}` is ambiguous; found in {}",
+                    candidates.iter().map(|path| path.display()).format(", ")
+                )));
+            }
+        };
+        std::fs::read_to_string(path).map_err(|err| SolcError::io(err, path))
+    }
+
     /// Either finds an installed Solc version or installs it if it's not found.
     #[cfg(feature = "svm-solc")]
     pub fn find_or_install(version: &Version) -> Result<Self> {
@@ -538,6 +597,22 @@ impl Solc {
 
         Ok(solc)
     }
+}
+
+fn absolute_path(cwd: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() { path.to_path_buf() } else { cwd.join(path) }
+}
+
+fn append_source_unit(root: &Path, source_unit: &str) -> PathBuf {
+    #[cfg(windows)]
+    let source_unit = source_unit.trim_start_matches(['/', '\\']);
+    #[cfg(not(windows))]
+    let source_unit = source_unit.trim_start_matches('/');
+
+    let mut path = root.as_os_str().to_os_string();
+    path.push(std::path::MAIN_SEPARATOR_STR);
+    path.push(source_unit);
+    path.into()
 }
 
 #[cfg(feature = "async")]
@@ -694,6 +769,67 @@ mod tests {
         for (_, c) in out.split().1.contracts_iter() {
             assert!(c.metadata.is_some());
         }
+    }
+
+    #[test]
+    fn reads_source_units_like_solc() {
+        let cwd = std::env::current_dir().unwrap();
+        let temp = tempfile::tempdir_in(&cwd).unwrap();
+        let relative_base = PathBuf::from(temp.path().file_name().unwrap());
+        let effective_base = temp.path().join(&relative_base);
+        let effective_include = temp.path().join("include");
+        std::fs::create_dir_all(effective_base.join("src")).unwrap();
+        std::fs::create_dir_all(effective_include.join("lib")).unwrap();
+        std::fs::write(effective_base.join("src/A.sol"), "base").unwrap();
+        std::fs::write(effective_include.join("lib/Include.sol"), "include").unwrap();
+        let absolute = temp.path().join("Absolute.sol");
+        std::fs::write(&absolute, "absolute").unwrap();
+
+        let mut configured_solc = solc();
+        configured_solc.base_path = Some(relative_base);
+        configured_solc.include_paths.insert(PathBuf::from("include"));
+
+        assert_eq!(configured_solc.read_source_unit("src/A.sol").unwrap(), "base");
+        assert_eq!(configured_solc.read_source_unit("lib/Include.sol").unwrap(), "include");
+        assert_eq!(configured_solc.read_source_unit("/src//A.sol").unwrap(), "base");
+        assert_eq!(configured_solc.read_source_unit("file://src//A.sol").unwrap(), "base");
+
+        let source = absolute.to_str().unwrap();
+        assert_eq!(solc().read_source_unit(source).unwrap(), "absolute");
+        assert_eq!(solc().read_source_unit(&format!("file://{source}")).unwrap(), "absolute");
+        configured_solc.version = Version::new(0, 6, 8);
+        assert_eq!(configured_solc.read_source_unit(source).unwrap(), "absolute");
+
+        #[cfg(not(windows))]
+        {
+            let backslash_dir = append_source_unit(&effective_base, "\\src");
+            std::fs::create_dir_all(&backslash_dir).unwrap();
+            std::fs::write(backslash_dir.join("A.sol"), "backslash").unwrap();
+            configured_solc.version = Version::new(0, 8, 26);
+            assert_eq!(configured_solc.read_source_unit("\\src/A.sol").unwrap(), "backslash");
+        }
+    }
+
+    #[test]
+    fn rejects_unreliable_source_unit_resolution() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().join("base");
+        let include = temp.path().join("include");
+        std::fs::create_dir_all(base.join("src")).unwrap();
+        std::fs::create_dir_all(include.join("src")).unwrap();
+        std::fs::write(base.join("src/A.sol"), "base").unwrap();
+        std::fs::write(include.join("src/A.sol"), "include").unwrap();
+
+        let mut solc = solc();
+        solc.base_path = Some(base);
+        solc.include_paths.insert(include);
+
+        let err = solc.read_source_unit("src/A.sol").unwrap_err();
+        assert!(err.to_string().contains("source unit `src/A.sol` is ambiguous"));
+
+        solc.extra_args.push("--base-path=other".to_string());
+        let err = solc.read_source_unit("src/A.sol").unwrap_err();
+        assert!(err.to_string().contains("extra Solc arguments override base or include paths"));
     }
 
     #[test]

--- a/crates/compilers/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/mod.rs
@@ -70,7 +70,7 @@ impl Compiler for SolcCompiler {
         solc.extra_args.extend_from_slice(&input.cli_settings.extra_args);
 
         let solc_output = solc.compile(&input.input)?;
-        compiler_output(input, solc_output)
+        compiler_output(&solc, input, solc_output)
     }
 
     fn available_versions(&self, _language: &Self::Language) -> Vec<CompilerVersion> {
@@ -108,10 +108,11 @@ impl Compiler for SolcCompiler {
 }
 
 fn compiler_output(
+    solc: &Solc,
     input: &SolcVersionedInput,
     output: foundry_compilers_artifacts::CompilerOutput,
 ) -> Result<CompilerOutput<Error, Contract>> {
-    let build_info = lossless_build_info(input, &output)?;
+    let build_info = lossless_build_info(solc, input, &output)?;
     let foundry_compilers_artifacts::CompilerOutput { errors, sources, contracts } = output;
     Ok(CompilerOutput {
         errors,
@@ -143,6 +144,7 @@ fn filesystem_projection<T>(
 }
 
 fn lossless_build_info(
+    solc: &Solc,
     input: &SolcVersionedInput,
     output: &foundry_compilers_artifacts::CompilerOutput,
 ) -> Result<Option<Box<super::BuildInfoPayload>>> {
@@ -156,27 +158,26 @@ fn lossless_build_info(
         .get_mut("sources")
         .and_then(serde_json::Value::as_object_mut)
         .ok_or_else(|| SolcError::msg("compiler input does not contain a sources object"))?;
-    let original_sources = input_sources.clone();
+    let input_names = input_sources.keys().cloned().collect::<Vec<_>>();
 
-    // Build-info consumers expect source content under every output source unit name. Add
-    // byte-identical content for path-equivalent aliases emitted by solc. This creates a
-    // self-consistent compatibility context, not an exact copy of the input originally sent to
-    // solc.
+    // Exact input names use the potentially preprocessed standard JSON content. Path-equivalent
+    // aliases were loaded separately by Solc's filesystem callback, so recover their disk content
+    // using the same search roots rather than assuming it is identical to the input.
     for output_name in output.sources.keys() {
         if input_sources.contains_key(output_name.as_str()) {
             continue;
         }
 
-        let mut matches = original_sources
-            .iter()
-            .filter(|(input_name, _)| Path::new(input_name) == output_name.as_path());
-        let Some((_, source)) = matches.next() else { continue };
+        let mut matches =
+            input_names.iter().filter(|input_name| Path::new(input_name) == output_name.as_path());
+        let Some(_) = matches.next() else { continue };
         if matches.next().is_some() {
             return Err(SolcError::msg(format!(
                 "multiple compiler input sources match output source unit `{output_name}`"
             )));
         }
-        input_sources.insert(output_name.to_string(), source.clone());
+        let content = solc.read_source_unit(output_name.as_str())?;
+        input_sources.insert(output_name.to_string(), serde_json::json!({ "content": content }));
     }
 
     let source_id_to_path = output
@@ -633,7 +634,11 @@ mod tests {
         },
     };
 
-    use super::compiler_output;
+    use super::{Solc, compiler_output};
+
+    fn solc() -> Solc {
+        Solc::new_with_version("solc", Version::new(0, 8, 26))
+    }
 
     #[test]
     fn uses_standard_build_info_without_path_equivalent_source_units() {
@@ -652,7 +657,7 @@ mod tests {
             errors: Vec::new(),
         };
 
-        assert!(compiler_output(&input, output).unwrap().build_info.is_none());
+        assert!(compiler_output(&solc(), &input, output).unwrap().build_info.is_none());
     }
 
     #[test]
@@ -688,7 +693,14 @@ mod tests {
             errors: Vec::new(),
         };
 
-        let output = compiler_output(&input, output).unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("src/file.sol");
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::write(&source, "contract File {}").unwrap();
+        let mut solc = solc();
+        solc.base_path = Some(temp.path().to_path_buf());
+
+        let output = compiler_output(&solc, &input, output).unwrap();
         assert_eq!(output.sources[Path::new("src/file.sol")].id, 2);
         assert_eq!(output.sources[Path::new("generated.sol")].id, 3);
 

--- a/crates/compilers/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 use foundry_compilers_artifacts::{
-    BytecodeHash, Contract, Error, EvmVersion, Settings, Severity, SolcInput,
+    BytecodeHash, Contract, Error, EvmVersion, Settings, Severity, SolcInput, SourceUnitName,
     error::SourceLocation,
     output_selection::OutputSelection,
     remappings::Remapping,
@@ -22,7 +22,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
 };
@@ -70,15 +70,7 @@ impl Compiler for SolcCompiler {
         solc.extra_args.extend_from_slice(&input.cli_settings.extra_args);
 
         let solc_output = solc.compile(&input.input)?;
-
-        let output = CompilerOutput {
-            errors: solc_output.errors,
-            contracts: solc_output.contracts,
-            sources: solc_output.sources,
-            metadata: BTreeMap::new(),
-        };
-
-        Ok(output)
+        compiler_output(input, solc_output)
     }
 
     fn available_versions(&self, _language: &Self::Language) -> Vec<CompilerVersion> {
@@ -113,6 +105,95 @@ impl Compiler for SolcCompiler {
             }
         }
     }
+}
+
+fn compiler_output(
+    input: &SolcVersionedInput,
+    output: foundry_compilers_artifacts::CompilerOutput,
+) -> Result<CompilerOutput<Error, Contract>> {
+    let build_info = lossless_build_info(input, &output)?;
+    let foundry_compilers_artifacts::CompilerOutput { errors, sources, contracts } = output;
+    Ok(CompilerOutput {
+        errors,
+        sources: filesystem_projection(&input.input, sources),
+        contracts: filesystem_projection(&input.input, contracts),
+        metadata: BTreeMap::new(),
+        build_info,
+    })
+}
+
+fn filesystem_projection<T>(
+    input: &SolcInput,
+    output: BTreeMap<SourceUnitName, T>,
+) -> BTreeMap<PathBuf, T> {
+    let input_names = input.sources.keys().filter_map(|path| path.to_str()).collect::<HashSet<_>>();
+    let (exact, aliases): (Vec<_>, Vec<_>) =
+        output.into_iter().partition(|(name, _)| input_names.contains(name.as_str()));
+    let mut selected = BTreeMap::new();
+
+    // Insert exact input names last so they deterministically represent path-equivalent source
+    // units in the filesystem-oriented output used for artifacts and caching.
+    for (name, value) in aliases.into_iter().chain(exact) {
+        let path = PathBuf::from(name.as_str());
+        selected.remove(&path);
+        selected.insert(path, value);
+    }
+
+    selected
+}
+
+fn lossless_build_info(
+    input: &SolcVersionedInput,
+    output: &foundry_compilers_artifacts::CompilerOutput,
+) -> Result<Option<Box<super::BuildInfoPayload>>> {
+    if !path_projection_is_lossy(&output.sources) && !path_projection_is_lossy(&output.contracts) {
+        return Ok(None);
+    }
+
+    let mut serialized_input = serde_json::to_value(input)?;
+    let serialized_output = serde_json::to_value(output)?;
+    let input_sources = serialized_input
+        .get_mut("sources")
+        .and_then(serde_json::Value::as_object_mut)
+        .ok_or_else(|| SolcError::msg("compiler input does not contain a sources object"))?;
+    let original_sources = input_sources.clone();
+
+    // Build-info consumers expect source content under every output source unit name. Add
+    // byte-identical content for path-equivalent aliases emitted by solc. This creates a
+    // self-consistent compatibility context, not an exact copy of the input originally sent to
+    // solc.
+    for output_name in output.sources.keys() {
+        if input_sources.contains_key(output_name.as_str()) {
+            continue;
+        }
+
+        let mut matches = original_sources
+            .iter()
+            .filter(|(input_name, _)| Path::new(input_name) == output_name.as_path());
+        let Some((_, source)) = matches.next() else { continue };
+        if matches.next().is_some() {
+            return Err(SolcError::msg(format!(
+                "multiple compiler input sources match output source unit `{output_name}`"
+            )));
+        }
+        input_sources.insert(output_name.to_string(), source.clone());
+    }
+
+    let source_id_to_path = output
+        .sources
+        .iter()
+        .map(|(name, source)| (source.id, PathBuf::from(name.as_str())))
+        .collect();
+    Ok(Some(Box::new(super::BuildInfoPayload {
+        input: serialized_input,
+        output: serialized_output,
+        source_id_to_path,
+    })))
+}
+
+fn path_projection_is_lossy<T>(output: &BTreeMap<SourceUnitName, T>) -> bool {
+    let mut paths = BTreeSet::new();
+    output.keys().any(|name| !paths.insert(name.as_path()))
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -533,8 +614,15 @@ impl CompilationError for Error {
 
 #[cfg(test)]
 mod tests {
-    use foundry_compilers_artifacts::{CompilerOutput, SolcLanguage};
+    use foundry_compilers_artifacts::{
+        CompilerOutput, Contract, SolcLanguage, SourceFile,
+        sources::{Source, Sources},
+    };
     use semver::Version;
+    use std::{
+        collections::BTreeMap,
+        path::{Path, PathBuf},
+    };
 
     use crate::{
         AggregatedCompilerOutput,
@@ -544,6 +632,83 @@ mod tests {
             solc::{SolcCompiler, SolcVersionedInput},
         },
     };
+
+    use super::compiler_output;
+
+    #[test]
+    fn uses_standard_build_info_without_path_equivalent_source_units() {
+        let input = SolcVersionedInput::build(
+            Sources::from([(PathBuf::from("src/file.sol"), Source::new("contract File {}"))]),
+            Default::default(),
+            SolcLanguage::Solidity,
+            Version::new(0, 8, 26),
+        );
+        let output = CompilerOutput {
+            sources: BTreeMap::from([(
+                "src/file.sol".to_string().into(),
+                SourceFile { id: 1, ast: None },
+            )]),
+            contracts: BTreeMap::new(),
+            errors: Vec::new(),
+        };
+
+        assert!(compiler_output(&input, output).unwrap().build_info.is_none());
+    }
+
+    #[test]
+    fn preserves_lossless_build_info_for_path_equivalent_source_units() {
+        let input = SolcVersionedInput::build(
+            Sources::from([(PathBuf::from("src/file.sol"), Source::new("contract File {}"))]),
+            Default::default(),
+            SolcLanguage::Solidity,
+            Version::new(0, 8, 26),
+        );
+        let output = CompilerOutput {
+            sources: BTreeMap::from([
+                ("src//file.sol".to_string().into(), SourceFile { id: 1, ast: None }),
+                ("src/file.sol".to_string().into(), SourceFile { id: 2, ast: None }),
+                ("generated.sol".to_string().into(), SourceFile { id: 3, ast: None }),
+            ]),
+            contracts: BTreeMap::from([
+                (
+                    "src//file.sol".to_string().into(),
+                    BTreeMap::from([(
+                        "Alias".to_string(),
+                        serde_json::from_str::<Contract>("{}").unwrap(),
+                    )]),
+                ),
+                (
+                    "src/file.sol".to_string().into(),
+                    BTreeMap::from([(
+                        "Exact".to_string(),
+                        serde_json::from_str::<Contract>("{}").unwrap(),
+                    )]),
+                ),
+            ]),
+            errors: Vec::new(),
+        };
+
+        let output = compiler_output(&input, output).unwrap();
+        assert_eq!(output.sources[Path::new("src/file.sol")].id, 2);
+        assert_eq!(output.sources[Path::new("generated.sol")].id, 3);
+
+        let build_info = RawBuildInfo::new(&input, &output, true).unwrap();
+        let input_sources = &build_info.build_info["input"]["sources"];
+        assert_eq!(input_sources["src//file.sol"], input_sources["src/file.sol"]);
+        let output_sources = &build_info.build_info["output"]["sources"];
+        assert_eq!(output_sources["src//file.sol"]["id"], 1);
+        assert_eq!(output_sources["src/file.sol"]["id"], 2);
+        assert!(build_info.build_info["output"]["contracts"].get("src//file.sol").is_some());
+        assert!(build_info.build_info["output"]["contracts"].get("src/file.sol").is_some());
+        assert_eq!(
+            build_info.build_context.source_id_to_path,
+            BTreeMap::from([
+                (1, PathBuf::from("src//file.sol")),
+                (2, PathBuf::from("src/file.sol")),
+                (3, PathBuf::from("generated.sol")),
+            ])
+        );
+    }
 
     #[test]
     fn can_parse_declaration_error() {
@@ -574,6 +739,7 @@ mod tests {
             contracts: Default::default(),
             sources: Default::default(),
             metadata: Default::default(),
+            build_info: None,
         };
 
         let v = Version::new(0, 8, 12);

--- a/crates/compilers/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/mod.rs
@@ -637,7 +637,7 @@ mod tests {
     use super::{Solc, compiler_output};
 
     fn solc() -> Solc {
-        Solc::new_with_version("solc", Version::new(0, 8, 26))
+        Solc::new("solc").unwrap_or_else(|_| Solc::new_with_version("solc", Version::new(0, 8, 26)))
     }
 
     #[test]

--- a/crates/compilers/crates/compilers/src/compilers/vyper/output.rs
+++ b/crates/compilers/crates/compilers/src/compilers/vyper/output.rs
@@ -13,6 +13,7 @@ impl From<VyperOutput> for super::CompilerOutput<VyperCompilationError, Contract
                 .collect(),
             sources: output.sources.into_iter().map(|(k, v)| (k, v.into())).collect(),
             metadata: Default::default(),
+            build_info: None,
         }
     }
 }

--- a/crates/compilers/crates/compilers/tests/project.rs
+++ b/crates/compilers/crates/compilers/tests/project.rs
@@ -3000,7 +3000,7 @@ fn can_compile_std_json_input() {
     if let Ok(solc) = Solc::find_or_install(&Version::new(0, 8, 28)) {
         let out = solc.compile(&input).unwrap();
         assert!(out.errors.is_empty());
-        assert!(out.sources.contains_key(Path::new("lib/ds-test/src/test.sol")));
+        assert!(out.sources.contains_key("lib/ds-test/src/test.sol"));
     }
 }
 
@@ -3280,7 +3280,7 @@ async fn can_install_solc_and_compile_std_json_input_async() {
 
     let out = solc.async_compile(&input).await.unwrap();
     assert!(!out.has_error());
-    assert!(out.sources.contains_key(&PathBuf::from("lib/ds-test/src/test.sol")));
+    assert!(out.sources.contains_key("lib/ds-test/src/test.sol"));
 }
 
 #[test]

--- a/crates/compilers/crates/compilers/tests/project.rs
+++ b/crates/compilers/crates/compilers/tests/project.rs
@@ -4633,6 +4633,99 @@ fn can_preprocess() {
     assert!(!compiled.is_unchanged());
 }
 
+#[test]
+fn build_info_uses_filesystem_content_for_preprocessed_source_alias() {
+    const DISK_SOURCE: &str = r#"// disk source
+pragma solidity 0.8.26;
+contract Dependency {
+    function diskOnlyMarker() external pure returns (uint256) {
+        return 1;
+    }
+}
+"#;
+    const PREPROCESSED_MARKER: &str =
+        "// preprocessed source with a deliberately much longer leading comment";
+
+    #[derive(Debug)]
+    struct MutatingPreprocessor;
+
+    impl Preprocessor<MultiCompiler> for MutatingPreprocessor {
+        fn preprocess(
+            &self,
+            _compiler: &MultiCompiler,
+            input: &mut MultiCompilerInput,
+            _paths: &ProjectPathsConfig<MultiCompilerLanguage>,
+            _mocks: &mut HashSet<PathBuf>,
+        ) -> foundry_compilers::error::Result<()> {
+            let MultiCompilerInput::Solc(input) = input else {
+                return Ok(());
+            };
+            let source = input.input.sources.get_mut(Path::new("src/Dependency.sol")).unwrap();
+            source.content = source.content.replace("// disk source", PREPROCESSED_MARKER).into();
+            Ok(())
+        }
+    }
+
+    let mut project = TempProject::<MultiCompiler>::dapptools().unwrap();
+    project.set_solc("0.8.26");
+    project.project_mut().build_info = true;
+    project.project_mut().update_output_selection(|selection| {
+        selection
+            .0
+            .entry("*".to_string())
+            .or_default()
+            .insert(String::new(), vec!["ast".to_string()]);
+    });
+    project.add_source("Dependency.sol", DISK_SOURCE).unwrap();
+    project
+        .add_source(
+            "Consumer.sol",
+            r#"pragma solidity 0.8.26;
+import "src//Dependency.sol";
+contract Consumer is Dependency {}
+"#,
+        )
+        .unwrap();
+
+    let compiled = ProjectCompiler::new(project.project())
+        .unwrap()
+        .with_preprocessor(MutatingPreprocessor)
+        .compile()
+        .unwrap();
+    compiled.assert_success();
+
+    let build_info_path =
+        fs::read_dir(project.project().build_info_path()).unwrap().next().unwrap().unwrap().path();
+    let build_info: serde_json::Value = utils::read_json_file(&build_info_path).unwrap();
+    let exact_content =
+        build_info["input"]["sources"]["src/Dependency.sol"]["content"].as_str().unwrap();
+    let alias_content =
+        build_info["input"]["sources"]["src//Dependency.sol"]["content"].as_str().unwrap();
+    assert!(exact_content.starts_with(PREPROCESSED_MARKER));
+    assert_eq!(alias_content, DISK_SOURCE);
+    assert_ne!(exact_content, alias_content);
+
+    let alias_source = &build_info["output"]["sources"]["src//Dependency.sol"];
+    let alias_id = alias_source["id"].as_u64().unwrap() as usize;
+    let parse_src = |src: &str| {
+        let mut parts = src.split(':').map(|part| part.parse::<usize>().unwrap());
+        (parts.next().unwrap(), parts.next().unwrap(), parts.next().unwrap())
+    };
+    let (start, length, id) = parse_src(alias_source["ast"]["src"].as_str().unwrap());
+    assert_eq!(start, alias_content.find("pragma").unwrap());
+    assert_eq!((start + length, id), (alias_content.len(), alias_id));
+
+    let contract = alias_source["ast"]["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|node| node["nodeType"] == "ContractDefinition" && node["name"] == "Dependency")
+        .unwrap();
+    let (start, length, id) = parse_src(contract["src"].as_str().unwrap());
+    assert_eq!(id, alias_id);
+    assert!(alias_content.get(start..start + length).unwrap().contains("contract Dependency"));
+}
+
 // https://github.com/foundry-rs/foundry/issues/13057
 // Tests that extra output files (.bin) are correctly generated for each profile
 // when the same contract is compiled with multiple profiles using the SAME solc version.


### PR DESCRIPTION
Preserves exact Solidity source-unit names in raw compiler output instead of collapsing path-equivalent names into a single `PathBuf` entry. When projection is lossy, build-info retains the complete source and contract records with matching alias content, preserving cross-source AST references and allowing OpenZeppelin upgrades validation to consume Foundry build-info correctly.

Addresses foundry-rs/foundry#9299.