### PR TITLE
feat(compilers): support split preprocessor inputs

### DIFF
--- a/crates/compilers/crates/compilers/src/cache.rs
+++ b/crates/compilers/crates/compilers/src/cache.rs
@@ -49,6 +49,9 @@ pub struct CompilerCache<S = Settings> {
     pub builds: BTreeSet<String>,
     pub profiles: BTreeMap<String, S>,
     pub preprocessed: bool,
+    /// Stable identity for artifact-transforming preprocessors.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preprocessor_cache_key: Option<String>,
     pub mocks: HashSet<PathBuf>,
 }
 
@@ -62,6 +65,7 @@ impl<S> CompilerCache<S> {
             builds: Default::default(),
             profiles: Default::default(),
             preprocessed,
+            preprocessor_cache_key: None,
             mocks: Default::default(),
         }
     }
@@ -401,6 +405,7 @@ impl<S> Default for CompilerCache<S> {
             paths: Default::default(),
             profiles: Default::default(),
             preprocessed: false,
+            preprocessor_cache_key: None,
             mocks: Default::default(),
         }
     }
@@ -1085,6 +1090,7 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
         project: &'a Project<C, T>,
         edges: GraphEdges<C::Parser>,
         preprocessed: bool,
+        preprocessor_cache_key: Option<String>,
     ) -> Result<Self> {
         /// Returns the [CompilerCache] to use
         ///
@@ -1093,6 +1099,7 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
             project: &Project<C, T>,
             invalidate_cache: bool,
             preprocessed: bool,
+            preprocessor_cache_key: Option<String>,
         ) -> CompilerCache<C::Settings> {
             // the currently configured paths
             let paths = project.paths.paths_relative();
@@ -1102,6 +1109,7 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
                 && let Ok(cache) = CompilerCache::read_joined(&project.paths)
                 && cache.paths == paths
                 && preprocessed == cache.preprocessed
+                && preprocessor_cache_key == cache.preprocessor_cache_key
             {
                 // unchanged project paths and same preprocess cache option
                 return cache;
@@ -1110,7 +1118,9 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
             trace!(invalidate_cache, "cache invalidated");
 
             // new empty cache
-            CompilerCache::new(Default::default(), paths, preprocessed)
+            let mut cache = CompilerCache::new(Default::default(), paths, preprocessed);
+            cache.preprocessor_cache_key = preprocessor_cache_key;
+            cache
         }
 
         let cache = if project.cached {
@@ -1120,7 +1130,8 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
             let invalidate_cache = !edges.unresolved_imports().is_empty();
 
             // read the cache file if it already exists
-            let mut cache = get_cache(project, invalidate_cache, preprocessed);
+            let mut cache =
+                get_cache(project, invalidate_cache, preprocessed, preprocessor_cache_key);
 
             cache.remove_missing_files();
 

--- a/crates/compilers/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/crates/compilers/src/compile/project.rs
@@ -139,6 +139,27 @@ pub trait Preprocessor<C: Compiler>: Debug {
         paths: &ProjectPathsConfig<C::Language>,
         mocks: &mut HashSet<PathBuf>,
     ) -> Result<()>;
+
+    /// Preprocesses a compiler input and optionally splits it into multiple compiler invocations.
+    fn preprocess_inputs(
+        &self,
+        compiler: &C,
+        mut input: C::Input,
+        paths: &ProjectPathsConfig<C::Language>,
+        mocks: &mut HashSet<PathBuf>,
+    ) -> Result<Vec<C::Input>> {
+        self.preprocess(compiler, &mut input, paths, mocks)?;
+        Ok(vec![input])
+    }
+
+    /// Updates a compiler output before build info and artifacts are generated.
+    fn postprocess(
+        &self,
+        _input: &C::Input,
+        _output: &mut CompilerOutput<C::CompilationError, C::CompilerContract>,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -154,8 +175,8 @@ pub struct ProjectCompiler<
     primary_profiles: HashMap<PathBuf, &'a str>,
     /// how to compile all the sources
     sources: CompilerSources<'a, C::Language, C::Settings>,
-    /// Optional preprocessor
-    preprocessor: Option<Box<dyn Preprocessor<C>>>,
+    /// Compiler input preprocessors.
+    preprocessors: Vec<Box<dyn Preprocessor<C>>>,
 }
 
 impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
@@ -190,11 +211,12 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
             sources,
         };
 
-        Ok(Self { edges, primary_profiles, project, sources, preprocessor: None })
+        Ok(Self { edges, primary_profiles, project, sources, preprocessors: Vec::new() })
     }
 
