### PR TITLE
fix(compilers): use native paths in remapping tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,9 @@ jobs:
       fail-fast: false
       matrix:
         # Keep PR feedback fast by running the test matrix on Linux only.
+        # Temporarily add Windows for this PR to validate the contextual remapping path fix.
         # Pushes to main retain cross-platform coverage.
-        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest", "macos-latest", "windows-latest"]') }}
+        os: ${{ fromJSON(github.event_name == 'pull_request' && (github.head_ref == 'mablr/fix-windows-contextual-remapping-tests' && '["ubuntu-latest", "windows-latest"]' || '["ubuntu-latest"]') || '["ubuntu-latest", "macos-latest", "windows-latest"]') }}
         rust: ["stable", "1.95"]
         flags: ["", "--all-features"]
         exclude:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,9 +152,8 @@ jobs:
       fail-fast: false
       matrix:
         # Keep PR feedback fast by running the test matrix on Linux only.
-        # Temporarily add Windows for this PR to validate the contextual remapping path fix.
         # Pushes to main retain cross-platform coverage.
-        os: ${{ fromJSON(github.event_name == 'pull_request' && (github.head_ref == 'mablr/fix-windows-contextual-remapping-tests' && '["ubuntu-latest", "windows-latest"]' || '["ubuntu-latest"]') || '["ubuntu-latest", "macos-latest", "windows-latest"]') }}
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest", "macos-latest", "windows-latest"]') }}
         rust: ["stable", "1.95"]
         flags: ["", "--all-features"]
         exclude:

--- a/crates/compilers/crates/artifacts/solc/src/remappings/find.rs
+++ b/crates/compilers/crates/artifacts/solc/src/remappings/find.rs
@@ -569,6 +569,7 @@ mod tests {
 
     /// Helper function for converting PathBufs to remapping strings.
     fn to_str(p: std::path::PathBuf) -> String {
+        let p = p.components().collect::<PathBuf>();
         format!("{}/", p.display())
     }
 
@@ -639,12 +640,12 @@ mod tests {
         assert!(relative.global.contains(&Remapping {
             context: None,
             name: "shared/".to_string(),
-            path: format!("a/lib/shared/src{MAIN_SEPARATOR}"),
+            path: to_str(PathBuf::from("a/lib/shared/src")),
         }));
         assert!(relative.contextual.contains(&Remapping {
             context: Some(format!("a{MAIN_SEPARATOR}")),
             name: "shared/".to_string(),
-            path: format!("a/lib/shared/src{MAIN_SEPARATOR}"),
+            path: to_str(PathBuf::from("a/lib/shared/src")),
         }));
         assert_eq!(
             relative


### PR DESCRIPTION
Fix Windows contextual remapping tests by constructing expected paths with native separators. The fix was validated by a [successful Windows CI run](https://github.com/foundry-rs/foundry-core/actions/runs/31413385802/job/93536540602?pr=155).
