### PR TITLE
feat(compilers): add ProjectPathsConfigBuilder::no_remappings

### DIFF
--- a/crates/compilers/crates/compilers/src/config.rs
+++ b/crates/compilers/crates/compilers/src/config.rs
@@ -880,6 +880,17 @@ impl ProjectPathsConfigBuilder {
         self
     }
 
+    /// Specifically disallow remappings, including auto-detected ones.
+    ///
+    /// When no remappings are configured, [`Self::build`] and [`Self::build_with_root`] auto-detect
+    /// them, which recursively walks every directory under every library path. That is the dominant
+    /// cost of building the config for a project with a large dependency tree, so callers that only
+    /// need the directory layout should opt out of it.
+    pub fn no_remappings(mut self) -> Self {
+        self.remappings = Some(Vec::new());
+        self
+    }
+
     /// Adds an allowed-path to the solc executable
     pub fn allowed_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
         self.allowed_paths.insert(path.into());
@@ -916,6 +927,11 @@ impl ProjectPathsConfigBuilder {
         self
     }
 
+    /// Builds the config, resolving anything that was not set explicitly from `root`.
+    ///
+    /// If no remappings were configured this auto-detects them, which recursively walks every
+    /// directory under every library path. Use [`Self::no_remappings`] to skip that scan when the
+    /// remappings are not needed.
     pub fn build_with_root<C>(self, root: impl Into<PathBuf>) -> ProjectPathsConfig<C> {
         let root = utils::canonicalized(root);
 
@@ -947,6 +963,10 @@ impl ProjectPathsConfigBuilder {
         }
     }
 
+    /// Builds the config, resolving anything that was not set explicitly from the current
+    /// directory.
+    ///
+    /// See [`Self::build_with_root`] for the remapping auto-detection this performs.
     pub fn build<C>(self) -> std::result::Result<ProjectPathsConfig<C>, SolcIoError> {
         let root = self
             .root
@@ -1449,5 +1469,37 @@ mod tests {
 
         // The resolved path should be the local override, not the external file
         assert_eq!(resolved, local_dir.join("LibMem.sol"));
+    }
+
+    #[test]
+    fn no_remappings_skips_auto_detection() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let dep_src = root.join("lib").join("dep").join("src");
+        std::fs::create_dir_all(&dep_src).unwrap();
+        std::fs::write(dep_src.join("Dep.sol"), "").unwrap();
+
+        // The default builder auto-detects the dependency.
+        let detected = ProjectPathsConfig::builder().build_with_root::<()>(root);
+        assert!(
+            detected.remappings.iter().any(|remapping| remapping.name == "dep/"),
+            "expected auto-detected remappings, got {:?}",
+            detected.remappings
+        );
+
+        // Opting out leaves them empty without walking the tree.
+        let skipped = ProjectPathsConfig::builder().no_remappings().build_with_root::<()>(root);
+        assert!(
+            skipped.remappings.is_empty(),
+            "expected no remappings, got {:?}",
+            skipped.remappings
+        );
+
+        // Explicit remappings are still honored.
+        let explicit = ProjectPathsConfig::builder()
+            .no_remappings()
+            .remapping(Remapping { context: None, name: "a/".into(), path: "b/".into() })
+            .build_with_root::<()>(root);
+        assert_eq!(explicit.remappings.len(), 1);
     }
 }


### PR DESCRIPTION
`ProjectPathsConfigBuilder::build` and `build_with_root` auto-detect remappings when none are configured:

```rust
remappings: self.remappings.unwrap_or_else(|| {
    libraries.iter().flat_map(|p| Remapping::find_many(p)).collect()
}),
```

`Remapping::find_many` recursively walks every directory under every library path. There is currently no way for a caller to say it does not want that, so anyone who builds the config just to resolve the source/artifact/library directory layout silently pays for a scan whose result they throw away.

Foundry was doing exactly that. `Config::with_root` reads only `paths.sources`, `paths.artifacts` and `paths.libraries` and never touches `paths.remappings`, and it runs once for the project root plus once for every nested dependency config it loads. A wall-clock profile of the main thread on ithacaxyz/account, whose `lib` tree is 1631 directories, showed that discarded scan blocking for ~44% of every config load — the same tree the remappings provider then walked again for real. Opting out cut `Config::load_with_root` there from 38.4ms to 18.6ms and `forge config` from 46.1ms to 28.0ms, halving system time from 287ms to 147ms (foundry-rs/foundry#16399, which currently spells the opt-out as `.remappings(Vec::new())`).

This adds an explicit `no_remappings()` mirroring the existing `no_libs()`, and documents on both builders that the default performs a recursive scan. Purely additive: the default stays exactly as it is, so nothing changes for callers that do want auto-detection.

I deliberately did not touch the default. The alternatives — making detection opt-in, or making `remappings` lazily computed — are both breaking, and the crate's own tests rely on the current behaviour, so that seems like a maintainer call rather than something to slip into a perf fix.

Worth noting for anyone tempted to optimise the walk itself instead: I profiled it, and it is ~95% kernel syscalls on a warm cache. I tried removing the per-entry `PathBuf` allocation for the ~4300 non-Solidity files in that tree and it measured as noise (13.8–14.7ms both ways), so the win is in not calling it, not in making it faster.

`cargo test -p foundry-compilers --lib` passes (54 tests), including a new one covering all three cases: default detects, `no_remappings()` skips, explicit remappings still honored.

> AI assistance: Claude profiled the config load path, found the discarded scan and ran the benchmarks.