-    pub fn with_preprocessor(self, preprocessor: impl Preprocessor<C> + 'static) -> Self {
-        Self { preprocessor: Some(Box::new(preprocessor)), ..self }
+    pub fn with_preprocessor(mut self, preprocessor: impl Preprocessor<C> + 'static) -> Self {
+        self.preprocessors.push(Box::new(preprocessor));
+        self
     }
 
     /// Compiles all the sources of the `Project` in the appropriate mode
@@ -233,17 +255,17 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
     #[instrument(skip_all)]
     fn preprocess(self) -> Result<PreprocessedState<'a, T, C>> {
         trace!("preprocessing");
-        let Self { edges, project, mut sources, primary_profiles, preprocessor } = self;
+        let Self { edges, project, mut sources, primary_profiles, preprocessors } = self;
 
         // convert paths on windows to ensure consistency with the `CompilerOutput` `solc` emits,
         // which is unix style `/`
         sources.slash_paths();
 
-        let mut cache = ArtifactsCache::new(project, edges, preprocessor.is_some())?;
+        let mut cache = ArtifactsCache::new(project, edges, !preprocessors.is_empty())?;
         // retain and compile only dirty sources and all their imports
         sources.filter(&mut cache);
 
-        Ok(PreprocessedState { sources, cache, primary_profiles, preprocessor })
+        Ok(PreprocessedState { sources, cache, primary_profiles, preprocessors })
     }
 }
 
@@ -262,8 +284,8 @@ struct PreprocessedState<'a, T: ArtifactOutput<CompilerContract = C::CompilerCon
     /// A mapping from a source file path to the primary profile name selected for it.
     primary_profiles: HashMap<PathBuf, &'a str>,
 
-    /// Optional preprocessor
-    preprocessor: Option<Box<dyn Preprocessor<C>>>,
+    /// Compiler input preprocessors.
+    preprocessors: Vec<Box<dyn Preprocessor<C>>>,
 }
 
 impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
@@ -273,9 +295,9 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
     #[instrument(skip_all)]
     fn compile(self) -> Result<CompiledState<'a, T, C>> {
         trace!("compiling");
-        let PreprocessedState { sources, mut cache, primary_profiles, preprocessor } = self;
+        let PreprocessedState { sources, mut cache, primary_profiles, preprocessors } = self;
 
-        let mut output = sources.compile(&mut cache, preprocessor)?;
+        let mut output = sources.compile(&mut cache, preprocessors)?;
 
         // source paths get stripped before handing them over to solc, so solc never uses absolute
         // paths, instead `--base-path <root dir>` is set. this way any metadata that's derived from
@@ -481,7 +503,7 @@ impl<L: Language, S: CompilerSettings> CompilerSources<'_, L, S> {
     >(
         self,
         cache: &mut ArtifactsCache<'_, T, C>,
-        preprocessor: Option<Box<dyn Preprocessor<C>>>,
+        preprocessors: Vec<Box<dyn Preprocessor<C>>>,
     ) -> Result<AggregatedCompilerOutput<C>> {
         let project = cache.project();
         let graph = cache.graph();
@@ -565,16 +587,22 @@ impl<L: Language, S: CompilerSettings> CompilerSources<'_, L, S> {
 
                 input.strip_prefix(project.paths.root.as_path());
 
-                if let Some(preprocessor) = preprocessor.as_ref() {
-                    preprocessor.preprocess(
-                        &project.compiler,
-                        &mut input,
-                        &project.paths,
-                        &mut mocks,
-                    )?;
+                let mut inputs = vec![input];
+                for preprocessor in &preprocessors {
+                    let mut next = Vec::new();
+                    for input in inputs {
+                        next.extend(preprocessor.preprocess_inputs(
+                            &project.compiler,
+                            input,
+                            &project.paths,
+                            &mut mocks,
+                        )?);
+                    }
+                    inputs = next;
                 }
-
-                jobs.push((input, profile, actually_dirty));
+                jobs.extend(
+                    inputs.into_iter().map(|input| (input, profile, actually_dirty.clone())),
+                );
             }
         }
 
