### PR TITLE
fix: preserve changelog history during releases

### DIFF
--- a/.github/scripts/changelog.sh
+++ b/.github/scripts/changelog.sh
@@ -52,14 +52,14 @@ if [ -f "$group_root/CHANGELOG.md" ] && grep -q '^## \[[0-9]' "$group_root/CHANG
     fi
 
     run_unless_dry_run git cliff \
-        --workdir "$root" \
+        --repository "$root" \
         --config "$group_root/cliff.toml" \
         --unreleased \
         "${@}" \
         --prepend "$group_root/CHANGELOG.md"
 else
     run_unless_dry_run git cliff \
-        --workdir "$root" \
+        --repository "$root" \
         --config "$group_root/cliff.toml" \
         "${@}" \
         --output "$group_root/CHANGELOG.md"


### PR DESCRIPTION
Passing the workspace root through `--workdir` can leave git-cliff 2.13.1 with no commits, so the release hook writes an empty changelog. Use `--repository` to select the repository without implicit path filtering.
