### PR TITLE
feat(ci): open issue for failed CI

### DIFF
--- a/.github/CI_FAILURE_TEMPLATE.md
+++ b/.github/CI_FAILURE_TEMPLATE.md
@@ -1,0 +1,10 @@
+---
+title: "bug: CI workflow failed on main"
+labels: P-normal, T-bug
+---
+
+The CI workflow on `main` branch has failed. This may indicate a regression or an issue with the CI environment.
+
+Check the [CI workflow page]({{ env.WORKFLOW_URL }}) for details.
+
+This issue was raised by the workflow at `.github/workflows/ci.yml`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,3 +277,24 @@ jobs:
         uses: re-actors/alls-green@b5b5b37504aa4183270bd3d855c52a67f212be35 # release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+
+  issue:
+    name: Open an issue
+    runs-on: ubuntu-latest
+    needs: [ci-success]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && failure()
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_URL: |
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: .github/CI_FAILURE_TEMPLATE.md


### PR DESCRIPTION
## Summary

Automatically open or update an issue when CI fails on `main`.

The issue links to the failed workflow run and uses a stable title and labels to avoid duplicate open issues.