@@ -591,6 +619,10 @@ impl<L: Language, S: CompilerSettings> CompilerSources<'_, L, S> {
 
         for (input, mut output, profile, actually_dirty) in results {
             let version = input.version();
+
+            for preprocessor in &preprocessors {
+                preprocessor.postprocess(&input, &mut output)?;
+            }
 
             // Mark all files as seen by the compiler
             for file in &actually_dirty {

--- a/crates/compilers/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/crates/compilers/src/compile/project.rs
@@ -287,9 +287,10 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
         // which is unix style `/`
         sources.slash_paths();
 
-        let preprocessed = preprocessors
-            .iter()
-            .any(|preprocessor| preprocessor.supports_interface_only_invalidation());
+        let preprocessed = !preprocessors.is_empty()
+            && preprocessors
+                .iter()
+                .all(|preprocessor| preprocessor.supports_interface_only_invalidation());
         let cache_key = preprocessors
             .iter()
             .filter_map(|preprocessor| preprocessor.cache_key())

--- a/crates/compilers/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/crates/compilers/src/compile/project.rs
@@ -134,11 +134,27 @@ pub(crate) type VersionedSources<'a, L, S> = HashMap<L, Vec<(Version, Sources, (
 pub trait Preprocessor<C: Compiler>: Debug {
     fn preprocess(
         &self,
-        compiler: &C,
-        input: &mut C::Input,
-        paths: &ProjectPathsConfig<C::Language>,
-        mocks: &mut HashSet<PathBuf>,
-    ) -> Result<()>;
+        _compiler: &C,
+        _input: &mut C::Input,
+        _paths: &ProjectPathsConfig<C::Language>,
+        _mocks: &mut HashSet<PathBuf>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Whether this preprocessor supports interface-only cache invalidation.
+    ///
+    /// This preserves the historical behavior for preprocessors that only override
+    /// [`Self::preprocess`]. Preprocessors that split inputs or otherwise transform complete
+    /// compilation units should opt out.
+    fn supports_interface_only_invalidation(&self) -> bool {
+        true
+    }
+
+    /// Stable identity for transformations whose artifacts must not be reused without them.
+    fn cache_key(&self) -> Option<&'static str> {
+        None
+    }
 
     /// Preprocesses a compiler input and optionally splits it into multiple compiler invocations.
     fn preprocess_inputs(
@@ -215,6 +231,16 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
     }
 
     pub fn with_preprocessor(mut self, preprocessor: impl Preprocessor<C> + 'static) -> Self {
+        self.preprocessors.clear();
+        self.preprocessors.push(Box::new(preprocessor));
+        self
+    }
+
+    /// Adds a preprocessor without replacing an already configured preprocessor.
+    pub fn with_additional_preprocessor(
+        mut self,
+        preprocessor: impl Preprocessor<C> + 'static,
+    ) -> Self {
         self.preprocessors.push(Box::new(preprocessor));
         self
     }
@@ -261,7 +287,16 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
         // which is unix style `/`
         sources.slash_paths();
 
-        let mut cache = ArtifactsCache::new(project, edges, !preprocessors.is_empty())?;
+        let preprocessed = preprocessors
+            .iter()
+            .any(|preprocessor| preprocessor.supports_interface_only_invalidation());
+        let cache_key = preprocessors
+            .iter()
+            .filter_map(|preprocessor| preprocessor.cache_key())
+            .collect::<Vec<_>>()
+            .join("\0");
+        let cache_key = (!cache_key.is_empty()).then_some(cache_key);
+        let mut cache = ArtifactsCache::new(project, edges, preprocessed, cache_key)?;
         // retain and compile only dirty sources and all their imports
         sources.filter(&mut cache);
 
@@ -583,7 +618,7 @@ impl<L: Language, S: CompilerSettings> CompilerSources<'_, L, S> {
                     })
                     .collect();
 
-                let mut input = C::Input::build(sources, settings, language, version.clone());
+                let mut input = C::Input::build(sources, settings, language, version);
 
                 input.strip_prefix(project.paths.root.as_path());
 

