### PR TITLE
fix(compilers): retry busy solc spawns

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,3 +4,8 @@
 retries = { backoff = "exponential", count = 2, delay = "5s", jitter = true }
 slow-timeout = { period = "30s", terminate-after = 3 }
 default-filter = "not test(/external_/)"
+
+# Retry regressions must pass on their first attempt, not be hidden by test-runner retries.
+[[profile.default.overrides]]
+filter = "test(compilers::solc::compiler::spawn_tests::) | test(compilers::solc::command::tests::)"
+retries = 0

--- a/crates/compilers/crates/compilers/Cargo.toml
+++ b/crates/compilers/crates/compilers/Cargo.toml
@@ -72,6 +72,7 @@ async = [
     "tokio/fs",
     "tokio/process",
     "tokio/io-util",
+    "tokio/time",
     "foundry-compilers-artifacts/async",
 ]
 # Enables `svm` to auto-detect and manage `solc` builds.

--- a/crates/compilers/crates/compilers/Cargo.toml
+++ b/crates/compilers/crates/compilers/Cargo.toml
@@ -32,6 +32,7 @@ path-slash.workspace = true
 yansi.workspace = true
 solar.workspace = true
 futures-util = { workspace = true, optional = true }
+futures-timer = { version = "3.0.4", optional = true }
 tokio = { workspace = true, optional = true }
 
 auto_impl = "1.3.0"
@@ -53,7 +54,7 @@ sha2 = { version = "0.11.0", default-features = false, optional = true }
 [dev-dependencies]
 tracing-subscriber.workspace = true
 fd-lock = "4.0.4"
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 reqwest.workspace = true
 tempfile.workspace = true
 snapbox.workspace = true
@@ -68,11 +69,11 @@ full = ["async", "svm-solc"]
 # Adds extra `async` methods using `tokio` to some types.
 async = [
     "dep:futures-util",
+    "dep:futures-timer",
     "dep:tokio",
     "tokio/fs",
     "tokio/process",
     "tokio/io-util",
-    "tokio/time",
     "foundry-compilers-artifacts/async",
 ]
 # Enables `svm` to auto-detect and manage `solc` builds.

