### PR TITLE
feat(compilers): expose ERC-7201 storage layouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,11 +163,11 @@ jobs:
         # Keep PR feedback fast by running the test matrix on Linux only.
         # Pushes to main retain cross-platform coverage.
         os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest", "macos-latest", "windows-latest"]') }}
-        rust: ["stable", "1.95"]
+        rust: ["stable", "1.96"]
         flags: ["", "--all-features"]
         exclude:
           # Skip because some features have higher MSRV.
-          - rust: "1.95" # MSRV
+          - rust: "1.96" # MSRV
             flags: "--all-features"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -926,7 +926,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -946,7 +946,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -967,7 +967,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "zeroize",
@@ -985,7 +985,7 @@ dependencies = [
  "ark-std 0.6.0",
  "digest 0.10.7",
  "educe",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "zeroize",
 ]
@@ -1036,7 +1036,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -1048,7 +1048,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1061,7 +1061,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1074,7 +1074,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1108,7 +1108,7 @@ dependencies = [
  "ark-std 0.6.0",
  "educe",
  "itertools 0.14.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "tracing",
@@ -1148,7 +1148,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -1160,7 +1160,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -1172,7 +1172,7 @@ dependencies = [
  "ark-serialize-derive",
  "ark-std 0.6.0",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.8",
  "serde_with",
 ]
 
@@ -2301,9 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "136c8c4c3823846e8ba6d4bda011b4e5d5827b8bb0ac26c31f9ab31abe9f54f2"
 dependencies = [
  "unicode-segmentation",
  "unicode-width",
@@ -2958,6 +2958,12 @@ dependencies = [
  "syn 2.0.119",
  "unicode-xid",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -4683,7 +4689,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -4696,6 +4702,16 @@ name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -4741,7 +4757,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
@@ -6087,7 +6103,7 @@ dependencies = [
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "parity-scale-codec",
@@ -6749,7 +6765,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "thiserror 2.0.20",
  "time",
@@ -6811,8 +6827,7 @@ dependencies = [
 [[package]]
 name = "solar-ast"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756d3259a664e087dcc43b4a7d335c8d86d9d1971d396430f128a0ce33622b18"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -6828,16 +6843,19 @@ dependencies = [
 [[package]]
 name = "solar-codegen"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd401083e2463480b4c11840ec7f654ca0b75a976a915033ca8b1804c3ad95e"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "alloy-primitives",
+ "arrayvec",
  "derive_more",
+ "either",
+ "memchr",
  "smallvec",
  "solar-ast",
  "solar-config",
  "solar-data-structures",
  "solar-interface",
+ "solar-parse",
  "solar-sema",
  "tracing",
 ]
@@ -6845,8 +6863,7 @@ dependencies = [
 [[package]]
 name = "solar-compiler"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0fb69164d78ebd2e399ebc47818e3a610414fe9da4f6b2579a058d7fc567f9"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "alloy-primitives",
  "idna_adapter",
@@ -6855,6 +6872,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-interface",
+ "solar-lint",
  "solar-macros",
  "solar-parse",
  "solar-sema",
@@ -6863,9 +6881,9 @@ dependencies = [
 [[package]]
 name = "solar-config"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4aae5537cc9b12d88f4d4464319b2f3395522b24d8661ae3ae466023f3bb217"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
+ "alloy-primitives",
  "colorchoice",
  "strum 0.28.0",
 ]
@@ -6873,10 +6891,10 @@ dependencies = [
 [[package]]
 name = "solar-data-structures"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199a526376b5b66acaee7a96349207e85242516e8daf4aad20963f1389145ee1"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "bumpalo",
+ "diff",
  "indexmap 2.14.1",
  "oxc_index",
  "parking_lot",
@@ -6888,8 +6906,7 @@ dependencies = [
 [[package]]
 name = "solar-interface"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eca1dc6ececb31400960e2614fa2c16f361633b8ce3497b3a358f509dd8195e"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "annotate-snippets",
  "anstream",
@@ -6897,7 +6914,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "itoa",
  "normalize-path",
  "once_map",
@@ -6909,34 +6926,43 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.20",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width",
 ]
 
 [[package]]
+name = "solar-lint"
+version = "0.2.0"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
+dependencies = [
+ "rayon",
+ "solar-ast",
+ "solar-interface",
+ "solar-sema",
+]
+
+[[package]]
 name = "solar-macros"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acba5b79d1cf90faca7c9115c35b2bee41c3f940b611bfd384b926fa40bc7083"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "solar-parse"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdfec224fb34c504576d0124fcfb0ffbdb5461d2b55df00253e89e37fcd3f6f5"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.13.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "memchr",
- "num-bigint",
+ "num-bigint 0.5.1",
  "num-rational",
  "num-traits",
  "ruint",
@@ -6950,8 +6976,7 @@ dependencies = [
 [[package]]
 name = "solar-sema"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13d74065eeed9b3f70ab8e62a8a449de624ebcc8618b5fb3afee0520f93cc57"
+source = "git+https://github.com/paradigmxyz/solar?rev=315cf80d7db9bff4e583c631c204d3fce69c0e1e#315cf80d7db9bff4e583c631c204d3fce69c0e1e"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -6960,11 +6985,13 @@ dependencies = [
  "comfy-table",
  "derive_more",
  "either",
- "num-bigint",
+ "indexmap 2.14.1",
+ "num-bigint 0.5.1",
  "num-traits",
  "once_map",
  "paste",
  "rayon",
+ "serde",
  "solar-ast",
  "solar-data-structures",
  "solar-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 authors = ["Foundry Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://getfoundry.sh"
@@ -221,7 +221,7 @@ semver = { version = "1.0.28", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = { version = "1.0.149", features = ["arbitrary_precision"] }
 snapbox = "1.2.1"
-solar = { package = "solar-compiler", version = "=0.2.0", default-features = false }
+solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "315cf80d7db9bff4e583c631c204d3fce69c0e1e", default-features = false }
 svm = { package = "svm-rs", version = "0.5.25", default-features = false }
 tempfile = "3.20.0"
 thiserror = "2.0.18"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Core libraries extracted from [Foundry](https://github.com/foundry-rs/foundry), 
 
 ## Supported Rust Versions (MSRV)
 
-The current MSRV (minimum supported rust version) is **1.95**.
+The current MSRV (minimum supported rust version) is **1.96**.
 
 Note that the MSRV is not increased automatically, and only as part of a minor release.
 

--- a/crates/compilers/crates/compilers/src/lib.rs
+++ b/crates/compilers/crates/compilers/src/lib.rs
@@ -18,6 +18,8 @@ pub mod cache;
 
 pub mod flatten;
 
+pub mod storage_layout;
+
 pub mod resolver;
 pub use resolver::Graph;
 

--- a/crates/compilers/crates/compilers/src/storage_layout.rs
+++ b/crates/compilers/crates/compilers/src/storage_layout.rs
@@ -5,6 +5,7 @@
 
 use crate::{artifacts::StorageLayout, error::SolcError, resolver::parse::SolParser};
 use alloy_primitives::{U256, keccak256};
+use path_slash::PathExt;
 use solar::{
     ast::NatSpecKind,
     sema::{
@@ -107,8 +108,21 @@ pub fn erc7201_storage_layouts(
         for item in gcx.hir.contract(base).items {
             if let Some(id) = item.as_struct() {
                 let strukt = gcx.hir.strukt(id);
-                let declaration =
-                    format!("{}.{}", gcx.contract_fully_qualified_name(base), strukt.name);
+                let contract = gcx.hir.contract(base);
+                let file = &gcx.hir.source(contract.source).file.name;
+                let contract_name = if let Some(path) = file.as_real() {
+                    let path = gcx
+                        .sess
+                        .opts
+                        .base_path
+                        .as_ref()
+                        .and_then(|root| path.strip_prefix(root).ok())
+                        .unwrap_or(path);
+                    format!("{}:{}", path.to_slash_lossy(), contract.name)
+                } else {
+                    gcx.contract_fully_qualified_name(base).to_string()
+                };
+                let declaration = format!("{contract_name}.{}", strukt.name);
                 let mut namespace = None;
                 for tag in gcx.natspec_doc_comments(strukt.doc) {
                     if let NatSpecKind::Custom { name } = tag.kind
@@ -123,7 +137,16 @@ pub fn erc7201_storage_layouts(
                 }
                 if let Some(namespace) = namespace {
                     let root = erc7201_root(namespace);
-                    let output = gcx.storage_layout_for_struct(id, root);
+                    let mut output = gcx.storage_layout_for_struct(id, root);
+                    // Match solc's project-relative source names at every level of the type graph.
+                    for entry in &mut output.storage {
+                        entry.contract.clone_from(&contract_name);
+                    }
+                    if let Some(types) = &mut output.types {
+                        for member in types.values_mut().flat_map(|ty| &mut ty.members) {
+                            member.contract.clone_from(&contract_name);
+                        }
+                    }
                     let mut layout: StorageLayout =
                         serde_json::from_value(serde_json::to_value(output)?)?;
                     scope_types(&mut layout, namespace);
@@ -193,19 +216,40 @@ mod tests {
     use solar::sema::Compiler;
     use std::path::PathBuf;
 
-    fn parser(source: &str) -> SolParser {
+    fn parser_at(source: &str, path: &str) -> SolParser {
         let mut compiler = Compiler::new(Session::builder().with_test_emitter().build());
         compiler.enter_mut(|compiler| {
-            let file = compiler
-                .sess()
-                .source_map()
-                .new_source_file(PathBuf::from("test.sol"), source)
-                .unwrap();
+            let file =
+                compiler.sess().source_map().new_source_file(PathBuf::from(path), source).unwrap();
             let mut parser = compiler.parse();
             parser.add_file(file);
             parser.parse();
         });
         SolParser { compiler }
+    }
+
+    fn parser(source: &str) -> SolParser {
+        parser_at(source, "test.sol")
+    }
+
+    #[test]
+    fn project_relative_source_names() {
+        let mut parser = parser_at(
+            r#"contract C {
+            struct Inner { uint256 x; }
+            /// @custom:storage-location erc7201:example
+            struct Data { Inner inner; }
+        }"#,
+            "/project/src/test.sol",
+        );
+        parser.compiler.sess_mut().opts.base_path = Some(PathBuf::from("/project"));
+        let namespaces =
+            parser.erc7201_storage_layouts(Path::new("/project/src/test.sol"), Some("C")).unwrap();
+        let namespace = &namespaces[0];
+        assert_eq!(namespace.declaration, "src/test.sol:C.Data");
+        assert_eq!(namespace.layout.storage[0].contract, "src/test.sol:C");
+        let ty = &namespace.layout.types[&namespace.layout.storage[0].storage_type];
+        assert_eq!(ty.other["members"][0]["contract"], "src/test.sol:C");
     }
 
     fn layouts(source: &str, contract: &str) -> Result<Vec<StorageNamespace>, SolcError> {

--- a/crates/compilers/crates/compilers/src/storage_layout.rs
+++ b/crates/compilers/crates/compilers/src/storage_layout.rs
@@ -1,0 +1,370 @@
+//! ERC-7201 namespace discovery and conversion to solc-compatible storage layouts.
+//!
+//! Packing and type generation are delegated to Solar. Callers decide how to merge namespaces
+//! with conventional storage and how to handle duplicate namespace declarations.
+
+use crate::{artifacts::StorageLayout, error::SolcError, resolver::parse::SolParser};
+use alloy_primitives::{U256, keccak256};
+use solar::{
+    ast::NatSpecKind,
+    sema::{
+        Gcx, hir,
+        interface::{Session, config::CompilerStage},
+    },
+};
+use std::{ops::ControlFlow, path::Path};
+
+impl SolParser {
+    /// Computes ERC-7201 layouts for a contract in this parser's resolved project.
+    ///
+    /// Lowering and analysis errors are returned rather than silently emitting incomplete layouts.
+    pub fn erc7201_storage_layouts(
+        &mut self,
+        target_path: &Path,
+        target_name: Option<&str>,
+    ) -> Result<Vec<StorageNamespace>, SolcError> {
+        self.compiler_mut().enter_mut(|compiler| {
+            if !matches!(compiler.gcx().stage(), Some(CompilerStage::Lowering | CompilerStage::Analysis))
+                && !matches!(compiler.lower_asts(), Ok(ControlFlow::Continue(())))
+            {
+                return Err(solar_error(compiler.sess(), "lowering"));
+            }
+            if compiler.sess().dcx.has_errors().is_err() {
+                return Err(solar_error(compiler.sess(), "lowering"));
+            }
+            let gcx = compiler.gcx();
+            let mut matches = gcx.hir.contract_ids().filter(|&id| {
+                let contract = gcx.hir.contract(id);
+                target_name.is_none_or(|name| contract.name.as_str() == name)
+                    && gcx.hir.source(contract.source).file.name.as_real().is_some_and(|path| path == target_path)
+            });
+            let target = matches.next().ok_or_else(|| SolcError::msg("storage layout contract not found"))?;
+            if matches.next().is_some() {
+                return Err(SolcError::msg("multiple contracts found; specify <path>:<contract>"));
+            }
+            // Conventional layouts do not need semantic analysis. Inspect raw parsed tags before
+            // requesting validated NatSpec or type information.
+            let bases = gcx.hir.contract(target).linearized_bases;
+            let bases = if bases.is_empty() { std::slice::from_ref(&target) } else { bases };
+            let annotated = bases.iter().any(|&base| gcx.hir.contract(base).items.iter().any(|item| {
+                item.as_struct().is_some_and(|id| gcx.hir.doc(gcx.hir.strukt(id).doc).ast_comments().iter().any(|doc| {
+                    doc.natspec.iter().any(|tag| matches!(tag.kind, NatSpecKind::Custom { name } if name.as_str() == "storage-location")
+                        && tag.content().trim().starts_with("erc7201"))
+                }))
+            }));
+            if !annotated {
+                return Ok(Vec::new());
+            }
+            if compiler.gcx().stage() != Some(CompilerStage::Analysis)
+                && !matches!(compiler.analysis(), Ok(ControlFlow::Continue(())))
+            {
+                return Err(solar_error(compiler.sess(), "analysis"));
+            }
+            erc7201_storage_layouts(compiler.gcx(), target)
+        })
+    }
+}
+
+/// A storage namespace declared by a struct in a contract or one of its bases.
+#[derive(Clone, Debug)]
+pub struct StorageNamespace {
+    /// The identifier following `erc7201:` in the storage-location annotation.
+    pub id: String,
+    /// The fully qualified name of the declaring struct.
+    pub declaration: String,
+    /// The ERC-7201 root slot.
+    pub root: U256,
+    /// The struct's fields at absolute slots, with nested members at relative slots.
+    ///
+    /// Type IDs are scoped to this namespace so they cannot alias solc-generated IDs.
+    /// AST IDs originate from Solar and are not solc AST IDs.
+    pub layout: StorageLayout,
+}
+
+/// Computes `keccak256(abi.encode(uint256(keccak256(id)) - 1)) & ~uint256(0xff)`.
+pub fn erc7201_root(id: &str) -> U256 {
+    let inner = U256::from_be_bytes(keccak256(id.as_bytes()).0).wrapping_sub(U256::from(1));
+    U256::from_be_bytes(keccak256(inner.to_be_bytes::<32>()).0) & !U256::from(0xff)
+}
+
+/// Returns namespaces declared in `contract` and its linearized bases, once per declaration.
+///
+/// The compiler must have completed lowering and semantic analysis. Unrelated contracts,
+/// imported libraries, and file-level structs are excluded: importing a declaration does not
+/// establish that the selected contract uses its storage. Unknown storage-location schemes
+/// are ignored; malformed ERC-7201 annotations are errors.
+pub fn erc7201_storage_layouts(
+    gcx: Gcx<'_>,
+    contract: hir::ContractId,
+) -> Result<Vec<StorageNamespace>, SolcError> {
+    if gcx.sess.dcx.has_errors().is_err() {
+        return Err(solar_error(gcx.sess, "analysis"));
+    }
+    let bases = gcx.hir.contract(contract).linearized_bases;
+    let bases = if bases.is_empty() { std::slice::from_ref(&contract) } else { bases };
+    let mut namespaces = Vec::new();
+    for &base in bases.iter().rev() {
+        for item in gcx.hir.contract(base).items {
+            if let Some(id) = item.as_struct() {
+                let strukt = gcx.hir.strukt(id);
+                let declaration =
+                    format!("{}.{}", gcx.contract_fully_qualified_name(base), strukt.name);
+                let mut namespace = None;
+                for tag in gcx.natspec_doc_comments(strukt.doc) {
+                    if let NatSpecKind::Custom { name } = tag.kind
+                        && name.as_str() == "storage-location"
+                        && let Some(id) = parse_namespace(tag.content())?
+                        && namespace.replace(id).is_some()
+                    {
+                        return Err(SolcError::msg(format!(
+                            "multiple ERC-7201 annotations on `{declaration}`"
+                        )));
+                    }
+                }
+                if let Some(namespace) = namespace {
+                    let root = erc7201_root(namespace);
+                    let output = gcx.storage_layout_for_struct(id, root);
+                    let mut layout: StorageLayout =
+                        serde_json::from_value(serde_json::to_value(output)?)?;
+                    scope_types(&mut layout, namespace);
+                    namespaces.push(StorageNamespace {
+                        id: namespace.to_owned(),
+                        declaration,
+                        root,
+                        layout,
+                    });
+                }
+            }
+        }
+    }
+    Ok(namespaces)
+}
+
+fn solar_error(sess: &Session, stage: &str) -> SolcError {
+    let diagnostics = sess.dcx.emitted_diagnostics().map(|d| d.to_string()).unwrap_or_default();
+    SolcError::msg(format!("Solar {stage} failed while inspecting ERC-7201 storage\n{diagnostics}"))
+}
+
+fn parse_namespace(annotation: &str) -> Result<Option<&str>, SolcError> {
+    let annotation = annotation.trim();
+    let Some(id) = annotation.strip_prefix("erc7201:") else {
+        if annotation.split_whitespace().next() == Some("erc7201") {
+            return Err(SolcError::msg("expected `erc7201:<namespace>` storage location"));
+        }
+        return Ok(None);
+    };
+    if id.is_empty() || id.chars().any(char::is_whitespace) {
+        return Err(SolcError::msg(
+            "ERC-7201 namespace must be nonempty and contain no whitespace",
+        ));
+    }
+    Ok(Some(id))
+}
+
+fn scope_types(layout: &mut StorageLayout, namespace: &str) {
+    let scope = |id: &str| format!("erc7201({namespace})::{id}");
+    for entry in &mut layout.storage {
+        entry.storage_type = scope(&entry.storage_type);
+    }
+    layout.types = std::mem::take(&mut layout.types)
+        .into_iter()
+        .map(|(id, mut ty)| {
+            for reference in [&mut ty.key, &mut ty.value].into_iter().flatten() {
+                *reference = scope(reference);
+            }
+            if let Some(serde_json::Value::String(base)) = ty.other.get_mut("base") {
+                *base = scope(base);
+            }
+            if let Some(serde_json::Value::Array(members)) = ty.other.get_mut("members") {
+                for member in members {
+                    if let Some(serde_json::Value::String(id)) = member.get_mut("type") {
+                        *id = scope(id);
+                    }
+                }
+            }
+            (scope(&id), ty)
+        })
+        .collect();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solar::sema::Compiler;
+    use std::path::PathBuf;
+
+    fn parser(source: &str) -> SolParser {
+        let mut compiler = Compiler::new(Session::builder().with_test_emitter().build());
+        compiler.enter_mut(|compiler| {
+            let file = compiler
+                .sess()
+                .source_map()
+                .new_source_file(PathBuf::from("test.sol"), source)
+                .unwrap();
+            let mut parser = compiler.parse();
+            parser.add_file(file);
+            parser.parse();
+        });
+        SolParser { compiler }
+    }
+
+    fn layouts(source: &str, contract: &str) -> Result<Vec<StorageNamespace>, SolcError> {
+        parser(source).erc7201_storage_layouts(Path::new("test.sol"), Some(contract))
+    }
+
+    #[test]
+    fn repeated_inspection() {
+        let mut parser = parser(
+            r#"contract C {
+            /// @custom:storage-location erc7201:example
+            struct Data { uint256 value; }
+        }"#,
+        );
+        let first = parser.erc7201_storage_layouts(Path::new("test.sol"), Some("C")).unwrap();
+        let second = parser.erc7201_storage_layouts(Path::new("test.sol"), Some("C")).unwrap();
+        assert_eq!(first[0].layout, second[0].layout);
+    }
+
+    #[test]
+    fn inherited_namespaces_and_type_graph() {
+        let namespaces = layouts(
+            r#"
+            type Amount is uint128;
+            contract Base {
+                enum State { Off, On }
+                struct Nested { uint128 x; bool y; }
+                /** @custom:storage-location erc7201:example.base */
+                struct Data {
+                    address owner;
+                    bool paused;
+                    Nested nested;
+                    uint128[3] fixedValues;
+                    mapping(address => Nested[]) accounts;
+                    bytes data;
+                    string name;
+                    Amount amount;
+                    State state;
+                    function() external callback;
+                }
+            }
+            contract Left is Base {}
+            contract Right is Base {}
+            contract Derived is Left, Right {
+                /// @custom:storage-location erc7201:example.derived
+                struct OtherData { uint256 value; }
+            }
+            contract Unrelated {
+                /// @custom:storage-location erc7201:example.base
+                struct Data { uint256 ignored; }
+            }
+        "#,
+            "Derived",
+        )
+        .unwrap();
+        assert_eq!(
+            namespaces.iter().map(|n| n.id.as_str()).collect::<Vec<_>>(),
+            ["example.base", "example.derived"]
+        );
+        assert_eq!(namespaces[0].declaration, "test.sol:Base.Data");
+        let layout = &namespaces[0].layout;
+        let root = namespaces[0].root;
+        assert_eq!(
+            layout
+                .storage
+                .iter()
+                .map(|s| (s.slot.parse::<U256>().unwrap() - root, s.offset))
+                .collect::<Vec<_>>(),
+            [(0, 0), (0, 20), (1, 0), (2, 0), (4, 0), (5, 0), (6, 0), (7, 0), (7, 16), (8, 0)]
+                .map(|(slot, offset)| (U256::from(slot), offset))
+        );
+        for ty in layout.types.values() {
+            for id in [&ty.key, &ty.value].into_iter().flatten() {
+                assert!(layout.types.contains_key(id), "missing {id}");
+            }
+            if let Some(base) = ty.other.get("base") {
+                assert!(layout.types.contains_key(base.as_str().unwrap()));
+            }
+            if let Some(members) = ty.other.get("members") {
+                for member in members.as_array().unwrap() {
+                    assert!(layout.types.contains_key(member["type"].as_str().unwrap()));
+                    assert_eq!(member["slot"], "0");
+                }
+            }
+        }
+        assert!(layout.types.keys().all(|id| id.starts_with("erc7201(example.base)::")));
+    }
+
+    #[test]
+    fn annotation_errors_and_non_namespaced_contracts() {
+        assert!(
+            layouts(
+                r#"contract C {
+            /// @custom:storage-location erc7201:example
+            struct Data { uint256 value; }
+            function invalid() public pure returns (uint256) { return true; }
+        }"#,
+                "C"
+            )
+            .is_err()
+        );
+        for annotation in ["erc7201:", "erc7201:two words", "erc7201"] {
+            assert!(layouts(&format!("contract C {{\n/// @custom:storage-location {annotation}\nstruct Data {{ uint256 x; }}\n}}"), "C").is_err());
+        }
+        assert!(
+            layouts(
+                r#"contract C {
+            /// @custom:storage-location erc7201:first
+            /// @custom:storage-location erc7201:second
+            struct Data { uint256 x; }
+        }"#,
+                "C"
+            )
+            .is_err()
+        );
+        assert!(
+            layouts(
+                r#"contract C {
+            /// @custom:storage-location other:example
+            struct Data { uint256 x; }
+            uint256 value;
+        }"#,
+                "C"
+            )
+            .unwrap()
+            .is_empty()
+        );
+        // Duplicate declarations are retained for the caller's collision policy.
+        assert_eq!(
+            layouts(
+                r#"contract C {
+            /// @custom:storage-location erc7201:same
+            struct A { uint256 x; }
+            /// @custom:storage-location erc7201:same
+            struct B { uint256 y; }
+        }"#,
+                "C"
+            )
+            .unwrap()
+            .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn root_and_annotations() {
+        assert_eq!(
+            erc7201_root("openzeppelin.storage.Initializable").to_string(),
+            U256::from_str_radix(
+                "f0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00",
+                16
+            )
+            .unwrap()
+            .to_string()
+        );
+        assert_eq!(parse_namespace(" erc7201:example.main \n").unwrap(), Some("example.main"));
+        assert_eq!(parse_namespace("erc9999:example.main").unwrap(), None);
+        for invalid in ["erc7201", "erc7201:", "erc7201:two words"] {
+            assert!(parse_namespace(invalid).is_err());
+        }
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,7 @@ unknown-registry = "warn"
 # in the allow list is encountered
 unknown-git = "deny"
 allow-git = [
+    "https://github.com/paradigmxyz/solar",
     "https://github.com/paradigmxyz/reth",
     "https://github.com/tempoxyz/tempo",
 ]


### PR DESCRIPTION
Add ERC-7201 namespace discovery, inheritance traversal, root-slot computation, and solc-compatible storage layouts to `foundry-compilers`. Packing and type generation use Solar's generic struct-layout primitive; namespace-scoped type IDs keep generated references separate from solc IDs. Malformed annotations and failed semantic analysis return errors, while duplicate declarations remain available for callers to reject.

Implements the compiler layer of [Mablr's plan](https://github.com/foundry-rs/foundry/pull/15299#issuecomment-5317766666) and depends on [Solar #1413](https://github.com/paradigmxyz/solar/pull/1413). The Solar dependency is pinned to that PR's commit for review and requires Rust 1.96. Discovery covers the selected contract and its bases; unrelated imports and file-level structs are excluded. Generated AST IDs belong to Solar.

Code and tests were written by Centaur with AI assistance.

Prompted by: @DaniPopes
