### PR TITLE
chore(deps): bump tempo-alloy to 1.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ alloy-sol-types = "1.6.0"
 alloy-chains = "0.2.34"
 
 # tempo
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "0f87fa6b42c86665142432337865d1adc04238e7", default-features = false }
+tempo-alloy = { version = "1.11.0", default-features = false }
 
 # misc
 async-trait = "0.1.89"


### PR DESCRIPTION
## Summary

- bump `tempo-alloy` from `1.10.1` to `1.11.0`
- switch from the temporary Git revision pin to the crates.io release
