### PR TITLE
feat(compilers): preserve remapping ownership

### DIFF
--- a/crates/compilers/crates/artifacts/solc/src/remappings/find.rs
+++ b/crates/compilers/crates/artifacts/solc/src/remappings/find.rs
@@ -5,6 +5,7 @@ use std::{
     collections::{BTreeMap, HashSet, btree_map::Entry},
     fs::FileType,
     path::{Path, PathBuf},
+    sync::Mutex,
 };
 
 const DAPPTOOLS_CONTRACTS_DIR: &str = "src";
@@ -56,38 +57,31 @@ impl Remapping {
     /// (`@aave`)
     #[instrument(level = "trace", name = "Remapping::find_many")]
     pub fn find_many(dir: &Path) -> Vec<Self> {
-        Self::find_many_with_context(dir).global
+        let mut all_remappings = BTreeMap::new();
+        for candidate in discover_candidates(dir, false) {
+            if let Some(name) = candidate.window_start.file_name().and_then(|s| s.to_str()) {
+                insert_prioritized(&mut all_remappings, format!("{name}/"), candidate.source_dir);
+            }
+        }
+        all_remappings
+            .into_iter()
+            .map(|(name, path)| Self { context: None, name, path: format!("{}/", path.display()) })
+            .collect()
     }
 
     /// Attempts to autodetect global remappings and their nested dependency ownership.
     ///
-    /// This performs the same traversal and global selection as [`Self::find_many`], while also
-    /// retaining the preferred nested candidate for each lexical owner and alias, using the same
-    /// priority rules as global discovery. The owner is the path prefix before the rightmost
-    /// lexical `lib` or `node_modules` barrier.
+    /// This uses the same global prioritization rules as [`Self::find_many`], while also retaining
+    /// the preferred nested candidate for each lexical owner and alias. The owner is the path
+    /// prefix before the rightmost lexical `lib` or `node_modules` barrier. Call
+    /// [`RemappingDiscovery::into_relative`] with the project root before installing the result
+    /// into a project configuration.
     #[instrument(level = "trace", name = "Remapping::find_many_with_context")]
     pub fn find_many_with_context(dir: &Path) -> RemappingDiscovery {
-        let is_inside_node_modules = dir.ends_with("node_modules");
-
-        // iterate over all dirs that are children of the root
-        let mut candidates = read_dir(dir)
-            .filter(|(_, file_type, _)| file_type.is_dir())
-            .collect::<Vec<_>>()
-            .par_iter()
-            .flat_map_iter(|(dir, _, _)| {
-                find_remapping_candidates(dir, dir, 0, is_inside_node_modules, &HashSet::new())
-            })
-            .collect::<Vec<_>>();
-
-        // sort candidates so they are deterministic.
-        // this ensures that hashes do not change due to non deterministic mappings for paths with
-        // same number of components.
-        candidates.sort_by(|a, b| a.source_dir.cmp(&b.source_dir));
-
         // Select remappings globally and within each lexical dependency owner.
         let mut all_remappings = BTreeMap::new();
         let mut contextual_remappings = BTreeMap::new();
-        for candidate in candidates {
+        for candidate in discover_candidates(dir, true) {
             if let Some(name) = candidate.window_start.file_name().and_then(|s| s.to_str()) {
                 let name = format!("{name}/");
                 if let Some(owner) = dependency_owner(dir, &candidate.window_start) {
@@ -105,7 +99,7 @@ impl Remapping {
             .into_iter()
             .map(|(name, path)| Self { context: None, name, path: format!("{}/", path.display()) })
             .collect();
-        let contextual = contextual_remappings
+        let mut contextual = contextual_remappings
             .into_iter()
             .flat_map(|(context, remappings)| {
                 remappings.into_iter().map(move |(name, path)| Self {
@@ -114,9 +108,41 @@ impl Remapping {
                     path: format!("{}/", path.display()),
                 })
             })
-            .collect();
+            .collect::<Vec<_>>();
+        contextual.sort_by(|a, b| {
+            let a = a.context.as_deref().unwrap_or_default();
+            let b = b.context.as_deref().unwrap_or_default();
+            Path::new(b)
+                .components()
+                .count()
+                .cmp(&Path::new(a).components().count())
+                .then_with(|| a.cmp(b))
+        });
         RemappingDiscovery { global, contextual }
     }
+}
+
+fn discover_candidates(dir: &Path, preserve_symlink_owners: bool) -> Vec<Candidate> {
+    let is_inside_node_modules = dir.ends_with("node_modules");
+    let visited_symlink_dirs = Mutex::new(HashSet::new());
+    let global_symlink_dirs = (!preserve_symlink_owners).then_some(&visited_symlink_dirs);
+    let mut candidates = read_dir(dir)
+        .filter(|(_, file_type, _)| file_type.is_dir())
+        .collect::<Vec<_>>()
+        .par_iter()
+        .flat_map_iter(|(dir, _, _)| {
+            find_remapping_candidates(
+                dir,
+                dir,
+                0,
+                is_inside_node_modules,
+                global_symlink_dirs,
+                &HashSet::new(),
+            )
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|a, b| a.source_dir.cmp(&b.source_dir));
+    candidates
 }
 
 /// Prioritizes:
@@ -339,6 +365,7 @@ fn find_remapping_candidates(
     open: &Path,
     current_level: usize,
     is_inside_node_modules: bool,
+    global_symlink_dirs: Option<&Mutex<HashSet<PathBuf>>>,
     visited_symlink_dirs: &HashSet<PathBuf>,
 ) -> Vec<Candidate> {
     trace!("find_remapping_candidates({})", current_dir.display());
@@ -363,14 +390,22 @@ fn find_remapping_candidates(
             //     ├── symlink to `my-package`
             // ```
             if path_is_symlink && let Ok(target) = utils::canonicalize(&subdir) {
-                if visited_symlink_dirs.contains(&target)
-                    || utils::canonicalize(current_dir)
-                        .is_ok_and(|current| current.starts_with(&target))
-                {
-                    // short-circuiting if we've already visited the symlink
-                    continue;
+                if let Some(global_symlink_dirs) = global_symlink_dirs {
+                    if !global_symlink_dirs.lock().unwrap().insert(target.clone())
+                        || open.components().count() > target.components().count()
+                            && utils::common_ancestor(open, &target).is_some()
+                    {
+                        return Vec::new();
+                    }
+                } else {
+                    if visited_symlink_dirs.contains(&target)
+                        || utils::canonicalize(current_dir)
+                            .is_ok_and(|current| current.starts_with(&target))
+                    {
+                        continue;
+                    }
+                    visited_symlink_dirs.insert(target);
                 }
-                visited_symlink_dirs.insert(target);
             }
 
             // we skip commonly used subdirs that should not be searched for recursively
@@ -398,6 +433,7 @@ fn find_remapping_candidates(
                     subdir,
                     current_level + 1,
                     is_inside_node_modules,
+                    global_symlink_dirs,
                     visited_symlink_dirs,
                 )
             } else {
@@ -407,6 +443,7 @@ fn find_remapping_candidates(
                     open,
                     current_level,
                     is_inside_node_modules,
+                    global_symlink_dirs,
                     visited_symlink_dirs,
                 )
             }
@@ -598,6 +635,26 @@ mod tests {
             name: "only/".to_string(),
             path: to_str(root.join("unique/lib/only/src")),
         }));
+        let relative = discovery.into_relative(root);
+        assert!(relative.global.contains(&Remapping {
+            context: None,
+            name: "shared/".to_string(),
+            path: format!("a/lib/shared/src{MAIN_SEPARATOR}"),
+        }));
+        assert!(relative.contextual.contains(&Remapping {
+            context: Some(format!("a{MAIN_SEPARATOR}")),
+            name: "shared/".to_string(),
+            path: format!("a/lib/shared/src{MAIN_SEPARATOR}"),
+        }));
+        assert_eq!(
+            relative
+                .contextual
+                .into_iter()
+                .filter(|remapping| remapping.name == "shared/")
+                .map(|remapping| remapping.context.unwrap())
+                .collect::<Vec<_>>(),
+            vec![format!("a{MAIN_SEPARATOR}"), format!("b{MAIN_SEPARATOR}")]
+        );
     }
 
     #[test]
@@ -634,6 +691,24 @@ mod tests {
                     path: to_str(root.join("a/lib/y/lib/shared/src")),
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn contextual_remappings_order_nested_owners_first() {
+        let tmp_dir = tempdir("lib").unwrap();
+        let root = tmp_dir.path();
+        mkdir_or_touch(root, &["a/lib/shared/src/Shared.sol", "a/lib/x/lib/shared/src/Shared.sol"]);
+
+        let discovery = Remapping::find_many_with_context(root);
+        assert_eq!(
+            discovery
+                .contextual
+                .into_iter()
+                .filter(|remapping| remapping.name == "shared/")
+                .map(|remapping| remapping.context.unwrap())
+                .collect::<Vec<_>>(),
+            vec![to_str(root.join("a/lib/x")), to_str(root.join("a"))]
         );
     }
 
@@ -702,6 +777,34 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn global_remappings_deduplicate_shared_symlink_targets() {
+        let tmp_dir = tempdir("lib").unwrap();
+        let external = tempdir("external").unwrap();
+        let root = tmp_dir.path();
+        let target = external.path().join("shared");
+        mkdir_or_touch(root, &["a/src/A.sol", "b/src/B.sol"]);
+        mkdir_or_touch(&target, &["src/Shared.sol"]);
+        std::fs::create_dir_all(root.join("a/lib")).unwrap();
+        std::fs::create_dir_all(root.join("b/lib")).unwrap();
+        symlink(&target, root.join("a/lib/first")).unwrap();
+        symlink(&target, root.join("b/lib/second")).unwrap();
+
+        let global = Remapping::find_many(root);
+        assert_eq!(
+            global
+                .iter()
+                .filter(|remapping| remapping.name == "first/" || remapping.name == "second/")
+                .count(),
+            1
+        );
+
+        let contextual = Remapping::find_many_with_context(root).contextual;
+        assert!(contextual.iter().any(|remapping| remapping.name == "first/"));
+        assert!(contextual.iter().any(|remapping| remapping.name == "second/"));
     }
 
     #[cfg(unix)]

--- a/crates/compilers/crates/artifacts/solc/src/remappings/find.rs
+++ b/crates/compilers/crates/artifacts/solc/src/remappings/find.rs
@@ -781,34 +781,6 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn global_remappings_deduplicate_shared_symlink_targets() {
-        let tmp_dir = tempdir("lib").unwrap();
-        let external = tempdir("external").unwrap();
-        let root = tmp_dir.path();
-        let target = external.path().join("shared");
-        mkdir_or_touch(root, &["a/src/A.sol", "b/src/B.sol"]);
-        mkdir_or_touch(&target, &["src/Shared.sol"]);
-        std::fs::create_dir_all(root.join("a/lib")).unwrap();
-        std::fs::create_dir_all(root.join("b/lib")).unwrap();
-        symlink(&target, root.join("a/lib/first")).unwrap();
-        symlink(&target, root.join("b/lib/second")).unwrap();
-
-        let global = Remapping::find_many(root);
-        assert_eq!(
-            global
-                .iter()
-                .filter(|remapping| remapping.name == "first/" || remapping.name == "second/")
-                .count(),
-            1
-        );
-
-        let contextual = Remapping::find_many_with_context(root).contextual;
-        assert!(contextual.iter().any(|remapping| remapping.name == "first/"));
-        assert!(contextual.iter().any(|remapping| remapping.name == "second/"));
-    }
-
-    #[cfg(unix)]
-    #[test]
     fn contextual_remappings_short_circuit_symlink_cycles() {
         let tmp_dir = tempdir("lib").unwrap();
         let external = tempdir("external").unwrap();

--- a/crates/compilers/crates/artifacts/solc/src/remappings/find.rs
+++ b/crates/compilers/crates/artifacts/solc/src/remappings/find.rs
@@ -5,7 +5,6 @@ use std::{
     collections::{BTreeMap, HashSet, btree_map::Entry},
     fs::FileType,
     path::{Path, PathBuf},
-    sync::Mutex,
 };
 
 const DAPPTOOLS_CONTRACTS_DIR: &str = "src";
@@ -69,7 +68,6 @@ impl Remapping {
     #[instrument(level = "trace", name = "Remapping::find_many_with_context")]
     pub fn find_many_with_context(dir: &Path) -> RemappingDiscovery {
         let is_inside_node_modules = dir.ends_with("node_modules");
-        let visited_symlink_dirs = Mutex::new(HashSet::new());
 
         // iterate over all dirs that are children of the root
         let mut candidates = read_dir(dir)
@@ -77,13 +75,7 @@ impl Remapping {
             .collect::<Vec<_>>()
             .par_iter()
             .flat_map_iter(|(dir, _, _)| {
-                find_remapping_candidates(
-                    dir,
-                    dir,
-                    0,
-                    is_inside_node_modules,
-                    &visited_symlink_dirs,
-                )
+                find_remapping_candidates(dir, dir, 0, is_inside_node_modules, &HashSet::new())
             })
             .collect::<Vec<_>>();
 
@@ -340,14 +332,14 @@ fn is_hidden(path: &Path) -> bool {
 
 /// Finds all remappings in the directory recursively
 ///
-/// Note: this supports symlinks and will short-circuit if a symlink dir has already been visited,
-/// this can occur in pnpm setups: <https://github.com/foundry-rs/foundry/issues/7820>
+/// Note: this supports symlinks and will short-circuit cycles within the current traversal path.
+/// This can occur in pnpm setups: <https://github.com/foundry-rs/foundry/issues/7820>.
 fn find_remapping_candidates(
     current_dir: &Path,
     open: &Path,
     current_level: usize,
     is_inside_node_modules: bool,
-    visited_symlink_dirs: &Mutex<HashSet<PathBuf>>,
+    visited_symlink_dirs: &HashSet<PathBuf>,
 ) -> Vec<Candidate> {
     trace!("find_remapping_candidates({})", current_dir.display());
 
@@ -361,6 +353,7 @@ fn find_remapping_candidates(
         if !is_candidate && file_type.is_file() && subdir.extension() == Some("sol".as_ref()) {
             is_candidate = true;
         } else if file_type.is_dir() {
+            let mut visited_symlink_dirs = visited_symlink_dirs.clone();
             // if the dir is a symlink to a parent dir we short circuit here
             // `walkdir` will catch symlink loops, but this check prevents that we end up scanning a
             // workspace like
@@ -370,22 +363,19 @@ fn find_remapping_candidates(
             //     ├── symlink to `my-package`
             // ```
             if path_is_symlink && let Ok(target) = utils::canonicalize(&subdir) {
-                if !visited_symlink_dirs.lock().unwrap().insert(target.clone()) {
-                    // short-circuiting if we've already visited the symlink
-                    return Vec::new();
-                }
-                // the symlink points to a parent dir of the current window
-                if open.components().count() > target.components().count()
-                    && utils::common_ancestor(open, &target).is_some()
+                if visited_symlink_dirs.contains(&target)
+                    || utils::canonicalize(current_dir)
+                        .is_ok_and(|current| current.starts_with(&target))
                 {
-                    // short-circuiting
-                    return Vec::new();
+                    // short-circuiting if we've already visited the symlink
+                    continue;
                 }
+                visited_symlink_dirs.insert(target);
             }
 
             // we skip commonly used subdirs that should not be searched for recursively
             if !no_recurse(&subdir) {
-                search.push(subdir);
+                search.push((subdir, visited_symlink_dirs));
             }
         }
     }
@@ -393,7 +383,7 @@ fn find_remapping_candidates(
     // all found candidates
     let mut candidates = search
         .par_iter()
-        .flat_map_iter(|subdir| {
+        .flat_map_iter(|(subdir, visited_symlink_dirs)| {
             // scan the subdirectory for remappings, but we need a way to identify nested
             // dependencies like `ds-token/lib/ds-stop/lib/ds-note/src/contract.sol`, or
             // `oz/{tokens,auth}/{contracts, interfaces}/contract.sol` to assign
@@ -670,6 +660,69 @@ mod tests {
         );
         assert!(discovery.contextual.iter().all(|remapping| {
             !remapping.path.starts_with(external.path().to_string_lossy().as_ref())
+        }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn contextual_remappings_preserve_shared_symlink_target_owners() {
+        let tmp_dir = tempdir("lib").unwrap();
+        let external = tempdir("external").unwrap();
+        let root = tmp_dir.path();
+        let target = external.path().join("shared");
+        mkdir_or_touch(root, &["a/src/A.sol", "b/src/B.sol"]);
+        mkdir_or_touch(&target, &["src/Shared.sol"]);
+        std::fs::create_dir_all(root.join("a/lib")).unwrap();
+        std::fs::create_dir_all(root.join("b/lib")).unwrap();
+        symlink(&target, root.join("a/lib/shared")).unwrap();
+        symlink(&target, root.join("b/lib/shared")).unwrap();
+
+        let discovery = Remapping::find_many_with_context(root);
+        assert!(discovery.global.contains(&Remapping {
+            context: None,
+            name: "shared/".to_string(),
+            path: to_str(root.join("a/lib/shared/src")),
+        }));
+        assert_eq!(
+            discovery
+                .contextual
+                .into_iter()
+                .filter(|remapping| remapping.name == "shared/")
+                .collect::<Vec<_>>(),
+            vec![
+                Remapping {
+                    context: Some(to_str(root.join("a"))),
+                    name: "shared/".to_string(),
+                    path: to_str(root.join("a/lib/shared/src")),
+                },
+                Remapping {
+                    context: Some(to_str(root.join("b"))),
+                    name: "shared/".to_string(),
+                    path: to_str(root.join("b/lib/shared/src")),
+                },
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn contextual_remappings_short_circuit_symlink_cycles() {
+        let tmp_dir = tempdir("lib").unwrap();
+        let external = tempdir("external").unwrap();
+        let root = tmp_dir.path();
+        let target = external.path().join("shared");
+        mkdir_or_touch(root, &["a/src/A.sol"]);
+        mkdir_or_touch(&target, &["src/Shared.sol"]);
+        std::fs::create_dir_all(root.join("a/lib")).unwrap();
+        std::fs::create_dir_all(target.join("lib")).unwrap();
+        symlink(&target, root.join("a/lib/shared")).unwrap();
+        symlink(&target, target.join("lib/self")).unwrap();
+
+        let discovery = Remapping::find_many_with_context(root);
+        assert!(discovery.contextual.contains(&Remapping {
+            context: Some(to_str(root.join("a"))),
+            name: "shared/".to_string(),
+            path: to_str(root.join("a/lib/shared/src")),
         }));
     }
 

--- a/crates/compilers/crates/artifacts/solc/src/remappings/find.rs
+++ b/crates/compilers/crates/artifacts/solc/src/remappings/find.rs
@@ -1,4 +1,4 @@
-use super::Remapping;
+use super::{Remapping, RemappingDiscovery};
 use foundry_compilers_core::utils;
 use rayon::prelude::*;
 use std::{
@@ -57,29 +57,17 @@ impl Remapping {
     /// (`@aave`)
     #[instrument(level = "trace", name = "Remapping::find_many")]
     pub fn find_many(dir: &Path) -> Vec<Self> {
-        /// prioritize
-        ///   - ("a", "1/2") over ("a", "1/2/3")
-        ///   - if a path ends with `src`
-        fn insert_prioritized(
-            mappings: &mut BTreeMap<String, PathBuf>,
-            key: String,
-            path: PathBuf,
-        ) {
-            match mappings.entry(key) {
-                Entry::Occupied(mut e) => {
-                    if e.get().components().count() > path.components().count()
-                        || (path.ends_with(DAPPTOOLS_CONTRACTS_DIR)
-                            && !e.get().ends_with(DAPPTOOLS_CONTRACTS_DIR))
-                    {
-                        e.insert(path);
-                    }
-                }
-                Entry::Vacant(e) => {
-                    e.insert(path);
-                }
-            }
-        }
+        Self::find_many_with_context(dir).global
+    }
 
+    /// Attempts to autodetect global remappings and their nested dependency ownership.
+    ///
+    /// This performs the same traversal and global selection as [`Self::find_many`], while also
+    /// retaining the preferred nested candidate for each lexical owner and alias, using the same
+    /// priority rules as global discovery. The owner is the path prefix before the rightmost
+    /// lexical `lib` or `node_modules` barrier.
+    #[instrument(level = "trace", name = "Remapping::find_many_with_context")]
+    pub fn find_many_with_context(dir: &Path) -> RemappingDiscovery {
         let is_inside_node_modules = dir.ends_with("node_modules");
         let visited_symlink_dirs = Mutex::new(HashSet::new());
 
@@ -104,19 +92,75 @@ impl Remapping {
         // same number of components.
         candidates.sort_by(|a, b| a.source_dir.cmp(&b.source_dir));
 
-        // all combined remappings from all subdirs
+        // Select remappings globally and within each lexical dependency owner.
         let mut all_remappings = BTreeMap::new();
+        let mut contextual_remappings = BTreeMap::new();
         for candidate in candidates {
             if let Some(name) = candidate.window_start.file_name().and_then(|s| s.to_str()) {
-                insert_prioritized(&mut all_remappings, format!("{name}/"), candidate.source_dir);
+                let name = format!("{name}/");
+                if let Some(owner) = dependency_owner(dir, &candidate.window_start) {
+                    insert_prioritized(
+                        contextual_remappings.entry(owner).or_default(),
+                        name.clone(),
+                        candidate.source_dir.clone(),
+                    );
+                }
+                insert_prioritized(&mut all_remappings, name, candidate.source_dir);
             }
         }
 
-        all_remappings
+        let global = all_remappings
             .into_iter()
             .map(|(name, path)| Self { context: None, name, path: format!("{}/", path.display()) })
-            .collect()
+            .collect();
+        let contextual = contextual_remappings
+            .into_iter()
+            .flat_map(|(context, remappings)| {
+                remappings.into_iter().map(move |(name, path)| Self {
+                    context: Some(format!("{}/", context.display())),
+                    name,
+                    path: format!("{}/", path.display()),
+                })
+            })
+            .collect();
+        RemappingDiscovery { global, contextual }
     }
+}
+
+/// Prioritizes:
+/// - ("a", "1/2") over ("a", "1/2/3")
+/// - a path ending with `src` over one that does not
+fn insert_prioritized(mappings: &mut BTreeMap<String, PathBuf>, key: String, path: PathBuf) {
+    match mappings.entry(key) {
+        Entry::Occupied(mut entry) => {
+            if entry.get().components().count() > path.components().count()
+                || (path.ends_with(DAPPTOOLS_CONTRACTS_DIR)
+                    && !entry.get().ends_with(DAPPTOOLS_CONTRACTS_DIR))
+            {
+                entry.insert(path);
+            }
+        }
+        Entry::Vacant(entry) => {
+            entry.insert(path);
+        }
+    }
+}
+
+/// Returns the lexical dependency that owns a nested package window.
+///
+/// The nearest `lib` or `node_modules` component below the scan root is the dependency barrier.
+/// The package containing that barrier owns imports of the nested package. This uses the same
+/// barriers as candidate discovery and intentionally preserves symlink aliases.
+fn dependency_owner(root: &Path, window_start: &Path) -> Option<PathBuf> {
+    let relative = window_start.strip_prefix(root).ok()?;
+    let components = relative.components().collect::<Vec<_>>();
+    let barrier = components.iter().rposition(|component| {
+        let component = Path::new(component.as_os_str());
+        component == Path::new(DAPPTOOLS_LIB_DIR) || component == Path::new(JS_LIB_DIR)
+    })?;
+    (barrier > 0).then(|| {
+        components[..barrier].iter().fold(root.to_path_buf(), |path, part| path.join(part))
+    })
 }
 
 #[derive(Clone, Debug)]
@@ -493,6 +537,9 @@ mod tests {
     use super::{super::tests::*, *};
     use foundry_compilers_core::utils::{mkdir_or_touch, tempdir, touch};
 
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+
     /// Helper function for converting PathBufs to remapping strings.
     fn to_str(p: std::path::PathBuf) -> String {
         format!("{}/", p.display())
@@ -511,6 +558,144 @@ mod tests {
             Path::new(
                 "/var/folders/l5/lprhf87s6xv8djgd017f0b2h0000gn/T/lib.Z6ODLZJQeJQa/repo1/lib/ds-test"
             )
+        );
+    }
+
+    #[test]
+    fn discovers_contextual_sibling_remappings_without_changing_global_selection() {
+        let tmp_dir = tempdir("lib").unwrap();
+        let root = tmp_dir.path();
+        mkdir_or_touch(
+            root,
+            &[
+                "a/src/A.sol",
+                "a/lib/shared/src/Shared.sol",
+                "b/src/B.sol",
+                "b/lib/shared/src/Shared.sol",
+                "unique/lib/only/src/Only.sol",
+            ],
+        );
+
+        let discovery = Remapping::find_many_with_context(root);
+        assert_eq!(Remapping::find_many(root), discovery.global);
+        assert!(discovery.global.contains(&Remapping {
+            context: None,
+            name: "shared/".to_string(),
+            path: to_str(root.join("a/lib/shared/src")),
+        }));
+        assert_eq!(
+            discovery
+                .contextual
+                .iter()
+                .filter(|remapping| remapping.name == "shared/")
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![
+                Remapping {
+                    context: Some(to_str(root.join("a"))),
+                    name: "shared/".to_string(),
+                    path: to_str(root.join("a/lib/shared/src")),
+                },
+                Remapping {
+                    context: Some(to_str(root.join("b"))),
+                    name: "shared/".to_string(),
+                    path: to_str(root.join("b/lib/shared/src")),
+                },
+            ]
+        );
+        assert!(discovery.contextual.contains(&Remapping {
+            context: Some(to_str(root.join("unique"))),
+            name: "only/".to_string(),
+            path: to_str(root.join("unique/lib/only/src")),
+        }));
+    }
+
+    #[test]
+    fn discovers_nearest_contextual_owner() {
+        let tmp_dir = tempdir("lib").unwrap();
+        let root = tmp_dir.path();
+        mkdir_or_touch(
+            root,
+            &[
+                "a/lib/x/src/X.sol",
+                "a/lib/x/lib/shared/src/Shared.sol",
+                "a/lib/y/src/Y.sol",
+                "a/lib/y/lib/shared/src/Shared.sol",
+            ],
+        );
+
+        let discovery = Remapping::find_many_with_context(root);
+        assert_eq!(
+            discovery
+                .contextual
+                .iter()
+                .filter(|remapping| remapping.name == "shared/")
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![
+                Remapping {
+                    context: Some(to_str(root.join("a/lib/x"))),
+                    name: "shared/".to_string(),
+                    path: to_str(root.join("a/lib/x/lib/shared/src")),
+                },
+                Remapping {
+                    context: Some(to_str(root.join("a/lib/y"))),
+                    name: "shared/".to_string(),
+                    path: to_str(root.join("a/lib/y/lib/shared/src")),
+                },
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn contextual_remappings_preserve_symlink_paths() {
+        let tmp_dir = tempdir("lib").unwrap();
+        let external = tempdir("external").unwrap();
+        let root = tmp_dir.path();
+        let target = external.path().join("cache/packages/shared");
+        mkdir_or_touch(root, &["a/src/A.sol"]);
+        mkdir_or_touch(&target, &["src/Shared.sol"]);
+        std::fs::create_dir_all(root.join("a/lib")).unwrap();
+        symlink(&target, root.join("a/lib/shared")).unwrap();
+
+        let discovery = Remapping::find_many_with_context(root);
+        assert!(
+            discovery.contextual.contains(&Remapping {
+                context: Some(to_str(root.join("a"))),
+                name: "shared/".to_string(),
+                path: to_str(root.join("a/lib/shared/src")),
+            }),
+            "{discovery:#?}"
+        );
+        assert!(discovery.contextual.iter().all(|remapping| {
+            !remapping.path.starts_with(external.path().to_string_lossy().as_ref())
+        }));
+    }
+
+    #[test]
+    fn discovers_full_scoped_package_owner() {
+        let tmp_dir = tempdir("node_modules").unwrap();
+        let root = tmp_dir.path().join("node_modules");
+        mkdir_or_touch(
+            tmp_dir.path(),
+            &[
+                "node_modules/@scope/a/contracts/A.sol",
+                "node_modules/@scope/a/node_modules/shared/contracts/Shared.sol",
+                "node_modules/@scope/b/contracts/B.sol",
+                "node_modules/@scope/b/node_modules/shared/contracts/Shared.sol",
+            ],
+        );
+
+        let discovery = Remapping::find_many_with_context(&root);
+        assert_eq!(
+            discovery
+                .contextual
+                .iter()
+                .filter(|remapping| remapping.name == "shared/")
+                .map(|remapping| remapping.context.clone().unwrap())
+                .collect::<Vec<_>>(),
+            vec![to_str(root.join("@scope/a")), to_str(root.join("@scope/b"))]
         );
     }
 

--- a/crates/compilers/crates/artifacts/solc/src/remappings/mod.rs
+++ b/crates/compilers/crates/artifacts/solc/src/remappings/mod.rs
@@ -55,6 +55,18 @@ pub struct Remapping {
     pub path: String,
 }
 
+/// The result of ownership-aware remapping discovery.
+#[cfg(feature = "walkdir")]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RemappingDiscovery {
+    /// Remappings selected using the global package priority.
+    pub global: Vec<Remapping>,
+    /// Preferred nested remappings for each lexical owner and alias.
+    ///
+    /// This includes aliases that occur only once within the scanned directory.
+    pub contextual: Vec<Remapping>,
+}
+
 impl Remapping {
     /// Convenience function for [`RelativeRemapping::new`]
     pub fn into_relative(self, root: &Path) -> RelativeRemapping {

--- a/crates/compilers/crates/artifacts/solc/src/remappings/mod.rs
+++ b/crates/compilers/crates/artifacts/solc/src/remappings/mod.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::{
     fmt,
-    path::{Path, PathBuf},
+    path::{MAIN_SEPARATOR, Path, PathBuf},
     str::FromStr,
 };
 
@@ -63,8 +63,21 @@ pub struct RemappingDiscovery {
     pub global: Vec<Remapping>,
     /// Preferred nested remappings for each lexical owner and alias.
     ///
-    /// This includes aliases that occur only once within the scanned directory.
+    /// This includes aliases that occur only once within the scanned directory. Entries are
+    /// ordered by the most specific owner first, and consumers must preserve this order.
     pub contextual: Vec<Remapping>,
+}
+
+#[cfg(feature = "walkdir")]
+impl RemappingDiscovery {
+    /// Makes all discovered remapping targets and contexts relative to `root`.
+    pub fn into_relative(self, root: &Path) -> Self {
+        let relative = |remapping| RelativeRemapping::new(remapping, root).to_relative_remapping();
+        Self {
+            global: self.global.into_iter().map(relative).collect(),
+            contextual: self.contextual.into_iter().map(relative).collect(),
+        }
+    }
 }
 
 impl Remapping {
@@ -203,10 +216,19 @@ pub struct RelativeRemapping {
 impl RelativeRemapping {
     /// Creates a new `RelativeRemapping` starting prefixed with `root`
     pub fn new(remapping: Remapping, root: &Path) -> Self {
+        let context = remapping.context.map(|context| {
+            let has_boundary = context.ends_with(['/', '\\']);
+            let mut context = RelativeRemappingPathBuf::with_root(root, context)
+                .path
+                .to_string_lossy()
+                .to_string();
+            if has_boundary && !context.ends_with(['/', '\\']) {
+                context.push(MAIN_SEPARATOR);
+            }
+            context
+        });
         Self {
-            context: remapping.context.map(|c| {
-                RelativeRemappingPathBuf::with_root(root, c).path.to_string_lossy().to_string()
-            }),
+            context,
             name: remapping.name,
             path: RelativeRemappingPathBuf::with_root(root, remapping.path),
         }


### PR DESCRIPTION
Remapping autodetection currently collapses candidates globally by alias, discarding nested versions before callers can contextualize them.

This adds `RemappingDiscovery` and `Remapping::find_many_with_context`, retaining the preferred candidate for each lexical dependency owner and alias. It uses the existing traversal and priority rules, including scoped npm and symlink handling, while preserving the output and behavior of `Remapping::find_many`.

This allows consumers to contextualize duplicate transitive dependencies without rescanning dependency trees or reimplementing remapping discovery.

Part of OSS-583