--- a/crates/compilers/crates/compilers/src/flatten.rs
+++ b/crates/compilers/crates/compilers/src/flatten.rs
@@ -330,7 +330,7 @@ impl Flattener {
             let mut definition_name = name.clone();
             let needs_rename = ids.len() > 1;
 
-            let mut ids = ids.clone().into_iter().collect::<Vec<_>>();
+            let mut ids = ids.into_iter().collect::<Vec<_>>();
             if needs_rename {
                 // `loc.path` is expected to be different for each id because there can't be 2
                 // top-level declarations with the same name in the same file.

--- a/crates/compilers/crates/compilers/src/resolver/parse.rs
+++ b/crates/compilers/crates/compilers/src/resolver/parse.rs
@@ -195,7 +195,7 @@ impl SolDataBuilder {
         match ast {
             Ok((sess, ast)) => builder.parse_from_ast(sess, ast),
             Err(err) => {
-                builder.parse_from_regex(content);
+                builder.parse_from_regex(content, file);
                 if let Some(err) = err {
                     builder.parse_err = Some(err);
                 }
@@ -261,7 +261,7 @@ impl SolDataBuilder {
         }
     }
 
-    fn parse_from_regex(&mut self, content: &str) {
+    fn parse_from_regex(&mut self, content: &str, file: &Path) {
         if self.version.is_none() {
             self.version = utils::capture_outer_and_inner(
                 content,
@@ -272,7 +272,16 @@ impl SolDataBuilder {
             .map(|(cap, name)| Spanned::new(name.as_str().to_owned(), cap.range()));
         }
         if self.imports.is_empty() {
-            self.imports = capture_imports(content);
+            self.imports = if file.extension().is_some_and(|extension| extension == "yul") {
+                utils::find_yul_imports(content)
+                    .into_iter()
+                    .map(|import| {
+                        Spanned::new(SolImport::new(PathBuf::from(import.path)), import.statement)
+                    })
+                    .collect()
+            } else {
+                capture_imports(content)
+            };
         }
         if self.contract_names.is_empty() {
             utils::RE_CONTRACT_NAMES.captures_iter(content).for_each(|cap| {

--- a/crates/compilers/crates/compilers/tests/project.rs
+++ b/crates/compilers/crates/compilers/tests/project.rs
@@ -34,9 +34,7 @@ use semver::Version;
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    env,
-    fs::{self},
-    io,
+    env, fs, io,
     path::{MAIN_SEPARATOR, Path, PathBuf},
     str::FromStr,
     sync::LazyLock,

--- a/crates/compilers/crates/core/src/utils/mod.rs
+++ b/crates/compilers/crates/core/src/utils/mod.rs
@@ -25,6 +25,111 @@ pub use wd::*;
 /// Extensions acceptable by solc compiler.
 pub const SOLC_EXTENSIONS: &[&str] = &["sol", "yul"];
 
+/// A top-level import in a Yul module.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct YulImport<'a> {
+    /// Range of the complete import declaration.
+    pub statement: Range<usize>,
+    /// Imported path without quotes.
+    pub path: &'a str,
+}
+
+/// Finds top-level `import "path"` declarations in a Yul module.
+///
+/// Both semicolon-free and semicolon-terminated declarations are accepted. Comments and strings
+/// are skipped so their contents cannot create dependency edges.
+pub fn find_yul_imports(source: &str) -> Vec<YulImport<'_>> {
+    let bytes = source.as_bytes();
+    let mut imports = Vec::new();
+    let mut index = 0;
+    let mut depth = 0usize;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                index += 2;
+                while bytes.get(index).is_some_and(|byte| *byte != b'\n') {
+                    index += 1;
+                }
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                index += 2;
+                while index + 1 < bytes.len() && !(bytes[index] == b'*' && bytes[index + 1] == b'/')
+                {
+                    index += 1;
+                }
+                index = (index + 2).min(bytes.len());
+            }
+            b'"' | b'\'' => index = skip_quoted(bytes, index),
+            b'{' => {
+                depth += 1;
+                index += 1;
+            }
+            b'}' => {
+                depth = depth.saturating_sub(1);
+                index += 1;
+            }
+            byte if depth == 0 && is_ident_start(byte) => {
+                let start = index;
+                index += 1;
+                while bytes.get(index).is_some_and(|byte| is_ident_continue(*byte)) {
+                    index += 1;
+                }
+                if &source[start..index] != "import" {
+                    continue;
+                }
+
+                let mut cursor = index;
+                while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+                    cursor += 1;
+                }
+                let Some(&quote @ (b'"' | b'\'')) = bytes.get(cursor) else { continue };
+                let path_start = cursor + 1;
+                cursor = skip_quoted(bytes, cursor);
+                if cursor == bytes.len() || bytes[cursor - 1] != quote {
+                    continue;
+                }
+                let path_end = cursor - 1;
+                while bytes.get(cursor).is_some_and(|byte| matches!(byte, b' ' | b'\t' | b'\r')) {
+                    cursor += 1;
+                }
+                if bytes.get(cursor) == Some(&b';') {
+                    cursor += 1;
+                }
+                imports.push(YulImport {
+                    statement: start..cursor,
+                    path: &source[path_start..path_end],
+                });
+                index = cursor;
+            }
+            _ => index += 1,
+        }
+    }
+
+    imports
+}
+
+const fn is_ident_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+const fn is_ident_continue(byte: u8) -> bool {
+    is_ident_start(byte) || byte.is_ascii_digit()
+}
+
+fn skip_quoted(bytes: &[u8], start: usize) -> usize {
+    let quote = bytes[start];
+    let mut index = start + 1;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\\' => index = (index + 2).min(bytes.len()),
+            byte if byte == quote => return index + 1,
+            _ => index += 1,
+        }
+    }
+    index
+}
+
 /// Support for configuring the EVM version
 /// <https://blog.soliditylang.org/2018/03/08/solidity-0.4.21-release-announcement/>
 pub const BYZANTIUM_SOLC: Version = Version::new(0, 4, 21);
@@ -513,6 +618,29 @@ pub fn mkdir_or_touch(tmp: &std::path::Path, paths: &[&str]) {
 mod tests {
     pub use super::*;
     pub use std::fs::{File, create_dir_all};
+
+    #[test]
+    fn finds_yul_imports() {
+        let source = r#"
+// import "ignored-line.yul"
+/*
+import "ignored-block.yul"
+*/
+import "src/One.yul"
+import 'src/Two.yul';
+function helper() {
+    let value := "import \"ignored-string.yul\""
+}
+"#;
+
+        let imports = find_yul_imports(source);
+        assert_eq!(
+            imports.iter().map(|import| import.path).collect::<Vec<_>>(),
+            ["src/One.yul", "src/Two.yul"]
+        );
+        assert_eq!(&source[imports[0].statement.clone()], "import \"src/One.yul\"");
+        assert_eq!(&source[imports[1].statement.clone()], "import 'src/Two.yul';");
+    }
 
     #[test]
     fn can_create_parent_dirs_with_ext() {

--- a/crates/compilers/crates/core/src/utils/mod.rs
+++ b/crates/compilers/crates/core/src/utils/mod.rs
@@ -60,7 +60,7 @@ pub fn find_yul_imports(source: &str) -> Vec<YulImport<'_>> {
                 }
                 index = (index + 2).min(bytes.len());
             }
-            b'"' | b'\'' => index = skip_quoted(bytes, index),
+            b'"' | b'\'' => index = skip_quoted(bytes, index).unwrap_or(bytes.len()),
             b'{' => {
                 depth += 1;
                 index += 1;
@@ -83,12 +83,10 @@ pub fn find_yul_imports(source: &str) -> Vec<YulImport<'_>> {
                 while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
                     cursor += 1;
                 }
-                let Some(&quote @ (b'"' | b'\'')) = bytes.get(cursor) else { continue };
+                let Some(b'"' | b'\'') = bytes.get(cursor) else { continue };
                 let path_start = cursor + 1;
-                cursor = skip_quoted(bytes, cursor);
-                if cursor == bytes.len() || bytes[cursor - 1] != quote {
-                    continue;
-                }
+                let Some(end) = skip_quoted(bytes, cursor) else { continue };
+                cursor = end;
                 let path_end = cursor - 1;
                 while bytes.get(cursor).is_some_and(|byte| matches!(byte, b' ' | b'\t' | b'\r')) {
                     cursor += 1;
@@ -117,17 +115,17 @@ const fn is_ident_continue(byte: u8) -> bool {
     is_ident_start(byte) || byte.is_ascii_digit()
 }
 
-fn skip_quoted(bytes: &[u8], start: usize) -> usize {
+fn skip_quoted(bytes: &[u8], start: usize) -> Option<usize> {
     let quote = bytes[start];
     let mut index = start + 1;
     while index < bytes.len() {
         match bytes[index] {
             b'\\' => index = (index + 2).min(bytes.len()),
-            byte if byte == quote => return index + 1,
+            byte if byte == quote => return Some(index + 1),
             _ => index += 1,
         }
     }
-    index
+    None
 }
 
 /// Support for configuring the EVM version
@@ -640,6 +638,15 @@ function helper() {
         );
         assert_eq!(&source[imports[0].statement.clone()], "import \"src/One.yul\"");
         assert_eq!(&source[imports[1].statement.clone()], "import 'src/Two.yul';");
+    }
+
+    #[test]
+    fn finds_yul_import_at_end_of_file() {
+        let source = "import \"src/One.yul\"";
+        let imports = find_yul_imports(source);
+        assert_eq!(imports, [YulImport { statement: 0..source.len(), path: "src/One.yul" }]);
+
+        assert!(find_yul_imports("import \"unterminated.yul").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- allow compiler preprocessors to split one input into multiple compiler jobs
- allow multiple preprocessors to compose and postprocess outputs before artifacts are persisted
- discover top-level imports in bare Yul modules for dependency tracking

This is the compiler-framework prerequisite for foundry-rs/foundry#11059.

## Testing

- cargo test -p foundry-compilers-core finds_yul_imports
- cargo test -p foundry-compilers --lib compile::project
- cargo clippy -p foundry-compilers-core -p foundry-compilers --lib -- -D warnings
- cargo +nightly fmt --all -- --check