### PR TITLE
test(compilers): use real paths for Windows context test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,9 +151,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Keep PR feedback fast by running the test matrix on Linux only.
+        # Keep PR feedback fast by running the test matrix on Linux and Windows.
         # Pushes to main retain cross-platform coverage.
-        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest", "macos-latest", "windows-latest"]') }}
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest", "windows-latest"]' || '["ubuntu-latest", "macos-latest", "windows-latest"]') }}
         rust: ["stable", "1.95"]
         flags: ["", "--all-features"]
         exclude:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,9 +151,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Keep PR feedback fast by running the test matrix on Linux and Windows.
+        # Keep PR feedback fast by running the test matrix on Linux only.
         # Pushes to main retain cross-platform coverage.
-        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest", "windows-latest"]' || '["ubuntu-latest", "macos-latest", "windows-latest"]') }}
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest", "macos-latest", "windows-latest"]') }}
         rust: ["stable", "1.95"]
         flags: ["", "--all-features"]
         exclude:

--- a/crates/compilers/crates/compilers/src/config.rs
+++ b/crates/compilers/crates/compilers/src/config.rs
@@ -1110,11 +1110,15 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn rooted_path_prefix_accepts_mixed_windows_separators() {
-        let root = Path::new("C:/workspace/utils");
-        let source = Path::new(r"..\node_modules\dependency\src\internal");
-        let context = Path::new(r"C:/workspace/node_modules/dependency\");
+        let temp = utils::tempdir("rooted-path-prefix").unwrap();
+        let root = temp.path().join("workspace/utils");
+        let dependency = temp.path().join("workspace/node_modules/dependency");
+        fs::create_dir_all(dependency.join("src/internal")).unwrap();
 
-        assert!(path_starts_with_rooted(source, context, root));
+        let source = Path::new(r"..\node_modules\dependency\src\internal");
+        let context = format!("{}\\", dependency.to_string_lossy().replace('\\', "/"));
+
+        assert!(path_starts_with_rooted(source, Path::new(&context), &root));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Make the Windows context path regression test use a real temporary directory tree.
- Preserve coverage for mixed separators and `..` path resolution.
- Avoid failing because path normalization requires filesystem entries to exist.
- Confirmed the Windows test matrix passes in [CI run #33537220747](https://github.com/foundry-rs/foundry-core/actions/runs/33537220747).