### PR TITLE
feat(compilers): approve resolved executable paths

### DIFF
--- a/crates/compilers/crates/compilers/src/compilers/compiler_path.rs
+++ b/crates/compilers/crates/compilers/src/compilers/compiler_path.rs
@@ -6,9 +6,37 @@ use std::{
     env,
     ffi::OsStr,
     path::{Path, PathBuf},
+    sync::{Arc, RwLock},
 };
 
-pub(super) fn resolve_and_approve(
+type CompilerApprovalHandler = dyn Fn(&Path) -> Result<()> + Send + Sync;
+
+static COMPILER_APPROVAL_HANDLER: RwLock<Option<Arc<CompilerApprovalHandler>>> = RwLock::new(None);
+
+/// Installs the process-wide handler used to approve resolved compiler executable paths.
+pub fn set_compiler_approval_handler(
+    handler: impl Fn(&Path) -> Result<()> + Send + Sync + 'static,
+) {
+    *COMPILER_APPROVAL_HANDLER.write().unwrap_or_else(|err| err.into_inner()) =
+        Some(Arc::new(handler));
+}
+
+pub(super) fn resolve_and_approve(path: PathBuf) -> Result<PathBuf> {
+    resolve_and_approve_with(path, |path| {
+        let handler = COMPILER_APPROVAL_HANDLER
+            .read()
+            .unwrap_or_else(|err| err.into_inner())
+            .clone()
+            .ok_or_else(|| {
+                SolcError::msg(format!(
+                    "compiler executable {path:?} requires approval, but no approval handler is installed"
+                ))
+            })?;
+        handler(path)
+    })
+}
+
+fn resolve_and_approve_with(
     path: PathBuf,
     approve: impl FnOnce(&Path) -> Result<()>,
 ) -> Result<PathBuf> {
@@ -98,7 +126,7 @@ mod tests {
         symlink(&compiler, &alias).unwrap();
         let expected = canonicalize(&compiler).unwrap();
 
-        let resolved = resolve_and_approve(alias, |path| {
+        let resolved = resolve_and_approve_with(alias, |path| {
             assert_eq!(path, expected);
             Ok(())
         })

--- a/crates/compilers/crates/compilers/src/compilers/compiler_path.rs
+++ b/crates/compilers/crates/compilers/src/compilers/compiler_path.rs
@@ -63,9 +63,22 @@ fn resolve(path: &Path) -> Result<PathBuf> {
 }
 
 fn resolve_in_path(path: &Path, search_path: &OsStr) -> Option<PathBuf> {
-    env::split_paths(search_path)
-        .flat_map(|dir| executable_candidates(dir.join(path)))
-        .find_map(|candidate| candidate.is_file().then(|| canonicalize(candidate).ok()).flatten())
+    env::split_paths(search_path).flat_map(|dir| executable_candidates(dir.join(path))).find_map(
+        |candidate| is_executable(&candidate).then(|| canonicalize(candidate).ok()).flatten(),
+    )
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    path.metadata()
+        .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
 }
 
 #[cfg(not(windows))]
@@ -75,17 +88,17 @@ fn executable_candidates(path: PathBuf) -> impl Iterator<Item = PathBuf> {
 
 #[cfg(windows)]
 fn executable_candidates(path: PathBuf) -> impl Iterator<Item = PathBuf> {
-    let mut candidates = vec![path.clone()];
-    if path.extension().is_none() {
+    let candidates = if path.extension().is_none() {
         let path_ext = env::var_os("PATHEXT").unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".into());
-        candidates.extend(
-            path_ext
-                .to_string_lossy()
-                .split(';')
-                .filter(|ext| !ext.is_empty())
-                .map(|ext| path.with_extension(ext.trim_start_matches('.'))),
-        );
-    }
+        path_ext
+            .to_string_lossy()
+            .split(';')
+            .filter(|ext| !ext.is_empty())
+            .map(|ext| path.with_extension(ext.trim_start_matches('.')))
+            .collect()
+    } else {
+        vec![path]
+    };
     candidates.into_iter()
 }
 
@@ -97,6 +110,15 @@ fn not_found(path: &Path) -> SolcError {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn make_executable(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = path.metadata().unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+
     #[test]
     fn resolves_bare_name_from_search_path() {
         let dir = tempfile::tempdir().unwrap();
@@ -106,11 +128,35 @@ mod tests {
         let (name, file_name) = ("compiler", "compiler");
         let compiler = dir.path().join(file_name);
         std::fs::write(&compiler, []).unwrap();
+        #[cfg(unix)]
+        make_executable(&compiler);
         let search_path = env::join_paths([dir.path()]).unwrap();
 
         assert_eq!(
             resolve_in_path(Path::new(name), &search_path),
             Some(canonicalize(compiler).unwrap())
+        );
+    }
+
+    #[test]
+    fn skips_non_executable_path_entry() {
+        let first_dir = tempfile::tempdir().unwrap();
+        let second_dir = tempfile::tempdir().unwrap();
+        #[cfg(windows)]
+        let (name, file_name) = ("compiler", "compiler.exe");
+        #[cfg(not(windows))]
+        let (name, file_name) = ("compiler", "compiler");
+        let non_executable = first_dir.path().join(name);
+        let executable = second_dir.path().join(file_name);
+        std::fs::write(non_executable, []).unwrap();
+        std::fs::write(&executable, []).unwrap();
+        #[cfg(unix)]
+        make_executable(&executable);
+        let search_path = env::join_paths([first_dir.path(), second_dir.path()]).unwrap();
+
+        assert_eq!(
+            resolve_in_path(Path::new(name), &search_path),
+            Some(canonicalize(executable).unwrap())
         );
     }
 

--- a/crates/compilers/crates/compilers/src/compilers/compiler_path.rs
+++ b/crates/compilers/crates/compilers/src/compilers/compiler_path.rs
@@ -1,0 +1,109 @@
+use foundry_compilers_core::{
+    error::{Result, SolcError},
+    utils::canonicalize,
+};
+use std::{
+    env,
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
+
+pub(super) fn resolve_and_approve(
+    path: PathBuf,
+    approve: impl FnOnce(&Path) -> Result<()>,
+) -> Result<PathBuf> {
+    let path = resolve(&path)?;
+    approve(&path)?;
+    Ok(path)
+}
+
+fn resolve(path: &Path) -> Result<PathBuf> {
+    if path.as_os_str().is_empty() {
+        return Err(not_found(path));
+    }
+    if path.components().count() != 1 {
+        return canonicalize(path).map_err(|err| {
+            SolcError::msg(format!(
+                "failed to resolve compiler executable {path:?}: {}",
+                err.source()
+            ))
+        });
+    }
+
+    let search_path = env::var_os("PATH").ok_or_else(|| not_found(path))?;
+    resolve_in_path(path, &search_path).ok_or_else(|| not_found(path))
+}
+
+fn resolve_in_path(path: &Path, search_path: &OsStr) -> Option<PathBuf> {
+    env::split_paths(search_path)
+        .flat_map(|dir| executable_candidates(dir.join(path)))
+        .find_map(|candidate| candidate.is_file().then(|| canonicalize(candidate).ok()).flatten())
+}
+
+#[cfg(not(windows))]
+fn executable_candidates(path: PathBuf) -> impl Iterator<Item = PathBuf> {
+    std::iter::once(path)
+}
+
+#[cfg(windows)]
+fn executable_candidates(path: PathBuf) -> impl Iterator<Item = PathBuf> {
+    let mut candidates = vec![path.clone()];
+    if path.extension().is_none() {
+        let path_ext = env::var_os("PATHEXT").unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".into());
+        candidates.extend(
+            path_ext
+                .to_string_lossy()
+                .split(';')
+                .filter(|ext| !ext.is_empty())
+                .map(|ext| path.with_extension(ext.trim_start_matches('.'))),
+        );
+    }
+    candidates.into_iter()
+}
+
+fn not_found(path: &Path) -> SolcError {
+    SolcError::msg(format!("compiler executable {path:?} was not found"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_bare_name_from_search_path() {
+        let dir = tempfile::tempdir().unwrap();
+        #[cfg(windows)]
+        let (name, file_name) = ("compiler", "compiler.exe");
+        #[cfg(not(windows))]
+        let (name, file_name) = ("compiler", "compiler");
+        let compiler = dir.path().join(file_name);
+        std::fs::write(&compiler, []).unwrap();
+        let search_path = env::join_paths([dir.path()]).unwrap();
+
+        assert_eq!(
+            resolve_in_path(Path::new(name), &search_path),
+            Some(canonicalize(compiler).unwrap())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn approval_receives_and_returns_symlink_target() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let compiler = dir.path().join("compiler");
+        let alias = dir.path().join("alias");
+        std::fs::write(&compiler, []).unwrap();
+        symlink(&compiler, &alias).unwrap();
+        let expected = canonicalize(&compiler).unwrap();
+
+        let resolved = resolve_and_approve(alias, |path| {
+            assert_eq!(path, expected);
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(resolved, expected);
+    }
+}

--- a/crates/compilers/crates/compilers/src/compilers/mod.rs
+++ b/crates/compilers/crates/compilers/src/compilers/mod.rs
@@ -22,6 +22,7 @@ use std::{
 };
 
 mod compiler_path;
+pub use compiler_path::set_compiler_approval_handler;
 pub mod multi;
 pub mod solc;
 pub mod vyper;

--- a/crates/compilers/crates/compilers/src/compilers/mod.rs
+++ b/crates/compilers/crates/compilers/src/compilers/mod.rs
@@ -21,6 +21,7 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
+mod compiler_path;
 pub mod multi;
 pub mod solc;
 pub mod vyper;

--- a/crates/compilers/crates/compilers/src/compilers/solc/compiler.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/compiler.rs
@@ -1,4 +1,4 @@
-use crate::resolver::parse::SolData;
+use crate::{compilers::compiler_path::resolve_and_approve, resolver::parse::SolData};
 use foundry_compilers_artifacts::{CompilerOutput, SolcInput, sources::Source};
 use foundry_compilers_core::{
     error::{Result, SolcError},
@@ -94,6 +94,15 @@ impl Solc {
         Self::new_with_args(path, Vec::<String>::new())
     }
 
+    /// Creates a new instance after resolving `path` to an exact executable and passing that path
+    /// to `approve`. The resolved path is used for both the version probe and later compilations.
+    pub fn new_with_approval(
+        path: impl Into<PathBuf>,
+        approve: impl FnOnce(&Path) -> Result<()>,
+    ) -> Result<Self> {
+        Self::new_with_args_and_approval(path, Vec::<String>::new(), approve)
+    }
+
     /// A new instance which points to `solc` with additional cli arguments. Invokes `solc
     /// --version` to determine the version.
     ///
@@ -106,6 +115,17 @@ impl Solc {
         let extra_args = extra_args.into_iter().map(Into::into).collect::<Vec<_>>();
         let version = Self::version_with_args(path.clone(), &extra_args)?;
         Ok(Self::_new(path, version, extra_args))
+    }
+
+    /// Creates a new instance with additional CLI arguments after resolving and approving its
+    /// exact executable path.
+    pub fn new_with_args_and_approval(
+        path: impl Into<PathBuf>,
+        extra_args: impl IntoIterator<Item: Into<String>>,
+        approve: impl FnOnce(&Path) -> Result<()>,
+    ) -> Result<Self> {
+        let path = resolve_and_approve(path.into(), approve)?;
+        Self::new_with_args(path, extra_args)
     }
 
     /// A new instance which points to `solc` with the given version
@@ -711,6 +731,50 @@ fn version_from_output(output: Output) -> Result<Version> {
 impl AsRef<Path> for Solc {
     fn as_ref(&self) -> &Path {
         &self.solc
+    }
+}
+
+#[cfg(all(test, unix))]
+mod approval_tests {
+    use super::*;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    #[test]
+    fn approved_symlink_target_is_used_for_compilation() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first");
+        let second = dir.path().join("second");
+        let alias = dir.path().join("solc");
+        let first_invoked = dir.path().join("first.invoked");
+        let second_invoked = dir.path().join("second.invoked");
+        for path in [&first, &second] {
+            std::fs::write(
+                path,
+                r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+    echo "solc, the solidity compiler commandline interface"
+    echo "Version: 0.8.35+commit.69074fbd"
+else
+    touch "$0.invoked"
+    echo '{}'
+fi
+"#,
+            )
+            .unwrap();
+            let mut permissions = std::fs::metadata(path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(path, permissions).unwrap();
+        }
+        symlink(&first, &alias).unwrap();
+
+        let solc = Solc::new_with_approval(&alias, |_| Ok(())).unwrap();
+        assert_eq!(solc.solc, foundry_compilers_core::utils::canonicalize(&first).unwrap());
+        std::fs::remove_file(&alias).unwrap();
+        symlink(&second, &alias).unwrap();
+
+        solc.compile_output(&serde_json::json!({})).unwrap();
+        assert!(first_invoked.exists());
+        assert!(!second_invoked.exists());
     }
 }
 

--- a/crates/compilers/crates/compilers/src/compilers/solc/compiler.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/compiler.rs
@@ -95,12 +95,10 @@ impl Solc {
     }
 
     /// Creates a new instance after resolving `path` to an exact executable and passing that path
-    /// to `approve`. The resolved path is used for both the version probe and later compilations.
-    pub fn new_with_approval(
-        path: impl Into<PathBuf>,
-        approve: impl FnOnce(&Path) -> Result<()>,
-    ) -> Result<Self> {
-        Self::new_with_args_and_approval(path, Vec::<String>::new(), approve)
+    /// to the process-wide approval handler. The resolved path is used for both the version probe
+    /// and later compilations.
+    pub fn new_with_approval(path: impl Into<PathBuf>) -> Result<Self> {
+        Self::new_with_args_and_approval(path, Vec::<String>::new())
     }
 
     /// A new instance which points to `solc` with additional cli arguments. Invokes `solc
@@ -118,13 +116,12 @@ impl Solc {
     }
 
     /// Creates a new instance with additional CLI arguments after resolving and approving its
-    /// exact executable path.
+    /// exact executable path with the process-wide approval handler.
     pub fn new_with_args_and_approval(
         path: impl Into<PathBuf>,
         extra_args: impl IntoIterator<Item: Into<String>>,
-        approve: impl FnOnce(&Path) -> Result<()>,
     ) -> Result<Self> {
-        let path = resolve_and_approve(path.into(), approve)?;
+        let path = resolve_and_approve(path.into())?;
         Self::new_with_args(path, extra_args)
     }
 
@@ -767,7 +764,8 @@ fi
         }
         symlink(&first, &alias).unwrap();
 
-        let solc = Solc::new_with_approval(&alias, |_| Ok(())).unwrap();
+        crate::set_compiler_approval_handler(|_| Ok(()));
+        let solc = Solc::new_with_approval(&alias).unwrap();
         assert_eq!(solc.solc, foundry_compilers_core::utils::canonicalize(&first).unwrap());
         std::fs::remove_file(&alias).unwrap();
         symlink(&second, &alias).unwrap();

--- a/crates/compilers/crates/compilers/src/compilers/vyper/mod.rs
+++ b/crates/compilers/crates/compilers/src/compilers/vyper/mod.rs
@@ -81,12 +81,10 @@ impl Vyper {
     }
 
     /// Creates a new instance after resolving `path` to an exact executable and passing that path
-    /// to `approve`. The resolved path is used for both the version probe and later compilations.
-    pub fn new_with_approval(
-        path: impl Into<PathBuf>,
-        approve: impl FnOnce(&Path) -> Result<()>,
-    ) -> Result<Self> {
-        let path = resolve_and_approve(path.into(), approve)?;
+    /// to the process-wide approval handler. The resolved path is used for both the version probe
+    /// and later compilations.
+    pub fn new_with_approval(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = resolve_and_approve(path.into())?;
         Self::new(path)
     }
 

--- a/crates/compilers/crates/compilers/src/compilers/vyper/mod.rs
+++ b/crates/compilers/crates/compilers/src/compilers/vyper/mod.rs
@@ -1,4 +1,5 @@
 use self::input::VyperVersionedInput;
+use super::compiler_path::resolve_and_approve;
 use super::{Compiler, CompilerOutput, Language};
 pub use crate::artifacts::vyper::{VyperCompilationError, VyperInput, VyperOutput, VyperSettings};
 use crate::parser::VyperParser;
@@ -77,6 +78,16 @@ impl Vyper {
         let path = path.into();
         let version = Self::version(path.clone())?;
         Ok(Self { path, version })
+    }
+
+    /// Creates a new instance after resolving `path` to an exact executable and passing that path
+    /// to `approve`. The resolved path is used for both the version probe and later compilations.
+    pub fn new_with_approval(
+        path: impl Into<PathBuf>,
+        approve: impl FnOnce(&Path) -> Result<()>,
+    ) -> Result<Self> {
+        let path = resolve_and_approve(path.into(), approve)?;
+        Self::new(path)
     }
 
     /// Convenience function for compiling all sources under the given path

--- a/crates/compilers/crates/compilers/src/compilers/vyper/mod.rs
+++ b/crates/compilers/crates/compilers/src/compilers/vyper/mod.rs
@@ -1,6 +1,5 @@
 use self::input::VyperVersionedInput;
-use super::compiler_path::resolve_and_approve;
-use super::{Compiler, CompilerOutput, Language};
+use super::{Compiler, CompilerOutput, Language, compiler_path::resolve_and_approve};
 pub use crate::artifacts::vyper::{VyperCompilationError, VyperInput, VyperOutput, VyperSettings};
 use crate::parser::VyperParser;
 use core::fmt;


### PR DESCRIPTION
Adds approval-aware Solc and Vyper constructors that:

- resolve bare executable names through `PATH`
- canonicalize the selected executable before approval
- use that exact path for version probes and later compilation spawns
- fail closed when resolution fails

Includes regressions for bare-name resolution and symlink retargeting.

Companion to foundry-rs/foundry#16113.