### PR TITLE
chore(ci): run cross-platform tests on main only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        # Keep PR feedback fast by running the test matrix on Linux only.
+        # Pushes to main retain cross-platform coverage.
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest", "macos-latest", "windows-latest"]') }}
         rust: ["stable", "1.95"]
         flags: ["", "--all-features"]
         exclude:


### PR DESCRIPTION
## Summary
- run the test matrix on Linux only for pull requests
- retain Linux, macOS, and Windows coverage on pushes to `main`
- leave the macOS-specific Touch ID link matrix unchanged

## Validation
- parsed `.github/workflows/ci.yml` with PyYAML
- `git diff --check`

This PR was authored by Centaur using AI assistance.

Prompted by: @grandizzy