--- a/crates/compilers/crates/compilers/src/compilers/solc/command.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/command.rs
@@ -31,7 +31,9 @@ pub(super) async fn async_retry_spawn<T>(
     for delay in RETRY_DELAYS {
         match spawn() {
             Err(err) if err.kind() == io::ErrorKind::ExecutableFileBusy => {
-                tokio::time::sleep(delay).await;
+                // Do not require a Tokio timer driver or a free blocking-pool thread:
+                // callers may be driving this future from a blocking task themselves.
+                futures_timer::Delay::new(delay).await;
             }
             result => return result,
         }

--- a/crates/compilers/crates/compilers/src/compilers/solc/command.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/command.rs
@@ -1,0 +1,101 @@
+//! Retry transient executable-file-busy errors before a compiler process has started.
+
+use std::{io, time::Duration};
+
+// A renamed compiler can still have a writable descriptor inherited by a concurrent fork.
+// Use five retries with 310 ms of total backoff so a persistently busy executable still errors.
+const RETRY_DELAYS: [Duration; 5] = [
+    Duration::from_millis(10),
+    Duration::from_millis(20),
+    Duration::from_millis(40),
+    Duration::from_millis(80),
+    Duration::from_millis(160),
+];
+
+pub(super) fn retry_spawn<T>(mut spawn: impl FnMut() -> io::Result<T>) -> io::Result<T> {
+    for delay in RETRY_DELAYS {
+        match spawn() {
+            Err(err) if err.kind() == io::ErrorKind::ExecutableFileBusy => {
+                std::thread::sleep(delay);
+            }
+            result => return result,
+        }
+    }
+    spawn()
+}
+
+#[cfg(feature = "async")]
+pub(super) async fn async_retry_spawn<T>(
+    mut spawn: impl FnMut() -> io::Result<T>,
+) -> io::Result<T> {
+    for delay in RETRY_DELAYS {
+        match spawn() {
+            Err(err) if err.kind() == io::ErrorKind::ExecutableFileBusy => {
+                tokio::time::sleep(delay).await;
+            }
+            result => return result,
+        }
+    }
+    spawn()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn does_not_retry_other_errors() {
+        for kind in
+            [io::ErrorKind::PermissionDenied, io::ErrorKind::NotFound, io::ErrorKind::Interrupted]
+        {
+            let mut attempts = 0;
+            let result: io::Result<()> = retry_spawn(|| {
+                attempts += 1;
+                Err(io::Error::from(kind))
+            });
+            assert_eq!(result.unwrap_err().kind(), kind);
+            assert_eq!(attempts, 1);
+        }
+    }
+
+    #[test]
+    fn persistent_busy_is_bounded() {
+        let mut attempts = 0;
+        let result: io::Result<()> = retry_spawn(|| {
+            attempts += 1;
+            Err(io::Error::from(io::ErrorKind::ExecutableFileBusy))
+        });
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::ExecutableFileBusy);
+        assert_eq!(attempts, RETRY_DELAYS.len() + 1);
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_does_not_retry_other_errors() {
+        for kind in
+            [io::ErrorKind::PermissionDenied, io::ErrorKind::NotFound, io::ErrorKind::Interrupted]
+        {
+            let mut attempts = 0;
+            let result: io::Result<()> = async_retry_spawn(|| {
+                attempts += 1;
+                Err(io::Error::from(kind))
+            })
+            .await;
+            assert_eq!(result.unwrap_err().kind(), kind);
+            assert_eq!(attempts, 1);
+        }
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_persistent_busy_is_bounded() {
+        let mut attempts = 0;
+        let result: io::Result<()> = async_retry_spawn(|| {
+            attempts += 1;
+            Err(io::Error::from(io::ErrorKind::ExecutableFileBusy))
+        })
+        .await;
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::ExecutableFileBusy);
+        assert_eq!(attempts, RETRY_DELAYS.len() + 1);
+    }
+}

--- a/crates/compilers/crates/compilers/src/compilers/solc/compiler.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/compiler.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "async")]
+use super::command::async_retry_spawn;
+use super::command::retry_spawn;
 use crate::resolver::parse::SolData;
 use foundry_compilers_artifacts::{CompilerOutput, SolcInput, sources::Source};
 use foundry_compilers_core::{
@@ -17,6 +20,10 @@ use std::{
 
 /// Extensions acceptable by solc compiler.
 pub const SOLC_EXTENSIONS: &[&str] = &["sol", "yul"];
+
+#[cfg(all(test, target_os = "linux"))]
+#[path = "spawn_tests.rs"]
+mod spawn_tests;
 
 /// take the lock in tests, we use this to enforce that
 /// a test does not run while a compiler version is being installed
@@ -441,7 +448,7 @@ impl Solc {
         trace!(input=%serde_json::to_string(input).unwrap_or_else(|e| e.to_string()));
         debug!(?cmd, "compiling");
 
-        let mut child = cmd.spawn().map_err(self.map_io_err())?;
+        let mut child = retry_spawn(|| cmd.spawn()).map_err(self.map_io_err())?;
         debug!("spawned");
 
         {
@@ -483,7 +490,8 @@ impl Solc {
             .stderr(Stdio::piped())
             .stdout(Stdio::piped());
         debug!(?cmd, "getting Solc version");
-        let output = cmd.output().map_err(|e| SolcError::io(e, solc))?;
+        let child = retry_spawn(|| cmd.spawn()).map_err(|e| SolcError::io(e, solc))?;
+        let output = child.wait_with_output().map_err(|e| SolcError::io(e, solc))?;
         trace!(?output);
         let version = version_from_output(output)?;
         debug!(%version);
@@ -649,7 +657,7 @@ impl Solc {
         use tokio::{io::AsyncWriteExt, process::Command};
 
         let mut cmd: Command = self.configure_cmd().into();
-        let mut child = cmd.spawn().map_err(self.map_io_err())?;
+        let mut child = async_retry_spawn(|| cmd.spawn()).await.map_err(self.map_io_err())?;
         let stdin = child.stdin.as_mut().unwrap();
 
         let content = serde_json::to_vec(input)?;
@@ -667,7 +675,8 @@ impl Solc {
         }
         cmd.arg("--version").stdin(Stdio::piped()).stderr(Stdio::piped()).stdout(Stdio::piped());
         debug!(?cmd, "getting version");
-        let output = cmd.output().await.map_err(|e| SolcError::io(e, solc))?;
+        let child = async_retry_spawn(|| cmd.spawn()).await.map_err(|e| SolcError::io(e, solc))?;
+        let output = child.wait_with_output().await.map_err(|e| SolcError::io(e, solc))?;
         let version = version_from_output(output)?;
         debug!(%version);
         Ok(version)

--- a/crates/compilers/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/mod.rs
@@ -29,6 +29,7 @@ use std::{
 
 pub use foundry_compilers_artifacts::SolcLanguage;
 
+mod command;
 mod compiler;
 pub use compiler::{SOLC_EXTENSIONS, Solc};
 

--- a/crates/compilers/crates/compilers/src/compilers/solc/spawn_tests.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/spawn_tests.rs
@@ -82,6 +82,73 @@ async fn async_compile_recovers_from_busy_executable() {
     assert_eq!(result.unwrap(), serde_json::to_vec(&input).unwrap());
 }
 
+#[cfg(feature = "async")]
+#[test]
+fn async_version_recovers_without_timer_driver() {
+    let BusySolc { _dir, solc, writer } = BusySolc::new();
+    let runtime = tokio::runtime::Builder::new_current_thread().enable_io().build().unwrap();
+    runtime.block_on(async {
+        // On a single-threaded runtime this task can release the writer only if the
+        // compiler yields while retrying. No timer driver is enabled or required.
+        let release = tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            drop(writer);
+        });
+        let result = Solc::async_version(&solc.solc).await;
+        release.await.unwrap();
+        assert_eq!(result.unwrap(), "0.8.18+commit.87f61d96.Linux.gcc".parse().unwrap());
+    });
+}
+
+#[cfg(feature = "async")]
+#[test]
+fn async_compile_recovers_without_timer_driver() {
+    let BusySolc { _dir, solc, writer } = BusySolc::new();
+    let runtime = tokio::runtime::Builder::new_current_thread().enable_io().build().unwrap();
+    runtime.block_on(async {
+        let release = tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            drop(writer);
+        });
+        let input = serde_json::json!({"large_input": "x".repeat(256 * 1024)});
+        let result = solc.async_compile_output(&input).await;
+        release.await.unwrap();
+        assert_eq!(result.unwrap(), serde_json::to_vec(&input).unwrap());
+    });
+}
+
+#[cfg(feature = "async")]
+#[test]
+fn async_version_recovers_with_saturated_blocking_pool() {
+    let BusySolc { _dir, solc, writer } = BusySolc::new();
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .max_blocking_threads(1)
+        .enable_io()
+        .build()
+        .unwrap();
+    let handle = runtime.handle().clone();
+    let (completed, result) = std::sync::mpsc::channel();
+    runtime.spawn_blocking(move || {
+        let result = handle.block_on(async {
+            let version = Solc::async_version(&solc.solc);
+            tokio::pin!(version);
+            // Keep the file busy until the first spawn has entered its backoff.
+            assert!(futures_util::poll!(&mut version).is_pending());
+            drop(writer);
+            version.await
+        });
+        let _ = completed.send(result);
+    });
+    let result = result.recv_timeout(Duration::from_secs(3));
+    // A regression must fail instead of hanging while dropping the runtime.
+    runtime.shutdown_timeout(Duration::from_millis(100));
+    assert_eq!(
+        result.expect("compiler retry deadlocked on the blocking pool").unwrap(),
+        "0.8.18+commit.87f61d96.Linux.gcc".parse().unwrap()
+    );
+}
+
 #[test]
 fn compiler_failure_is_not_retried() {
     let BusySolc { _dir, solc, writer } = BusySolc::with_contents(

--- a/crates/compilers/crates/compilers/src/compilers/solc/spawn_tests.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/spawn_tests.rs
@@ -173,13 +173,39 @@ async fn async_compiler_failure_is_not_retried() {
 }
 
 #[test]
+fn persistent_busy_executable_returns_io_error() {
+    let BusySolc { _dir, solc, writer: _writer } = BusySolc::new();
+    for result in [
+        Solc::version(&solc.solc).map(|_| ()),
+        solc.compile_output(&serde_json::json!({})).map(|_| ()),
+    ] {
+        let SolcError::Io(error) = result.unwrap_err() else {
+            panic!("expected a compiler spawn I/O error");
+        };
+        assert_eq!(error.source().kind(), io::ErrorKind::ExecutableFileBusy);
+        assert_eq!(error.path(), solc.solc);
+    }
+}
+
+#[test]
 fn concurrent_publish_and_spawn() {
+    fn assert_output_or_busy<T: std::fmt::Debug + PartialEq>(result: Result<T>, expected: &T) {
+        match result {
+            Ok(output) => assert_eq!(&output, expected),
+            Err(SolcError::Io(error)) => {
+                assert_eq!(error.source().kind(), io::ErrorKind::ExecutableFileBusy);
+            }
+            Err(error) => panic!("unexpected compiler error: {error}"),
+        }
+    }
+
     let BusySolc { _dir, solc, writer } = BusySolc::new();
     drop(writer);
     let bytes = fs::read(&solc.solc).unwrap();
     let barrier = Barrier::new(5);
     let input = serde_json::json!({"input": 42});
     let expected = serde_json::to_vec(&input).unwrap();
+    let version = "0.8.18+commit.87f61d96.Linux.gcc".parse().unwrap();
     thread::scope(|scope| {
         scope.spawn(|| {
             barrier.wait();
@@ -201,15 +227,19 @@ fn concurrent_publish_and_spawn() {
             scope.spawn(|| {
                 barrier.wait();
                 for _ in 0..250 {
-                    assert_eq!(
-                        Solc::version_impl(&solc.solc, &[]).unwrap(),
-                        "0.8.18+commit.87f61d96.Linux.gcc".parse().unwrap()
-                    );
-                    assert_eq!(solc.compile_output(&input).unwrap(), expected);
+                    // Continuous replacement can outlast all bounded retries. Only an
+                    // executable-file-busy error is valid during this adversarial phase;
+                    // successful launches must still produce the exact expected output.
+                    assert_output_or_busy(Solc::version_impl(&solc.solc, &[]), &version);
+                    assert_output_or_busy(solc.compile_output(&input), &expected);
                 }
             });
         }
     });
+    // Join readers as well as the publisher: a reader's concurrent fork can inherit a
+    // writable descriptor. Once all threads/children finish, no busy error is acceptable.
+    assert_eq!(Solc::version_impl(&solc.solc, &[]).unwrap(), version);
+    assert_eq!(solc.compile_output(&input).unwrap(), expected);
 }
 
 #[cfg(feature = "async")]

--- a/crates/compilers/crates/compilers/src/compilers/solc/spawn_tests.rs
+++ b/crates/compilers/crates/compilers/src/compilers/solc/spawn_tests.rs
@@ -1,0 +1,185 @@
+use super::*;
+use std::{fs, os::unix::fs::PermissionsExt, sync::Barrier, thread, time::Duration};
+
+struct BusySolc {
+    _dir: tempfile::TempDir,
+    solc: Solc,
+    writer: fs::File,
+}
+
+impl BusySolc {
+    fn new() -> Self {
+        Self::with_contents(b"#!/bin/sh\ncase \"$*\" in\n*--version*) echo 'Version: 0.8.18+commit.87f61d96.Linux.g++';;\n*) input=$(cat); printf '%s' \"$input\";;\nesac\n")
+    }
+
+    fn with_contents(contents: &[u8]) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("solc");
+        let (mut file, temp_path) =
+            tempfile::NamedTempFile::new_in(dir.path()).unwrap().into_parts();
+        file.write_all(contents).unwrap();
+        file.set_permissions(fs::Permissions::from_mode(0o755)).unwrap();
+        // Model a descriptor inherited by a fork: closing the publisher's copy before the
+        // rename is insufficient while another process still holds a writable copy.
+        let writer = file.try_clone().unwrap();
+        drop(file);
+        temp_path.persist(&path).unwrap();
+        let error = Command::new(&path).spawn().unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::ExecutableFileBusy);
+        Self { _dir: dir, solc: Solc::new_with_version(path, Version::new(0, 8, 18)), writer }
+    }
+}
+
+#[test]
+fn version_recovers_from_busy_executable() {
+    let BusySolc { _dir, solc, writer } = BusySolc::new();
+    let release = thread::spawn(|| {
+        thread::sleep(Duration::from_millis(50));
+        drop(writer);
+    });
+    let result = Solc::version_with_args(&solc.solc, &["--extra-argument".into()]);
+    release.join().unwrap();
+    assert_eq!(result.unwrap(), "0.8.18+commit.87f61d96.Linux.gcc".parse().unwrap());
+}
+
+#[test]
+fn compile_recovers_from_busy_executable() {
+    let BusySolc { _dir, solc, writer } = BusySolc::new();
+    let release = thread::spawn(|| {
+        thread::sleep(Duration::from_millis(50));
+        drop(writer);
+    });
+    let input = serde_json::json!({"large_input": "x".repeat(256 * 1024)});
+    let result = solc.compile_output(&input);
+    release.join().unwrap();
+    assert_eq!(result.unwrap(), serde_json::to_vec(&input).unwrap());
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn async_version_recovers_from_busy_executable() {
+    let BusySolc { _dir, solc, writer } = BusySolc::new();
+    let release = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        drop(writer);
+    });
+    let result = Solc::async_version(&solc.solc).await;
+    release.await.unwrap();
+    assert_eq!(result.unwrap(), "0.8.18+commit.87f61d96.Linux.gcc".parse().unwrap());
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn async_compile_recovers_from_busy_executable() {
+    let BusySolc { _dir, solc, writer } = BusySolc::new();
+    let release = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        drop(writer);
+    });
+    let input = serde_json::json!({"large_input": "x".repeat(256 * 1024)});
+    let result = solc.async_compile_output(&input).await;
+    release.await.unwrap();
+    assert_eq!(result.unwrap(), serde_json::to_vec(&input).unwrap());
+}
+
+#[test]
+fn compiler_failure_is_not_retried() {
+    let BusySolc { _dir, solc, writer } = BusySolc::with_contents(
+        b"#!/bin/sh\ncat >/dev/null\nprintf x >> \"$0.runs\"\necho 'compiler failed' >&2\nexit 1\n",
+    );
+    drop(writer);
+    let result = solc.compile_output(&serde_json::json!({}));
+    assert!(matches!(result, Err(SolcError::SolcError(..))));
+    assert_eq!(fs::read(solc.solc.with_extension("runs")).unwrap(), b"x");
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn async_compiler_failure_is_not_retried() {
+    let BusySolc { _dir, solc, writer } = BusySolc::with_contents(
+        b"#!/bin/sh\ncat >/dev/null\nprintf x >> \"$0.runs\"\necho 'compiler failed' >&2\nexit 1\n",
+    );
+    drop(writer);
+    let result = solc.async_compile_output(&serde_json::json!({})).await;
+    assert!(matches!(result, Err(SolcError::SolcError(..))));
+    assert_eq!(fs::read(solc.solc.with_extension("runs")).unwrap(), b"x");
+}
+
+#[test]
+fn concurrent_publish_and_spawn() {
+    let BusySolc { _dir, solc, writer } = BusySolc::new();
+    drop(writer);
+    let bytes = fs::read(&solc.solc).unwrap();
+    let barrier = Barrier::new(5);
+    let input = serde_json::json!({"input": 42});
+    let expected = serde_json::to_vec(&input).unwrap();
+    thread::scope(|scope| {
+        scope.spawn(|| {
+            barrier.wait();
+            for _ in 0..1000 {
+                let (mut file, path) =
+                    tempfile::NamedTempFile::new_in(_dir.path()).unwrap().into_parts();
+                file.write_all(&bytes).unwrap();
+                file.set_permissions(fs::Permissions::from_mode(0o755)).unwrap();
+                path.persist(&solc.solc).unwrap();
+                // Positive control: the unguarded spawn must fail in the publication window.
+                assert_eq!(
+                    Command::new(&solc.solc).spawn().unwrap_err().kind(),
+                    io::ErrorKind::ExecutableFileBusy
+                );
+                drop(file);
+            }
+        });
+        for _ in 0..4 {
+            scope.spawn(|| {
+                barrier.wait();
+                for _ in 0..250 {
+                    assert_eq!(
+                        Solc::version_impl(&solc.solc, &[]).unwrap(),
+                        "0.8.18+commit.87f61d96.Linux.gcc".parse().unwrap()
+                    );
+                    assert_eq!(solc.compile_output(&input).unwrap(), expected);
+                }
+            });
+        }
+    });
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+#[ignore = "requires SVM_STRESS_SOLC pointing to solc 0.8.18"]
+async fn real_solc_recovers_from_busy_executable() {
+    let bytes =
+        fs::read(std::env::var_os("SVM_STRESS_SOLC").expect("set SVM_STRESS_SOLC")).unwrap();
+    let input = serde_json::json!({
+        "language": "Solidity",
+        "sources": {"Test.sol": {"content": "pragma solidity =0.8.18; contract Test { function value() external pure returns (uint256) { return 42; } }"}},
+        "settings": {"outputSelection": {"*": {"*": ["abi"]}}}
+    });
+    for asynchronous in [false, true] {
+        for version_only in [false, true] {
+            let BusySolc { _dir, solc, writer } = BusySolc::with_contents(&bytes);
+            let release = thread::spawn(|| {
+                thread::sleep(Duration::from_millis(50));
+                drop(writer);
+            });
+            if version_only {
+                let version = if asynchronous {
+                    Solc::async_version(&solc.solc).await.unwrap()
+                } else {
+                    Solc::version(&solc.solc).unwrap()
+                };
+                assert_eq!((version.major, version.minor, version.patch), (0, 8, 18));
+            } else {
+                let output = if asynchronous {
+                    solc.async_compile_output(&input).await.unwrap()
+                } else {
+                    solc.compile_output(&input).unwrap()
+                };
+                let output: serde_json::Value = serde_json::from_slice(&output).unwrap();
+                assert_eq!(output["contracts"]["Test.sol"]["Test"]["abi"][0]["name"], "value");
+            }
+            release.join().unwrap();
+        }
+    }
+}


### PR DESCRIPTION
Launching solc can fail with `Text file busy` even after an installer closes its writable handle before publishing the binary: a concurrently forked child can retain a duplicate until it execs. This complements [alloy-rs/svm-rs#230](https://github.com/alloy-rs/svm-rs/pull/230) and addresses the execution-side failure seen in [this Foundry CI job](https://github.com/foundry-rs/foundry/actions/runs/34018298207/job/101489061398?pr=16689).

Retry only `ExecutableFileBusy` failures from process creation in synchronous and asynchronous compilation and version detection. Five exponential delays total 310 ms; successful processes, compiler failures, and other I/O errors are never retried. Async retries yield to the runtime, and exhausted retries preserve the original path and I/O error.

All four launch-path regressions failed with OS error 26 before the patch and pass afterward. Linux tests publish an executable while a duplicate writable descriptor remains open, cover large compiler input and single-threaded async scheduling, and verify that compiler failures execute only once. A real solc 0.8.18 binary also passed all four recovery paths and compiled a Solidity contract. Twenty-five stress repetitions completed 50,000 compiler calls during 25,000 replacements with no failures; an unguarded control spawn failed with `ETXTBSY` on every replacement.

Workspace-wide nightly Clippy and formatting checks pass, as does `cargo check` with only the `async` feature enabled. The final `cargo test --workspace --all-features --no-fail-fast -- --skip external` run passed. The unfiltered suite needs unavailable explorer API credentials/paid access. Earlier runs had intermittent project-cache and warning-filter assertions; the warning-filter failures also reproduced on unchanged base [fccc0fe](https://github.com/foundry-rs/foundry-core/commit/fccc0fe4a3e69cd9b27c53adeb1fe7122a9a8b80), and the final rerun passed without changes to those tests or their code.

Independent review found that using Tokio timers would panic on an I/O-only runtime. An intermediate blocking-pool delay could instead deadlock when the only blocking worker drove the compiler future. Async retries now use an optional `futures-timer` delay, independent of both facilities; this lazily starts one shared timer thread on the first busy retry. Public-API regressions cover version detection and compilation without a timer driver, plus a saturated blocking pool with a bounded timeout. These regressions failed against the respective earlier implementations and pass with the final fix.

The independent-timer revision passed 14 focused nextest tests, 75 repeated runtime-edge tests with retries disabled, real solc 0.8.18 integration, the async-only check, nightly Clippy and formatting. A separate reviewer independently confirmed the deadlock reproducer now completes and all three runtime-edge regressions pass.

An earlier CI run also exposed an overly strong expectation in the adversarial stress test: 1,000 consecutive busy publications can outlast all six spawn attempts. The test now accepts only typed `ExecutableFileBusy` during that contention phase, still checks every successful output exactly, rejects all other errors, and requires unconditional version/compile success after all workers finish. An additional public-API regression verifies persistent-busy errors retain their kind and compiler path. These changes were independently reviewed; the bounded production retry policy is unchanged. Nextest retries are disabled for both spawn regression modules so runner retries cannot hide failures.

Final local validation: 15 focused regressions passed, followed by 394/394 workspace tests with all features and runner retries disabled. The existing default filter excluded 41 external tests; four other tests remained ignored (45 skipped total). All 25 additional adversarial publication stress repetitions passed with every worker and child process pinned to one CPU and runner retries disabled. Final nightly Clippy, formatting, and diff checks passed.

This PR was written and tested with AI assistance (Codex).

Prompted by: @DaniPopes
