### PR TITLE
fix(wallets): reject invalid BIP-32 indices

### DIFF
--- a/crates/wallets/src/error.rs
+++ b/crates/wallets/src/error.rs
@@ -36,6 +36,8 @@ pub enum PrivateKeyError {
 pub enum WalletSignerError {
     #[error(transparent)]
     Local(#[from] LocalSignerError),
+    #[error("BIP-32 index {0} must be less than 2147483648")]
+    InvalidBip32Index(u32),
     #[error("Failed to decrypt keystore: incorrect password")]
     IncorrectKeystorePassword,
     #[error("decrypted keystore address mismatch: expected {expected}, got {actual}")]

--- a/crates/wallets/src/signer.rs
+++ b/crates/wallets/src/signer.rs
@@ -29,6 +29,23 @@ use alloy_signer_turnkey::TurnkeySigner;
 
 pub type Result<T> = std::result::Result<T, WalletSignerError>;
 
+const BIP32_HARDEN: u32 = 0x8000_0000;
+
+fn validate_bip32_path(path: &str) -> Result<()> {
+    for component in path.split('/') {
+        let index = component
+            .strip_suffix('\'')
+            .or_else(|| component.strip_suffix('h'))
+            .unwrap_or(component);
+        if let Ok(index) = index.parse::<u32>()
+            && index >= BIP32_HARDEN
+        {
+            return Err(WalletSignerError::InvalidBip32Index(index));
+        }
+    }
+    Ok(())
+}
+
 /// Wrapper enum around different signers.
 #[derive(Debug)]
 pub enum WalletSigner {
@@ -264,8 +281,12 @@ impl WalletSigner {
         }
 
         builder = if let Some(hd_path) = derivation_path {
+            validate_bip32_path(hd_path)?;
             builder.derivation_path(hd_path)?
         } else {
+            if index >= BIP32_HARDEN {
+                return Err(WalletSignerError::InvalidBip32Index(index));
+            }
             builder.index(index)?
         };
 
@@ -423,6 +444,38 @@ fn checked_keystore_signer(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const TEST_MNEMONIC: &str = "test test test test test test test test test test test junk";
+
+    #[test]
+    fn rejects_mnemonic_indices_that_set_harden_bit() {
+        assert!(matches!(
+            WalletSigner::from_mnemonic(TEST_MNEMONIC, None, None, BIP32_HARDEN),
+            Err(WalletSignerError::InvalidBip32Index(BIP32_HARDEN))
+        ));
+
+        for path in [
+            "m/2147483648",
+            "m/2147483648'",
+            "m/2147483648h",
+            "m/+2147483648'",
+            "m/02147483648'",
+            "m/4294967295",
+        ] {
+            assert!(matches!(
+                WalletSigner::from_mnemonic(TEST_MNEMONIC, None, Some(path), 0),
+                Err(WalletSignerError::InvalidBip32Index(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn accepts_largest_unhardened_mnemonic_index() {
+        assert!(WalletSigner::from_mnemonic(TEST_MNEMONIC, None, None, BIP32_HARDEN - 1).is_ok());
+        assert!(
+            WalletSigner::from_mnemonic(TEST_MNEMONIC, None, Some("m/2147483647'"), 0,).is_ok()
+        );
+    }
 
     #[test]
     fn rejects_keystore_signer_with_unexpected_address() {

--- a/crates/wallets/src/signer.rs
+++ b/crates/wallets/src/signer.rs
@@ -31,21 +31,6 @@ pub type Result<T> = std::result::Result<T, WalletSignerError>;
 
 const BIP32_HARDEN: u32 = 0x8000_0000;
 
-fn validate_bip32_path(path: &str) -> Result<()> {
-    for component in path.split('/') {
-        let index = component
-            .strip_suffix('\'')
-            .or_else(|| component.strip_suffix('h'))
-            .unwrap_or(component);
-        if let Ok(index) = index.parse::<u32>()
-            && index >= BIP32_HARDEN
-        {
-            return Err(WalletSignerError::InvalidBip32Index(index));
-        }
-    }
-    Ok(())
-}
-
 /// Wrapper enum around different signers.
 #[derive(Debug)]
 pub enum WalletSigner {
@@ -426,6 +411,21 @@ impl PendingSigner {
             }
         }
     }
+}
+
+fn validate_bip32_path(path: &str) -> Result<()> {
+    for component in path.split('/') {
+        let index = component
+            .strip_suffix('\'')
+            .or_else(|| component.strip_suffix('h'))
+            .unwrap_or(component);
+        if let Ok(index) = index.parse::<u32>()
+            && index >= BIP32_HARDEN
+        {
+            return Err(WalletSignerError::InvalidBip32Index(index));
+        }
+    }
+    Ok(())
 }
 
 fn checked_keystore_signer(


### PR DESCRIPTION
Reject mnemonic derivation indices that set the BIP-32 hardened bit. This prevents out-of-range indices and derivation-path components from aliasing other wallet keys across raw and multi-wallet flows.