### PR TITLE
fix(fork-db): omit requireCanonical from anchored block id

### DIFF
--- a/crates/fork-db/src/backend.rs
+++ b/crates/fork-db/src/backend.rs
@@ -1046,7 +1046,7 @@ impl<N: Network, B: ForkBlockEnv> SharedBackend<N, B> {
         let (backend, backend_rx) = unbounded();
         let cache = Arc::new(FlushJsonBlockCacheDB(Arc::clone(db.cache())));
         db.block_hashes().write().insert(U256::from(anchor.number), anchor.hash);
-        let block_id = BlockId::from((anchor.hash, Some(false)));
+        let block_id = BlockId::from((anchor.hash, None));
         let handler =
             BackendHandler::new(provider.erased(), db, backend_rx, Some(block_id), Some(anchor));
         Ok((Self { backend, cache, blocking_mode: Default::default(), exact: true }, handler))
@@ -1460,8 +1460,7 @@ mod tests {
             let mut storage_request = server.recv().unwrap();
             let storage: Request = serde_json::from_reader(storage_request.as_reader()).unwrap();
             assert_eq!(storage.method, "eth_getStorageAt");
-            assert_eq!(storage.params[2]["blockHash"], anchor_hash.to_string());
-            assert_eq!(storage.params[2]["requireCanonical"], false);
+            assert_eq!(storage.params[2], anchor_hash.to_string());
             storage_request
                 .respond(Response::from_string(
                     serde_json::json!({
@@ -1794,8 +1793,7 @@ mod tests {
             let mut request = server.recv().unwrap();
             let rpc_request: Request = serde_json::from_reader(request.as_reader()).unwrap();
             assert_eq!(rpc_request.method, "eth_call");
-            assert_eq!(rpc_request.params[1]["blockHash"], anchor_hash.to_string());
-            assert_eq!(rpc_request.params[1]["requireCanonical"], false);
+            assert_eq!(rpc_request.params[1], anchor_hash.to_string());
             assert_eq!(
                 rpc_request.params[0]["data"],
                 format!("0x7f{:064x}4060005260206000f3", U256::from(99))


### PR DESCRIPTION
## Motivation

Since the exact block anchoring introduced in #157 (shipped in foundry v1.8.0), every state read made by an anchored `SharedBackend` (`eth_getBalance`, `eth_getTransactionCount`, `eth_getCode`, `eth_getStorageAt`, `eth_call`) is pinned with `BlockId::from((anchor.hash, Some(false)))`, which alloy serializes as:

```json
{"blockHash": "0x…", "requireCanonical": false}
```

Some RPC implementations do not accept `requireCanonical` as a JSON boolean. RSKj (Rootstock) deserializes the EIP-1898 object into a `Map<String, String>` and fails with `-32603 Internal server error` when the value is a boolean. As a result `anvil --fork-url <rootstock> --fork-block-number N` aborts on the first account fetch:

```
failed to get account for 0x…: server returned an error response: error code -32603: Internal server error
```

The same fork works on foundry ≤ 1.7.x, which read state by block number.

## Solution

Pass `None` for `require_canonical` in `SharedBackend::new_with_anchor`. alloy then serializes the block id as a bare 32-byte hash string (`"0x…"`) instead of the EIP-1898 object. This is the form geth has always accepted as a block parameter ([rpc/types.go](https://github.com/ethereum/go-ethereum/blob/master/rpc/types.go#L196)), and alloy/reth parse it the same way, so state is still read strictly by the anchor hash and the reorg protection from #157 is unchanged.

`requireCanonical` defaults to `false` per EIP-1898, so nothing is lost by not sending it explicitly.

The two anchor tests that asserted the explicit `"requireCanonical": false` object now assert the bare anchor hash.

The unrelated `Some(false)` in `block_hash_via_evm` (chain heuristic for `BLOCKHASH` opcode handling) is intentionally left untouched.

Fixes [16769](https://github.com/foundry-rs/foundry/issues/16769)


## AI disclosure

The root-cause investigation was done with Claude Code; the patch is a one-line change plus two test assertion updates, reviewed and tested manually (`cargo test -p foundry-fork-db`).

