### PR TITLE
fix: filter changelog commits by crate

### DIFF
--- a/.github/scripts/changelog.sh
+++ b/.github/scripts/changelog.sh
@@ -17,6 +17,7 @@ run_unless_dry_run() {
 
 root=$WORKSPACE_ROOT
 crate=$CRATE_ROOT
+crate_glob="${crate#"$root/"}/**"
 
 # Find the crate group root (where cliff.toml lives) by walking up from the crate.
 group_root="$crate"
@@ -54,6 +55,7 @@ if [ -f "$group_root/CHANGELOG.md" ] && grep -q '^## \[[0-9]' "$group_root/CHANG
     run_unless_dry_run git cliff \
         --workdir "$root" \
         --config "$group_root/cliff.toml" \
+        --include-path "$crate_glob" \
         --unreleased \
         "${@}" \
         --prepend "$group_root/CHANGELOG.md"
@@ -61,6 +63,7 @@ else
     run_unless_dry_run git cliff \
         --workdir "$root" \
         --config "$group_root/cliff.toml" \
+        --include-path "$crate_glob" \
         "${@}" \
         --output "$group_root/CHANGELOG.md"
 fi


### PR DESCRIPTION
Pass the releasing crate path to git-cliff explicitly so each Foundry Core changelog contains only commits for that crate. Keep the incremental prepend flow so repeated cargo-release hooks preserve existing history.