### PR TITLE
fix(fork-db): support required account-info reads

### DIFF
--- a/crates/fork-db/README.md
+++ b/crates/fork-db/README.md
@@ -9,3 +9,10 @@ Provides a shared, caching database layer backed by a remote RPC provider, allow
 ## Features
 
 - `zstd`: Enables [zstd](https://github.com/gysber/zstd-rs) compression support.
+
+## Remote account loading
+
+For RPCs such as Tempo, where `eth_getBalance` returns a placeholder, use
+`BlockchainDbMeta::with_account_fetch_policy(AccountFetchPolicy::RequireAccountInfo)`
+to require authoritative account data without fallback. The policy is part of cache
+identity, so incompatible caches are discarded even in offline-start mode.

--- a/crates/fork-db/src/backend.rs
+++ b/crates/fork-db/src/backend.rs
@@ -1,7 +1,9 @@
 //! Smart caching and deduplication of requests when using a forking provider.
 
 use crate::{
-    cache::{BlockchainDb, FlushJsonBlockCacheDB, ForkBlockEnv, MemDb, StorageInfo},
+    cache::{
+        AccountFetchPolicy, BlockchainDb, FlushJsonBlockCacheDB, ForkBlockEnv, MemDb, StorageInfo,
+    },
     error::{DatabaseError, DatabaseResult},
 };
 use alloy_chains::Chain;
@@ -206,6 +208,8 @@ pub struct BackendHandler<N: Network = AnyNetwork, B = BlockEnv> {
     block_hash_via_evm: Option<bool>,
     /// The mode for fetching account data
     account_fetch_mode: Arc<AtomicU8>,
+    /// Account-loading policy fixed when this backend is created.
+    account_fetch_policy: AccountFetchPolicy,
 }
 
 impl<N: Network, B: ForkBlockEnv> BackendHandler<N, B> {
@@ -225,9 +229,11 @@ impl<N: Network, B: ForkBlockEnv> BackendHandler<N, B> {
                 None
             }
         });
