### PR TITLE
fix(compilers): remove redundant clones

### DIFF
--- a/crates/compilers/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/crates/compilers/src/compile/project.rs
@@ -561,7 +561,7 @@ impl<L: Language, S: CompilerSettings> CompilerSources<'_, L, S> {
                     })
                     .collect();
 
-                let mut input = C::Input::build(sources, settings, language, version.clone());
+                let mut input = C::Input::build(sources, settings, language, version);
 
                 input.strip_prefix(project.paths.root.as_path());
 

--- a/crates/compilers/crates/compilers/src/flatten.rs
+++ b/crates/compilers/crates/compilers/src/flatten.rs
@@ -330,7 +330,7 @@ impl Flattener {
             let mut definition_name = name.clone();
             let needs_rename = ids.len() > 1;
 
-            let mut ids = ids.clone().into_iter().collect::<Vec<_>>();
+            let mut ids = ids.into_iter().collect::<Vec<_>>();
             if needs_rename {
                 // `loc.path` is expected to be different for each id because there can't be 2
                 // top-level declarations with the same name in the same file.

--- a/crates/compilers/crates/compilers/tests/project.rs
+++ b/crates/compilers/crates/compilers/tests/project.rs
@@ -34,9 +34,7 @@ use semver::Version;
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    env,
-    fs::{self},
-    io,
+    env, fs, io,
     path::{MAIN_SEPARATOR, Path, PathBuf},
     str::FromStr,
     sync::LazyLock,


### PR DESCRIPTION
Removes two redundant clones in compiler input construction and flattening that cause nightly Clippy to fail on existing code, including the [CI run for #170](https://github.com/foundry-rs/foundry-core/actions/runs/33969194718/job/101314578529?pr=170). Both values can be moved because they are not used afterward.

Also simplifies the compiler project tests' `fs::{self}` import to `fs` to fix the remaining nightly Clippy failure.

AI disclosure: Centaur (Codex) authored the import cleanup and this description update.
