### PR TITLE
chore(deps): bump Tempo revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ alloy-sol-types = "1.6.0"
 alloy-chains = "0.2.34"
 
 # tempo
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580", default-features = false }
+tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
 
 # misc
 async-trait = "0.1.89"


### PR DESCRIPTION
Update foundry-wallets to Tempo revision 7690815 so downstream consumers can share one Tempo source revision.

Prompted by: @grandizzy

This PR was written primarily by Codex.