+        let account_fetch_policy = db.meta().read().account_fetch_policy;
         Self {
             provider,
             db,
+            account_fetch_policy,
             pending_requests: Default::default(),
             account_requests: Default::default(),
             storage_requests: Default::default(),
@@ -354,7 +360,16 @@ impl<N: Network, B: ForkBlockEnv> BackendHandler<N, B> {
         let provider = self.provider.clone();
         let block_id = self.block_id.unwrap_or_default();
         let mode = Arc::clone(&self.account_fetch_mode);
+        let policy = self.account_fetch_policy;
         let fut = async move {
+            if policy == AccountFetchPolicy::RequireAccountInfo {
+                return provider
+                    .get_account_info(address)
+                    .block_id(block_id)
+                    .await
+                    .map(|info| (info.balance, info.nonce, info.code))
+                    .wrap_err("fork account policy requires eth_getAccountInfo");
+            }
             // depending on the tracked mode we can dispatch requests.
             let initial_mode = mode.load(Ordering::Relaxed);
             match initial_mode {
@@ -1291,7 +1306,7 @@ mod tests {
     use alloy_provider::ProviderBuilder;
     use alloy_rpc_client::ClientBuilder;
     use serde::Deserialize;
-    use std::{fs, path::PathBuf};
+    use std::{fs, path::PathBuf, sync::atomic::AtomicBool, time::Duration};
     use tiny_http::{Response, Server};
 
     pub fn get_http_provider(endpoint: &str) -> impl Provider<AnyNetwork> + Clone + use<> {
@@ -1303,6 +1318,108 @@ mod tests {
     fn exact_meta(endpoint: &str, anchor_hash: B256) -> BlockchainDbMeta<BlockEnv> {
         BlockchainDbMeta::new(BlockEnv::default(), endpoint.to_string())
             .with_fork_identity(anchor_hash, B256::with_last_byte(1))
+    }
+
+    /// Serves deliberately inconsistent balances from the two account RPC paths.
+    fn account_policy_server(
+        reject_account_info: bool,
+    ) -> (String, Arc<AtomicBool>, std::thread::JoinHandle<Vec<serde_json::Value>>) {
+        let server = Server::http("127.0.0.1:0").unwrap();
+        let endpoint = format!("http://{}", server.server_addr());
+        let stop = Arc::new(AtomicBool::new(false));
+        let stopped = Arc::clone(&stop);
+        let handle = std::thread::spawn(move || {
+            let mut requests = Vec::new();
+            while !stopped.load(Ordering::Relaxed) {
+                if let Some(mut request) = server.recv_timeout(Duration::from_millis(20)).unwrap() {
+                    let rpc: serde_json::Value =
+                        serde_json::from_reader(request.as_reader()).unwrap();
+                    let mut response = serde_json::json!({"jsonrpc": "2.0", "id": rpc["id"]});
+                    if rpc["method"] == "eth_getAccountInfo" && reject_account_info {
+                        response["error"] =
+                            serde_json::json!({"code": -32601, "message": "unsupported"});
+                    } else {
+                        response["result"] = match rpc["method"].as_str().unwrap() {
+                            "eth_getAccountInfo" => serde_json::json!({
+                                "balance": "0x2a", "nonce": "0x7", "code": "0x6000",
+                            }),
+                            "eth_getBalance" => serde_json::json!("0xffff"),
+                            "eth_getTransactionCount" => serde_json::json!("0x7"),
+                            "eth_getCode" => serde_json::json!("0x6000"),
+                            method => panic!("unexpected method {method}"),
+                        };
+                    }
+                    requests.push(rpc);
+                    request.respond(Response::from_string(response.to_string())).unwrap();
+                }
+            }
+            requests
+        });
+        (endpoint, stop, handle)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn required_account_info_uses_authoritative_balance_and_pinned_block() {
+        let (endpoint, stop, server) = account_policy_server(false);
+        let provider = get_http_provider(&endpoint);
+        let meta = BlockchainDbMeta::new(BlockEnv::default(), endpoint)
+            .with_account_fetch_policy(AccountFetchPolicy::RequireAccountInfo);
+        let db = BlockchainDb::new(meta, None);
+        let hash = B256::with_last_byte(1);
+        let backend = SharedBackend::spawn_backend(Arc::new(provider), db, Some(hash.into())).await;
+        let address = Address::with_last_byte(1);
+        let account = backend.basic_ref(address).unwrap().unwrap();
+        assert_eq!(account.balance, U256::from(42));
+        assert_eq!(account.nonce, 7);
+        assert_eq!(account.code.unwrap().original_bytes(), Bytes::from_static(&[0x60, 0]));
+
+        backend.set_pinned_block(123).unwrap();
+        let clone = backend.clone();
+        assert_eq!(
+            clone.basic_ref(Address::with_last_byte(2)).unwrap().unwrap().balance,
+            U256::from(42)
+        );
+        assert_eq!(backend.basic_ref(address).unwrap().unwrap().balance, U256::from(42));
+        stop.store(true, Ordering::Relaxed);
+        let requests = server.join().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(requests.iter().all(|r| r["method"] == "eth_getAccountInfo"));
+        assert_eq!(requests[0]["params"], serde_json::json!([address, BlockId::from(hash)]));
+        assert_eq!(requests[1]["params"][1], "0x7b");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn required_account_info_never_falls_back_after_rpc_errors() {
+        let (endpoint, stop, server) = account_policy_server(true);
+        let provider = get_http_provider(&endpoint);
+        let meta = BlockchainDbMeta::new(BlockEnv::default(), endpoint)
+            .with_account_fetch_policy(AccountFetchPolicy::RequireAccountInfo);
+        let db = BlockchainDb::new(meta, None);
+        let backend = SharedBackend::spawn_backend(Arc::new(provider), db.clone(), None).await;
+        for address in [Address::with_last_byte(1), Address::with_last_byte(2)] {
+            assert!(backend.basic_ref(address).is_err());
+        }
+        assert!(db.accounts().read().is_empty());
+        stop.store(true, Ordering::Relaxed);
+        let requests = server.join().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(requests.iter().all(|r| r["method"] == "eth_getAccountInfo"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn auto_account_fetch_still_supports_separate_requests() {
+        let (endpoint, stop, server) = account_policy_server(true);
+        let provider = get_http_provider(&endpoint);
+        let meta = BlockchainDbMeta::new(BlockEnv::default(), endpoint);
+        let db = BlockchainDb::new(meta, None);
+        let backend = SharedBackend::spawn_backend(Arc::new(provider), db, None).await;
+        assert_eq!(
+            backend.basic_ref(Address::with_last_byte(1)).unwrap().unwrap().balance,
+            U256::from(65535)
+        );
+        stop.store(true, Ordering::Relaxed);
+        let requests = server.join().unwrap();
+        assert!(requests.iter().any(|r| r["method"] == "eth_getBalance"));
     }
 
     const ENDPOINT: Option<&str> = option_env!("ETH_RPC_URL");

--- a/crates/fork-db/src/cache.rs
+++ b/crates/fork-db/src/cache.rs
@@ -32,6 +32,20 @@ pub type StorageInfo = StorageKeyMap<U256>;
 /// Zstd frame magic number: `0x28B52FFD` (little-endian).
 const ZSTD_FRAME_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
 
+/// Policy for loading remote account balances, nonces, and code.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccountFetchPolicy {
+    /// Race `eth_getAccountInfo` against separate balance, nonce, and code requests.
+    #[default]
+    Auto,
+    /// Require `eth_getAccountInfo`, without falling back to separate requests.
+    ///
+    /// Use this when `eth_getBalance` does not expose the balance used by execution,
+    /// such as Tempo RPCs that return a placeholder native balance.
+    RequireAccountInfo,
+}
+
 /// A shareable Block database
 #[derive(Clone, Debug)]
 pub struct BlockchainDb<B = BlockEnv> {
@@ -58,7 +72,8 @@ impl<B: ForkBlockEnv> BlockchainDb<B> {
         Self::new_db(meta, cache_path, false)
     }
 
-    /// Creates a new instance of the [BlockchainDb] and skips check when comparing meta
+    /// Creates a new instance of the [BlockchainDb] without comparing block metadata.
+    /// Account-fetch policies must still match, preventing reuse of incompatible account data.
     /// This is useful for offline-start mode when we don't want to fetch metadata of `block`.
     ///
     /// if a `cache_path` is provided it attempts to load a previously stored [JsonBlockCacheData]
@@ -80,6 +95,10 @@ impl<B: ForkBlockEnv> BlockchainDb<B> {
             .as_ref()
             .and_then(|p| {
                 JsonBlockCacheDB::load(p).ok().filter(|cache| {
+                    // Account-loading semantics must match even when block checks are skipped.
+                    if cache.meta().read().account_fetch_policy != meta.account_fetch_policy {
+                        return false;
+                    }
                     if skip_check {
                         return true;
                     }
@@ -156,6 +175,8 @@ pub struct BlockchainDbMeta<B> {
     pub fork_hash: Option<B256>,
     /// Opaque identity of the RPC source and its authentication context.
     pub source_id: Option<B256>,
+    /// Account-loading semantics used to populate this cache.
+    pub account_fetch_policy: AccountFetchPolicy,
 }
 
 impl<B> BlockchainDbMeta<B> {
@@ -172,7 +193,14 @@ impl<B> BlockchainDbMeta<B> {
             hosts: BTreeSet::from([host]),
             fork_hash: None,
             source_id: None,
+            account_fetch_policy: AccountFetchPolicy::Auto,
         }
+    }
+
+    /// Sets the remote account-loading policy and binds cached data to that policy.
+    pub const fn with_account_fetch_policy(mut self, policy: AccountFetchPolicy) -> Self {
+        self.account_fetch_policy = policy;
+        self
     }
 
     /// Infers the host from the provided url and adds it to the set of hosts
@@ -212,6 +240,7 @@ impl<B: PartialEq> PartialEq for BlockchainDbMeta<B> {
         self.block_env == other.block_env
             && self.fork_hash == other.fork_hash
             && self.source_id == other.source_id
+            && self.account_fetch_policy == other.account_fetch_policy
     }
 }
 
@@ -219,7 +248,7 @@ impl<B: Serialize> Serialize for BlockchainDbMeta<B> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeStruct;
 
-        let field_count = 2
+        let field_count = 3
             + usize::from(self.chain.is_some())
             + usize::from(self.fork_hash.is_some())
             + usize::from(self.source_id.is_some());
@@ -229,6 +258,7 @@ impl<B: Serialize> Serialize for BlockchainDbMeta<B> {
         }
         s.serialize_field("block_env", &self.block_env)?;
         s.serialize_field("hosts", &self.hosts)?;
+        s.serialize_field("account_fetch_policy", &self.account_fetch_policy)?;
         if let Some(fork_hash) = self.fork_hash {
             s.serialize_field("fork_hash", &fork_hash)?;
         }
@@ -298,11 +328,20 @@ impl<'de, B: DeserializeOwned + Default + Serialize> Deserialize<'de> for Blockc
             fork_hash: Option<B256>,
             #[serde(default)]
             source_id: Option<B256>,
+            #[serde(default)]
+            account_fetch_policy: AccountFetchPolicy,
         }
 
-        let Meta { chain, block_env, hosts, fork_hash, source_id } =
+        let Meta { chain, block_env, hosts, fork_hash, source_id, account_fetch_policy } =
             Meta::deserialize(deserializer)?;
-        Ok(Self { chain, block_env: block_env.inner, hosts: hosts.into(), fork_hash, source_id })
+        Ok(Self {
+            chain,
+            block_env: block_env.inner,
+            hosts: hosts.into(),
+            fork_hash,
+            source_id,
+            account_fetch_policy,
+        })
     }
 }
 
@@ -786,6 +825,48 @@ mod tests {
     }
 
     #[test]
+    fn account_fetch_policy_invalidates_incompatible_disk_caches() {
+        for skip_check in [false, true] {
+            for (stored, requested) in [
+                (AccountFetchPolicy::Auto, AccountFetchPolicy::RequireAccountInfo),
+                (AccountFetchPolicy::RequireAccountInfo, AccountFetchPolicy::Auto),
+            ] {
+                let temp = tempfile::tempdir().unwrap();
+                let path = temp.path().join("cache.json");
+                let meta = BlockchainDbMeta::new(BlockEnv::default(), "http://localhost".into())
+                    .with_account_fetch_policy(stored);
+                let db = BlockchainDb::new(meta.clone(), Some(path.clone()));
+                let address = Address::with_last_byte(1);
+                db.accounts().write().insert(address, AccountInfo::from_balance(U256::from(42)));
+                db.cache().flush();
+
+                // Matching semantics preserve the actual balance, including nonzero values.
+                let compatible = BlockchainDb::new_db(meta.clone(), Some(path.clone()), skip_check);
+                assert_eq!(compatible.accounts().read()[&address].balance, U256::from(42));
+                let incompatible = BlockchainDb::new_db(
+                    meta.with_account_fetch_policy(requested),
+                    Some(path),
+                    skip_check,
+                );
+                assert!(incompatible.accounts().read().is_empty());
+                assert_eq!(incompatible.meta().read().account_fetch_policy, requested);
+            }
+        }
+    }
+
+    #[test]
+    fn legacy_account_cache_defaults_to_auto_policy() {
+        let mut value = serde_json::to_value(BlockchainDbMeta::<BlockEnv>::default()).unwrap();
+        value.as_object_mut().unwrap().remove("account_fetch_policy");
+        let legacy = serde_json::from_value::<BlockchainDbMeta<BlockEnv>>(value).unwrap();
+        assert_eq!(legacy.account_fetch_policy, AccountFetchPolicy::Auto);
+        assert_ne!(
+            legacy,
+            legacy.clone().with_account_fetch_policy(AccountFetchPolicy::RequireAccountInfo)
+        );
+    }
+
+    #[test]
     fn roundtrip_meta_block_env() {
         let meta = BlockchainDbMeta {
             chain: Some(Chain::mainnet()),
@@ -793,6 +874,7 @@ mod tests {
             hosts: BTreeSet::from(["eth-mainnet.alchemyapi.io".to_string()]),
             fork_hash: Some(B256::with_last_byte(1)),
             source_id: Some(B256::with_last_byte(2)),
+            account_fetch_policy: AccountFetchPolicy::RequireAccountInfo,
         };
         let json = serde_json::to_string(&meta).unwrap();
         let recovered: BlockchainDbMeta<BlockEnv> = serde_json::from_str(&json).unwrap();

--- a/crates/fork-db/src/lib.rs
+++ b/crates/fork-db/src/lib.rs
@@ -10,5 +10,5 @@ pub mod cache;
 pub mod error;
 
 pub use backend::{BackendHandler, ForkBlock, SharedBackend};
-pub use cache::{BlockchainDb, ForkBlockEnv};
+pub use cache::{AccountFetchPolicy, BlockchainDb, ForkBlockEnv};
 pub use error::{DatabaseError, DatabaseResult};


### PR DESCRIPTION
Tempo's `eth_getBalance` returns a placeholder native balance, while `eth_getAccountInfo` returns the real balance. Racing these methods can cache incorrect execution state: Relay's multicaller then sends an extra native refund, adding 13,836 gas and failing the canary introduced in https://github.com/foundry-rs/foundry/pull/16793.

Add `AccountFetchPolicy::RequireAccountInfo` so callers can require authoritative account data without fallback. The policy is part of cache identity, preventing reuse of incompatible caches even in offline-start mode. The default retains automatic account loading; the Foundry integration selects the new policy for Tempo forks.

AI assistance was used for implementation and validation.
